### PR TITLE
2.6 Additional sensor inputs・2.6.1 動作による起動・2.6.2 表示の向き・3.2.6 ステータス変更 翻訳作業

### DIFF
--- a/index.html
+++ b/index.html
@@ -1581,7 +1581,7 @@ details.respec-tests-details > li {
    					
   <p>コンテンツが、その表示及び操作を縦向き (ポートレート) または横向き (ランドスケープ) などの単一の向きに制限しない。ただし、その表示の向きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合は例外とする。</p>
    				
-   <div class="note"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>注記</span></div><p class="">単一の表示の向きが必要不可欠な例としては、銀行の小切手、ピアノのアプリケーション、プロジェクタやテレビ向けのスライド、バイナリ表示が使用できないバーチャルリアリティのコンテンツなどが挙げられる。</p></div><!--OddPage-->
+   <div class="note"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>注記</span></div><p class="">単一の表示の向きが必要不可欠な例としては、銀行の小切手、ピアノのアプリケーション、プロジェクタやテレビ向けのスライド、バイナリディスプレイ表示が適用されないバーチャルリアリティのコンテンツなどが挙げられる。</p></div><!--OddPage-->
    					
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1556,12 +1556,12 @@ details.respec-tests-details > li {
    					
    
    					
-   <p>デバイスの動作やユーザの動作で操作できる<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>が、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザーインタフェース コンポーネント</a>でも操作でき、and responding to the motion、かつ予期しない起動を防ぐために無効化することができる。ただし、以下の場合は例外とする。</p>
+   <p>デバイスの動作やユーザの動作で操作できる<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>が、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザーインタフェース コンポーネント</a>でも操作でき、かつ予期しない起動を防ぐために動作への反応を無効化することができる。ただし、以下の場合は例外とする。</p>
    
    <dl>
    
-   <dt>Supported Interface</dt>
-     <dd>The motion is used to operate functionality through an <a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">accessibility supported</a> interface;</dd>
+   <dt>サポートされたインタフェース</dt>
+     <dd>動作は機能を操作するために<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポーテッド</a>なインタフェースを通じて用いられる。</dd>
    
    <dt>必要不可欠</dt>
    <dd>その動作が機能にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>であり、これを無効化すればアクティビティを無効化してしまう。</dd>


### PR DESCRIPTION
#23の翻訳対応をしました。

- 2.6は削除されているので、翻訳していません。
- 2.6.1は勧告版では2.5.4になっているなど変更がありますが、数字などについてはいったんそのままにしています。

- 2.6.1 動作による起動
    - 2.6.1から2.5.4に変更
    - 達成基準の内容そのものに変化はありません。
- 2.6.2 表示の向き
    - 2.6.2から1.3.4に変更
    - 達成基準の内容そのものに変化はありません。
    - 「binary display orientation」については縦横両方のディスプレイの向きを指していると認識していますが、適切な単語が浮かばなかったので「バイナリ」のままにしています。
- 3.2.6 ステータス変更
    - 3.2.6から4.1.3に変更
    - Status ChangesからStatus Messageに変更されたので、後々調整が必要な認識です。
    - 達成基準の内容そのものに変化はなく、翻訳済みの内容そのままで問題ないと思いましたので調整していません。

どうぞよろしくお願い致します。