### PR TITLE
WCAG 2.1本体: 名前→名前 (name) に変更

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2137,7 +2137,7 @@ details.respec-tests-details > li {
 	
   <p><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>が<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>又は<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>を含む<a href="#dfn-labels" class="internalDFN" data-link-type="dfn">ラベル</a>を持つ場合、視覚的に提示されたテキストが<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> に含まれている。</p>
 
-  <div class="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-25" aria-level="5"><span>注記</span></div><p class="">ベストプラクティスは、ラベルのテキストを名前 (name)の最初に使用することである。</p></div>
+  <div class="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-25" aria-level="5"><span>注記</span></div><p class="">ベストプラクティスは、ラベルのテキストを名前 (name) の最初に使用することである。</p></div>
 	
 </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2137,7 +2137,7 @@ details.respec-tests-details > li {
 	
   <p><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>が<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>又は<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>を含む<a href="#dfn-labels" class="internalDFN" data-link-type="dfn">ラベル</a>を持つ場合、視覚的に提示されたテキストが<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> に含まれている。</p>
 
-  <div class="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-25" aria-level="5"><span>注記</span></div><p class="">ベストプラクティスは、ラベルのテキストを名前の最初に使用することである。</p></div>
+  <div class="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-25" aria-level="5"><span>注記</span></div><p class="">ベストプラクティスは、ラベルのテキストを名前 (name)の最初に使用することである。</p></div>
 	
 </section>
 


### PR DESCRIPTION
closes #82 

「名前」を「名前 (name)」に変更しました。全体的に検索しましたが、「(name)」が不足しているところは1箇所だけでした。

どうぞよろしくお願いいたします。