### PR TITLE
6. 用語集 ポインタ入力 (pointer input)・region・シングルポインタ (single pointer) ・ウェブページ一式 (set of Web pages) 翻訳作業

### DIFF
--- a/index.html
+++ b/index.html
@@ -3139,10 +3139,7 @@ details.respec-tests-details > li {
    <p>共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作された<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>の集合。
    </p>
    
-   <p class="example">Examples include a publication which is split across multiple Web pages, where each page contains
-      one chapter or other significant section of the work. The publication is logically
-      a single contiguous unit, and contains navigation features that enable access to the
-      full set of pages.
+   <p class="example">例には複数のウェブページにまたがる発行物が含まれ、各ページには1つの章又はその他の重要なセクションが含まれる。論理的に発行物は1つの連続した単位であり、ウェブページ一式へのアクセスを可能にするナビゲーション機能を有する。
    
    </p>
 

--- a/index.html
+++ b/index.html
@@ -3175,7 +3175,7 @@ details.respec-tests-details > li {
    					
    
    	
-   <p>pointer input that operates with one point of contact with the screen, including single taps and clicks, double-taps and clicks, long presses, and path-based gestures</p>
+   <p>シングルタップやクリック、ダブルタップやクリック、長押し及びパスを基点としたジェスチャーを含む、画面と1つの接点で動作するポインタ入力</p>
   				
 </dd>
 

--- a/index.html
+++ b/index.html
@@ -3000,12 +3000,12 @@ details.respec-tests-details > li {
 </dd>
 
 
-                <dt class="new"><dfn data-lt="regions|region" data-dfn-type="dfn" id="dfn-regions">region</dfn></dt>
+                <dt class="new"><dfn data-lt="regions|region" data-dfn-type="dfn" id="dfn-regions">領域 (region)</dfn></dt>
 <dd class="new">
   
-  <p>perceivable, programmatically determined section of content</p>
-  <div class="note"><div role="heading" class="note-title marker" id="h-note-117" aria-level="3"><span>注記</span></div><p class="">In HTML, any area designated with a landmark role would be a region.</p></div>
-	<div class="ednote"><div role="heading" class="ednote-title marker" id="h-ednote-6" aria-level="3"><span>編集者注</span></div><p class="">This term is <a href="#at-risk">at risk</a>.</p></div>
+  <p>コンテンツの知覚可能、プログラムによる解釈が可能なセクション</p>
+  <div class="note"><div role="heading" class="note-title marker" id="h-note-117" aria-level="3"><span>注記</span></div><p class="">HTMLでは、landmarkロールが指定されたあらゆるエリアは領域になる。</p></div>
+	<div class="ednote"><div role="heading" class="ednote-title marker" id="h-ednote-6" aria-level="3"><span>編集者注</span></div><p class="">この用語は<a href="#at-risk">リスク下にある</a>.</p></div>
 </dd>
 
 

--- a/index.html
+++ b/index.html
@@ -2885,7 +2885,7 @@ details.respec-tests-details > li {
    <p>マウス、ペン、タッチ接触のように、画面上の特定の (1つまたは複数の) 地点を指すことができる入力デバイス。
    </p>
    					
-   <p><a href="https://www.w3.org/TR/pointerevents/#dfn-pointer">ポインタイベント のポインタの定義</a>も参照できる[<cite><a class="bibref" href="#bib-pointerevents">pointerevents</a></cite>]
+   <p><a href="https://www.w3.org/TR/pointerevents/#dfn-pointer">Pointer Events pointerの定義</a>も参照[<cite><a class="bibref" href="#bib-pointerevents">pointerevents</a></cite>]。
    </p>
    				
 </dd>


### PR DESCRIPTION
#26 対応

用語集内下記用語の一部調整と、未翻訳部分の訳出をしました。
- ポインタ入力 (pointer input)
- region
- シングルポインタ (single pointer) 
- ウェブページ一式 (set of Web pages) 