### PR TITLE
WCAG 2.1本体: versionの訳語統一

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -421,7 +421,7 @@ details.respec-tests-details > li {
                 </li>
                 <li class="tocline">
                   <a href="#later-versions-of-accessibility-guidelines" class=
-                  "tocxref"><span class="secno">0.6 </span>アクセシビリティガイドラインの後続バージョン</a>
+                  "tocxref"><span class="secno">0.6 </span>アクセシビリティガイドラインの後続版</a>
                 </li>
               </ol>
             </li>
@@ -940,7 +940,7 @@ details.respec-tests-details > li {
 				<p>Web Content Accessibility Guidelines (WCAG) 2.1 は、ウェブコンテンツを障害者にとってよりアクセシブルにする方法を定義している。アクセシビリティは、視覚、聴覚、身体、発話、認知、言語、学習、神経の障害を含む、広範な障害に関係している。このガイドラインは、広範囲に及ぶ事項を網羅しているが、障害のすべての種類、程度、組合せからくるニーズを満たすことはできない。また、このガイドラインは、加齢により能力が変化している高齢者にとってもウェブコンテンツをより使いやすくするものであるとともに、しばしば利用者全般のユーザビリティを向上させる。</p>
 				<p>WCAG 2.1 は、ウェブコンテンツのアクセシビリティに対して、様々な国の個人、組織、政府のニーズを満たすような共通の基準を提供することを目的として、<a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/"><abbr title="World Wide Web Consortium">W3C</abbr> process</a> に従って世界中の個人及び組織の協力のもと作成されている。WCAG 2.0 [<cite><a class="bibref" href="#bib-WCAG20">WCAG20</a></cite>] は WCAG 1.0 [<cite><a class="bibref" href="#bib-WAI-WEBCONTENT">WAI-WEBCONTENT</a></cite>] をベースに、 WCAG 2.1 は WCAG 2.0 [WCAG20] をベースに、順に作られており、現在及び将来のさまざまなウェブ技術に広く適用され、自動テストと人間による評価の組み合わせでテスト可能になるように設計されている。WCAG のイントロダクションとしては、<a href="http://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。</p>
                 
-				<p>認知、言語、および学習障害に対処するための追加の達成基準を定義するにあたり、勧告策定期間の短さに加えて、勧告案のテスト可能性や実装可能性、国際的な観点からの検討について合意形成することへのチャレンジなど、重大な課題に向き合うこととなった。こうした領域については、WCAG の将来のバージョンで検討が継続されることになる。コンテンツ制作者においては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/#supplement">学習障害、認知障害、ロービジョンなど障害を持つ人々のインクルージョンを向上するための補足的なガイダンス</a>を参照することを推奨する。</p>
+				<p>認知、言語、および学習障害に対処するための追加の達成基準を定義するにあたり、勧告策定期間の短さに加えて、勧告案のテスト可能性や実装可能性、国際的な観点からの検討について合意形成することへのチャレンジなど、重大な課題に向き合うこととなった。こうした領域については、WCAG の将来の版で検討が継続されることになる。コンテンツ制作者においては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/#supplement">学習障害、認知障害、ロービジョンなど障害を持つ人々のインクルージョンを向上するための補足的なガイダンス</a>を参照することを推奨する。</p>
 
 				<p>ウェブアクセシビリティは、アクセシブルなコンテンツだけではなく、アクセシブルなウェブブラウザやその他のユーザエージェントにも依存している。そして、オーサリングツールもウェブアクセシビリティにおいて重要な役割を担っている。ウェブ開発やインタラクションを構成するこれらの要素が相互にどのように関係しているかの概要については、以下を参照:</p>
 				<ul>
@@ -994,7 +994,7 @@ details.respec-tests-details > li {
         	</section>
     		<section id="comparison-with-wcag-2-0">
                 <h3 id="x0-5-comparison-with-wcag-2-0"><span class="secno">0.5 </span>WCAG 2.0 との比較<span class="permalink"><a href="#comparison-with-wcag-2-0" aria-label="Permalink for 0.5 Comparison with WCAG 2.0" title="Permalink for 0.5 Comparison with WCAG 2.0"><span>§</span></a></span></h3>
-                <p>WCAG 2.1 は、認知または学習障害を持つ利用者、ロービジョンの利用者、モバイルデバイス上の障害を持つ利用者、という三つの主要なグループためのアクセシビリティのガイダンスを改善することを目的に開始された。これらのニーズを満たすために多くの方法が提案され評価され、ワーキンググループによって洗練された。WCAG 2.0 から継承された構造的な要件、勧告案の明快さとインパクト、および勧告策定までのタイムラインが、このバージョンに含まれる最終的な達成基準のセットにつながっている。ワーキンググループは、WCAG 2.1 がこれらすべての領域におけるウェブコンテンツのアクセシビリティのガイダンスを段階的に進歩させると考えているが、このガイドラインではすべての利用者のニーズが満たされているわけではないことを強調している。</p>
+                <p>WCAG 2.1 は、認知または学習障害を持つ利用者、ロービジョンの利用者、モバイルデバイス上の障害を持つ利用者、という三つの主要なグループためのアクセシビリティのガイダンスを改善することを目的に開始された。これらのニーズを満たすために多くの方法が提案され評価され、ワーキンググループによって洗練された。WCAG 2.0 から継承された構造的な要件、勧告案の明快さとインパクト、および勧告策定までのタイムラインが、この版に含まれる最終的な達成基準のセットにつながっている。ワーキンググループは、WCAG 2.1 がこれらすべての領域におけるウェブコンテンツのアクセシビリティのガイダンスを段階的に進歩させると考えているが、このガイドラインではすべての利用者のニーズが満たされているわけではないことを強調している。</p>
 
 				<p>WCAG 2.1 は WCAG 2.0 をベースに構築され、WCAG 2.0 と後方互換性があるため、WCAG 2.1 に適合しているウェブページはすなわち WCAG 2.0 にも適合していることにもなる。WCAG 2.0 への適合を方針によって要求されているコンテンツ制作者は、WCAG 2.0 への適合を維持したままコンテンツを WCAG 2.1 に適合できるようアップデートすることができる。両方のガイドラインに従うコンテンツ制作者は、以下に挙げる差異に注意すべきである。</p>
 				<section id="new-features-in-wcag-2-1">
@@ -1035,8 +1035,8 @@ details.respec-tests-details > li {
 				</section>
 			</section>
         	<section id="later-versions-of-accessibility-guidelines">
-        		<h3 id="x0-6-later-versions-of-accessibility-guidelines"><span class="secno">0.6 </span>アクセシビリティガイドラインの後続バージョン<span class="permalink"><a href="#later-versions-of-accessibility-guidelines" aria-label="Permalink for 0.6 Later Versions of Accessibility Guidelines" title="Permalink for 0.6 Later Versions of Accessibility Guidelines"><span>§</span></a></span></h3>
-        		<p>WCAG 2.1 と並行して、アクセシビリティガイドラインワーキンググループは、アクセシビリティガイドラインの別の主要バージョンを開発している。この作業の結果は、WCAG 2 のドットリリースに現実的であるよりも、ウェブアクセシビリティガイダンスのより実質的な再構築になると期待されている。この作業は、コンテンツ制作、ユーザエージェントのサポート、及びオーサリングツールのサポートの役割を含む、最も効果的かつ柔軟な結果を生むために、研究に焦点を合わせた、ユーザ中心設計の方法論に従う。これは長年にわたる努力であるため、WCAG 2.0 の公開からのウェブ上の変化を反映するための最新のウェブアクセシビリティガイダンスを提供するための暫定措置として WCAG 2.1 が必要とされる。ワーキンググループは、主要バージョンが完成するまでの間、同様に短いタイムラインで追加のサポートを提供するために、WCAG 2.2 及びそれに続く暫定バージョンを開発するかもしれない。</p><!--OddPage-->
+        		<h3 id="x0-6-later-versions-of-accessibility-guidelines"><span class="secno">0.6 </span>アクセシビリティガイドラインの後続版<span class="permalink"><a href="#later-versions-of-accessibility-guidelines" aria-label="Permalink for 0.6 Later Versions of Accessibility Guidelines" title="Permalink for 0.6 Later Versions of Accessibility Guidelines"><span>§</span></a></span></h3>
+        		<p>WCAG 2.1 と並行して、アクセシビリティガイドラインワーキンググループは、アクセシビリティガイドラインの別の主要版を開発している。この作業の結果は、WCAG 2 のドットリリースに現実的であるよりも、ウェブアクセシビリティガイダンスのより実質的な再構築になると期待されている。この作業は、コンテンツ制作、ユーザエージェントのサポート、及びオーサリングツールのサポートの役割を含む、最も効果的かつ柔軟な結果を生むために、研究に焦点を合わせた、ユーザ中心設計の方法論に従う。これは長年にわたる努力であるため、WCAG 2.0 の公開からのウェブ上の変化を反映するための最新のウェブアクセシビリティガイダンスを提供するための暫定措置として WCAG 2.1 が必要とされる。ワーキンググループは、主要版が完成するまでの間、同様に短いタイムラインで追加のサポートを提供するために、WCAG 2.2 及びそれに続く暫定版を開発するかもしれない。</p><!--OddPage-->
         	</section>
         </section>
         <section class="principle" id="perceivable">
@@ -2507,7 +2507,7 @@ details.respec-tests-details > li {
                     <p><a href="#dfn-conform" class="internalDFN" data-link-type="dfn">適合</a> (及び適合レベル) は<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>全体に対するもののみであり、ウェブページの一部が除外されている場合には適合にならない。</p>
                     <div class="note" id="issue-container-generatedID-30"><div role="heading" class="note-title marker" id="h-note-30" aria-level="5"><span>注記</span></div><p class="">適合の判断をするときに、例えば、詳細な説明又は映像の代替の提示のように、代替となるものがそのページから直接得られる場合は、ページのコンテンツの一部に対する代替コンテンツはそのページの一部であるとみなされる。</p></div>
                     <div class="note" id="issue-container-generatedID-31"><div role="heading" class="note-title marker" id="h-note-31" aria-level="5"><span>注記</span></div><p class="">コンテンツ制作者が制御できないコンテンツがあるために適合できないウェブページについては、<a href="#conformance-partial">部分適合に関する記述</a>を行うことを検討するとよい。</p></div>
-                  <div class="note" id="issue-container-generatedID-32"><div role="heading" class="note-title marker" id="h-note-32" aria-level="5"><span>注記</span></div><p class="new">ウェブページ全体には、さまざまな画面サイズ向けに自動的に提示される個々のウェブページのバリエーションを含む (例: レスポンジブウェブページのバリエーション)。ウェブページ全体が適合するためには、個々のバリエーションが適合するか、適合する代替バージョンが必要である。</p></div>
+                  <div class="note" id="issue-container-generatedID-32"><div role="heading" class="note-title marker" id="h-note-32" aria-level="5"><span>注記</span></div><p class="new">ウェブページ全体には、さまざまな画面サイズ向けに自動的に提示される個々のウェブページのバリエーションを含む (例: レスポンジブウェブページのバリエーション)。ウェブページ全体が適合するためには、個々のバリエーションが適合するか、適合する代替版が必要である。</p></div>
                 </section>
 
                 <section id="cc3">


### PR DESCRIPTION
closes #102 

「バージョン」となっていたところは基本的に「版」にしています。
WCAG 2.0から「バージョン」となっていた以下については「バージョン」のままです。

> ガイドライン名、バージョン、及び URI

> 複数のバージョンを有するウェブコンテンツ技術を挙げる際は、アクセシビリティ サポーテッドなバージョンを特定すべきである。

ご確認よろしくお願いいたします。