### PR TITLE
勧告の 7. の箇所の日本語翻訳

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4058,12 +4058,12 @@ details.respec-tests-details > li {
         </section>
     	    	
       <section id="input-purposes">
-	<h2 id="x7-input-purposes-for-user-interface-components"><span class="secno">7. </span>Input Purposes for User Interface Components<span class="permalink"><a href="#input-purposes" aria-label="Permalink for 7. Input Purposes for User Interface Components" title="Permalink for 7. Input Purposes for User Interface Components"><span>§</span></a></span></h2>
-	<p>This section contains a listing of common <a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">user interface component</a> input purposes. The terms below are not keywords that must be used, but instead represent purposes that must be captured in the taxonomy adopted by a webpage. Where applicable, authors mark up controls with the chosen taxonomy to indicate the semantic purpose. This provides the potential for user agents and assistive technologies to apply personalized presentations that can enable more people to understand and use the content.</p>
+	<h2 id="x7-input-purposes-for-user-interface-components"><span class="secno">7. </span>ユーザインタフェース コンポーネントにおける入力用途<span class="permalink"><a href="#input-purposes" aria-label="Permalink for 7. Input Purposes for User Interface Components" title="Permalink for 7. Input Purposes for User Interface Components"><span>§</span></a></span></h2>
+	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の入力用途の一覧が含まれる。以下の用語は使わなければならないキーワードではなく、ウェブページに適用される分類法でとらえねばならない用途を表す。コンテンツ制作者は、できれば、セマンティックな用途を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
   
-  <div class="note" id="issue-container-generatedID-143"><div role="heading" class="note-title marker" id="h-note-143" aria-level="3"><span>注記</span></div><p class="">The list of input type purposes is based on the control purposes defined in the <a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 Autofill field section</a>, but it is important to understand that a different technology may have some or all of the same concepts defined in its specification and only the concepts that are mapped to the meanings below are required.</p></div>
+  <div class="note" id="issue-container-generatedID-143"><div role="heading" class="note-title marker" id="h-note-143" aria-level="3"><span>注記</span></div><p class="">入力タイプの用途の一覧は、<a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 オートフィル の節</a> で定義されているコントロールの用途に基づいている。しかし、異なる技術でもその仕様に定義されている同じ概念の一部または全部を有することができ、概念は以下の意味にマッピングされていることのみが必要である、ということを理解することは重要である。訳注：この節での「セマンティックな」という記載の趣旨は、ウェブを構成するシステムが意味的に正確に解釈できるような、というものである。</p></div>
 	    
-  <p>The following input control purposes are intended to relate to the user of the content and pertain only to information related to that individual.</p>
+  <p>以下の入力コントロールの用途は、コンテンツのユーザに関連することを意図しており、その個人に関連する情報のみにふさわしいものである。</p>
 
 	<ul>
 		<li><strong>name</strong> - フルネーム</li>
@@ -4099,8 +4099,8 @@ details.respec-tests-details > li {
 		<li><strong>cc-exp-year</strong> - 決済手段の有効期限の年コンポーネント</li>
 		<li><strong>cc-csc</strong> - 決済手段のセキュリティーコード (カードのセキュリティーコード (CSC)、カード検証コード (CVC)、カード検証値 (CVV)、署名欄コード (SPC)、クレジットカード ID (CCID) などとして知られている)</li>
 		<li><strong>cc-type</strong> - 決済手段の種類</li>
-		<li><strong>transaction-currency</strong> - 利用者が使用よりトランザクションを好む通貨</li>
-		<li><strong>transaction-amount</strong> - (例えば、ビッド又は販売価格を入力する時に) 利用者がトランザクションに望む金額</li>
+		<li><strong>transaction-currency</strong> - 利用者が取引での使用を望む通貨</li>
+		<li><strong>transaction-amount</strong> - (例えば、ビッド又は販売価格を入力する時に) 利用者が取引したい金額</li>
 		<li><strong>language</strong> - 優先言語</li>
 		<li><strong>bday</strong> - 誕生日</li>
 		<li><strong>bday-day</strong> - 誕生日の日コンポーネント</li>


### PR DESCRIPTION
https://github.com/waic/wcag21/issues/54 に基づく訳出作業です。達成基準1.3.5、達成基準1.3.6 同様 purpose の訳出は「用途」としました。「セマンティックな」という訳出に対し訳注を記載しています。https://www.w3.org/TR/html52/sec-forms.html#sec-autofill に由来する訳出では、以下の2か所を修正しています。
transaction-currency の用途説明部分
（原文）The currency that the user would prefer the transaction to use
（修正前）利用者が使用よりトランザクションを好む通貨
（修正後）利用者が取引での使用を望む通貨
transaction-amount の用途説明部分
（原文）The amount that the user would like for the transaction (e.g., when entering a bid or sale price)
（修正前）(例えば、ビッド又は販売価格を入力する時に) 利用者がトランザクションに望む金額
（修正後）(例えば、ビッド又は販売価格を入力する時に) 利用者が取引したい金額

 @motchie さん、 @bakera さん、 @momdo さん、レビュー願います。