### PR TITLE
7章第1段落の訳語調整

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4054,7 +4054,7 @@ details.respec-tests-details > li {
     	    	
       <section id="input-purposes">
 	<h2 id="x7-input-purposes-for-user-interface-components"><span class="secno">7. </span>ユーザインタフェース コンポーネントにおける入力目的<span class="permalink"><a href="#input-purposes" aria-label="Permalink for 7. Input Purposes for User Interface Components" title="Permalink for 7. Input Purposes for User Interface Components"><span>§</span></a></span></h2>
-	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は使わなければならないキーワードではなく、ウェブページに適用される分類法でとらえねばならない目的を表す。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
+	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は使わなければならないキーワードではなく、むしろウェブページで採用されている分類法で取り込まれなければならない目的を表す。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
   
   <div class="note" id="issue-container-generatedID-143"><div role="heading" class="note-title marker" id="h-note-143" aria-level="3"><span>注記</span></div><p class="">入力タイプの目的の一覧は、<a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 オートフィル の節</a> で定義されているコントロールの目的に基づいている。しかし、異なる技術でもその仕様に定義されている同じ概念の一部または全部を有することができ、概念は以下の意味にマッピングされていることのみが必要である、ということを理解することは重要である。</p></div>
   <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>この節での「セマンティック上の」という記載の趣旨は、ウェブを構成するシステムが意味的に正確に解釈できるような、というものである。</p></div>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4054,7 +4054,7 @@ details.respec-tests-details > li {
     	    	
       <section id="input-purposes">
 	<h2 id="x7-input-purposes-for-user-interface-components"><span class="secno">7. </span>ユーザインタフェース コンポーネントにおける入力目的<span class="permalink"><a href="#input-purposes" aria-label="Permalink for 7. Input Purposes for User Interface Components" title="Permalink for 7. Input Purposes for User Interface Components"><span>§</span></a></span></h2>
-	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は使わなければならないキーワードではなく、むしろウェブページで採用されている分類法で取り込まれなければならない目的を表す。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
+	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は、使わなければならないキーワードというわけではない。そのかわり、これらのキーワードは目的を表現するものとなり、ウェブページに適用されている分類法の観点でとらえなければならないことになる。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
   
   <div class="note" id="issue-container-generatedID-143"><div role="heading" class="note-title marker" id="h-note-143" aria-level="3"><span>注記</span></div><p class="">入力タイプの目的の一覧は、<a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 オートフィル の節</a> で定義されているコントロールの目的に基づいている。しかし、異なる技術でもその仕様に定義されている同じ概念の一部または全部を有することができ、概念は以下の意味にマッピングされていることのみが必要である、ということを理解することは重要である。</p></div>
   <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>この節での「セマンティック上の」という記載の趣旨は、ウェブを構成するシステムが意味的に正確に解釈できるような、というものである。</p></div>


### PR DESCRIPTION
Close #146 
taxonomyはカナでタクソノミーとする方が個人的には好みですが、他にも出現箇所があるようので、一旦「分類法」のままとしました。