### PR TITLE
コントラスト比3.1→3:1に修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1422,7 +1422,7 @@ details.respec-tests-details > li {
    					
    
    					
-   <p>以下の視覚的<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>には、隣接した色との間で少なくとも3.1の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn">コントラスト比</a>がある。</p>
+   <p>以下の視覚的<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>には、隣接した色との間で少なくとも 3:1 の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn">コントラスト比</a>がある。</p>
    					
    <dl>
       						


### PR DESCRIPTION
達成基準 1.4.11にコントラスト比「3.1」という記述がありますが、明らかに3:1が正と思われますので修正しました。
原文は以下のようになっていても原文の方は問題ないようです。

>The visual presentation of the following have a contrast ratio of at least 3:1 against adjacent color(s):