### PR TITLE
２章の訳出漏れ・訳出修正の対応

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -630,8 +630,7 @@ details.respec-tests-details > li {
                 </li>
                 <li class="tocline">
                   <a href="#seizures-and-physical-reactions" class=
-                  "tocxref"><span class="secno">2.3</span> Seizures and Physical
-                  Reactions</a>
+                  "tocxref"><span class="secno">2.3</span> 発作と身体的反応</a>
                   <ol class="toc">
                     <li class="tocline">
                       <a href="#three-flashes-or-below-threshold" class=
@@ -695,7 +694,7 @@ details.respec-tests-details > li {
                 </li>
                 <li class="tocline">
                   <a href="#input-modalities" class="tocxref"><span class=
-                  "secno">2.5</span> Input Modalities</a>
+                  "secno">2.5</span> 入力モダリティ</a>
                   <ol class="toc">
                     <li class="tocline">
                       <a href="#pointer-gestures" class="tocxref"><span class=
@@ -1915,8 +1914,8 @@ details.respec-tests-details > li {
             </section>
 
             <section class="guideline new" id="seizures-and-physical-reactions">
-                <h3 id="x2-3-seizures-and-physical-reactions"><span class="secno">ガイドライン 2.3 </span>Seizures and Physical Reactions<span class="permalink"><a href="#seizures-and-physical-reactions" aria-label="Permalink for 2.3 Seizures and Physical Reactions" title="Permalink for 2.3 Seizures and Physical Reactions"><span>§</span></a></span></h3>
-                <p>Do not design content in a way that is known to cause seizures or physical reactions.</p>
+                <h3 id="x2-3-seizures-and-physical-reactions"><span class="secno">ガイドライン 2.3 </span>発作と身体的反応<span class="permalink"><a href="#seizures-and-physical-reactions" aria-label="Permalink for 2.3 Seizures and Physical Reactions" title="Permalink for 2.3 Seizures and Physical Reactions"><span>§</span></a></span></h3>
+                <p>発作や身体的反応を引き起こすようなコンテンツを設計しないこと。</p>
 
                 <section class="sc" id="three-flashes-or-below-threshold">
    
@@ -2081,9 +2080,9 @@ details.respec-tests-details > li {
             </section>
 
             <section class="guideline new" id="input-modalities">
-                <h3 id="x2-5-input-modalities"><span class="secno">ガイドライン 2.5 </span>Input Modalities<span class="permalink"><a href="#input-modalities" aria-label="Permalink for 2.5 Input Modalities" title="Permalink for 2.5 Input Modalities"><span>§</span></a></span></h3>
+                <h3 id="x2-5-input-modalities"><span class="secno">ガイドライン 2.5 </span>入力モダリティ<span class="permalink"><a href="#input-modalities" aria-label="Permalink for 2.5 Input Modalities" title="Permalink for 2.5 Input Modalities"><span>§</span></a></span></h3>
                 
-                <p>Make it easier for users to operate functionality through various inputs beyond keyboard.</p>
+                <p>ユーザーがキーボード以外の様々な入力を通じて機能を操作しやすくすること。</p>
 
                 <section class="sc new" id="pointer-gestures">
    					
@@ -2115,7 +2114,7 @@ details.respec-tests-details > li {
    <dt>ダウンイベントがない</dt>
      <dd>機能を実行する目的でポインタの<a href="#dfn-down-event" class="internalDFN" data-link-type="dfn">ダウンイベント</a>を使用していない。</dd>
       						
-   <dt>Abort or Undo</dt>
+   <dt>中止または元に戻すことができる</dt>
      <dd>機能を完了させる目的には<a href="#dfn-up-event" class="internalDFN" data-link-type="dfn">アップイベント</a>を使用し、かつ機能の完了前にを中止する、又は機能の完了後に元に戻すための<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。[mark]</dd>
       						
    <dt>アップイベントで戻すことができる</dt>
@@ -2125,7 +2124,7 @@ details.respec-tests-details > li {
      <dd>ダウンイベントによって機能を完了させることが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である。</dd>
       						
    </dl>
-   <div class="note" id="issue-container-generatedID-23"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>注記</span></div><p class="">Functions that emulate a keyboard or numeric keypad key press are considered essential.</p></div>
+   <div class="note" id="issue-container-generatedID-23"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>注記</span></div><p class="">キーボードまたはテンキーパッドのキープレスをエミュレートする機能は必須と考えられる。</p></div>
    					
   <div class="note" id="issue-container-generatedID-24"><div role="heading" class="note-title marker" id="h-note-24" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツを対象としている (ユーザエージェントや支援技術の操作に必要なジェスチャは対象としていない)。[mark]</p></div>
 	

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1950,7 +1950,7 @@ details.respec-tests-details > li {
    					
    
 
-  <p>アニメーションが、機能や伝達される情報に<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>でない限り、インタラクションによる<a href="#dfn-motion-animation" class="internalDFN" data-link-type="dfn">モーションアニメーション</a>は無効化できる。[mark]</p>
+  <p>アニメーションが、機能や伝達される情報に<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>でない限り、インタラクションによる<a href="#dfn-motion-animation" class="internalDFN" data-link-type="dfn">モーションアニメーション</a>は無効化できる。</p>
    				
 </section>
 
@@ -2094,7 +2094,7 @@ details.respec-tests-details > li {
    					
    <p>マルチポイント又は軌跡ベースのジェスチャを使って操作する<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>はすべて、軌跡ベースのジェスチャーなしの<a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn">シングルポインタ</a>で操作することができる。ただし、マルチポイント又は軌跡ベースのジェスチャが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である場合は例外とする。</p>
    					
-   <div class="note" id="issue-container-generatedID-22"><div role="heading" class="note-title marker" id="h-note-22" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツを対象としている (ユーザエージェントや支援技術の操作に必要なジェスチャは対象としていない)。[mark]</p></div>
+   <div class="note" id="issue-container-generatedID-22"><div role="heading" class="note-title marker" id="h-note-22" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツに適用される (ユーザエージェントや支援技術の操作に必要なアクションには適用されない)。</p></div>
 	
 </section>
 
@@ -2115,7 +2115,7 @@ details.respec-tests-details > li {
      <dd>機能を実行する目的でポインタの<a href="#dfn-down-event" class="internalDFN" data-link-type="dfn">ダウンイベント</a>を使用していない。</dd>
       						
    <dt>中止または元に戻すことができる</dt>
-     <dd>機能を完了させる目的には<a href="#dfn-up-event" class="internalDFN" data-link-type="dfn">アップイベント</a>を使用し、かつ機能の完了前にを中止する、又は機能の完了後に元に戻すための<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。[mark]</dd>
+     <dd>機能の完了には<a href="#dfn-up-event" class="internalDFN" data-link-type="dfn">アップイベント</a>を使用し、かつ機能の完了前にを中止する、又は機能の完了後に元に戻すための<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。</dd>
       						
    <dt>アップイベントで戻すことができる</dt>
      <dd>アップイベントによって、先行したダウンイベントの結果を元に戻すことができる。</dd>
@@ -2126,7 +2126,7 @@ details.respec-tests-details > li {
    </dl>
    <div class="note" id="issue-container-generatedID-23"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>注記</span></div><p class="">キーボードまたはテンキーパッドのキープレスをエミュレートする機能は必須と考えられる。</p></div>
    					
-  <div class="note" id="issue-container-generatedID-24"><div role="heading" class="note-title marker" id="h-note-24" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツを対象としている (ユーザエージェントや支援技術の操作に必要なジェスチャは対象としていない)。[mark]</p></div>
+  <div class="note" id="issue-container-generatedID-24"><div role="heading" class="note-title marker" id="h-note-24" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツに適用される (ユーザエージェントや支援技術の操作に必要なアクションには適用されない)。</p></div>
 	
 </section>
 


### PR DESCRIPTION
担当分の２章の対応をしました。

- 1コミットめ：訳出漏れの訳出
- 2コミットめ：`[mark]`された箇所の訳出修正