### PR TITLE
WCAG 2.1本体: presentationの訳を「提示」に統一

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1438,7 +1438,7 @@ details.respec-tests-details > li {
       
       <dd>
          
-         <p>テキストの特定の表現が、伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である。
+         <p>テキストの特定の提示が、伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である。
          </p>
          
       </dd>
@@ -1558,7 +1558,7 @@ details.respec-tests-details > li {
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/images-of-text-no-exception.html">Understanding Images of Text (No Exception)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#images-of-text-no-exception">How to Meet Images of Text (No Exception)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>は、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn">純粋な装飾</a>に用いられているか、<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>の特定の表現が伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である場合に用いられている。
+   <p><a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>は、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn">純粋な装飾</a>に用いられているか、<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>の特定の提示が伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である場合に用いられている。
    </p>
    
    <div class="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-5" aria-level="5"><span>注記</span></div><p class="">ロゴタイプ (ロゴ又はブランド名の一部である文字) は必要不可欠なものであると考えられる。</p></div>
@@ -3108,7 +3108,7 @@ details.respec-tests-details > li {
                 <dt><dfn data-dfn-type="dfn" id="dfn-extended-audio-description">拡張音声解説 (extended audio description)</dfn></dt>
 <dd>
    
-   <p><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>を一時停止することで追加の説明を付加するための時間を確保し、視聴覚プレゼンテーションに付加した音声解説。
+   <p><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>を一時停止することで追加の説明を付加するための時間を確保し、視聴覚提示に付加した音声解説。
    </p>
    
    <div class="note" id="issue-container-generatedID-80"><div role="heading" class="note-title marker" id="h-note-80" aria-level="3"><span>注記</span></div><p class="">この達成方法は、追加の<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>がないと<a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。


### PR DESCRIPTION
closes #72

waic/wcag20#33 にあわせて、本体のpresentationを「提示」にしました。
ご確認お願いいたします。