### PR TITLE
2.4.11 文字キーのショートカットの訳出

### DIFF
--- a/index.html
+++ b/index.html
@@ -1432,18 +1432,18 @@ details.respec-tests-details > li {
    					
    
 	
-  <p>If a <a href="#dfn-keyboard-shortcuts" class="internalDFN" data-link-type="dfn">keyboard shortcut</a> is implemented in content using only letter (including upper- and lower-case letters), punctuation, number, or symbol characters, then at least one of the following is true:</p>
+  <p>コンテンツに文字 (大文字と小文字を含む)、句読点、数字、又は記号のみを使用した<a href="#dfn-keyboard-shortcuts" class="internalDFN" data-link-type="dfn">キーボードショートカット</a>が実装されている場合、少なくとも次のいずれかを満たしている:</p>
 
   <dl>
    
    <dt>解除</dt>
-    <dd>A <a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">mechanism</a> is available to turn the shortcut off;</dd>
+    <dd>ショートカットを解除する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる</dd>
       						
-   <dt>Remap</dt>
-     <dd>A mechanism is available to remap the shortcut to use one or more non-printable keyboard characters (e.g. Ctrl, Alt, etc).</dd>
+   <dt>再割り当て</dt>
+     <dd>1つ以上の非表示文字 (例えばCtrlやAltなど) にショートカットを再割り当てするメカニズムが利用できる</dd>
 
-    <dt>Active only on focus</dt>
-    <dd>The keyboard shortcut for a <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">user interface component</a> is only active when that component has focus.</dd>
+    <dt>フォーカス中にのみ有効化</dt>
+    <dd><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>のキーボードショートカットは、そのコンポーネントがフォーカスをもっているときのみ有効になる。</dd>
     
   </dl>  
 	


### PR DESCRIPTION
https://waic.github.io/wcag21/#character-key-shortcuts 2.4.11 文字キーのショートカットの訳出です。