### PR TITLE
WCAG 2.1本体: 「規定実装要件」→「規定要件の解釈」

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -841,7 +841,7 @@ details.respec-tests-details > li {
               <ol class="toc">
                 <li class="tocline">
                   <a href="#interpreting-normative-requirements" class=
-                  "tocxref"><span class="secno">5.1</span> 規定実装要件</a>
+                  "tocxref"><span class="secno">5.1</span> 規定要件の解釈</a>
                 </li>
                 <li class="tocline">
                   <a href="#conformance-reqs" class="tocxref"><span class=
@@ -2480,7 +2480,7 @@ details.respec-tests-details > li {
             <p>この節では、WCAG 2.1 への<a href="#dfn-conform" class="internalDFN" data-link-type="dfn">適合</a>に関する要件を列挙する。又、任意である適合表明の作成方法に関する情報も提供する。最後に、<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポーテッド</a>とは何かを説明する。なぜならば、適合においては技術のアクセシビリティ サポーテッドな使用方法だけに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存する</a>ことができるからである。アクセシビリティ サポーテッドという概念については、<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conformance</a> でさらに詳しい説明がある。</p>
         	
         	<section id="interpreting-normative-requirements">
-        		<h3 id="x5-1-interpreting-normative-requirements"><span class="secno">5.1 </span>規定実装要件<span class="permalink"><a href="#interpreting-normative-requirements" aria-label="Permalink for 5.1 Interpreting Normative Requirements" title="Permalink for 5.1 Interpreting Normative Requirements"><span>§</span></a></span></h3>
+        		<h3 id="x5-1-interpreting-normative-requirements"><span class="secno">5.1 </span>規定要件の解釈<span class="permalink"><a href="#interpreting-normative-requirements" aria-label="Permalink for 5.1 Interpreting Normative Requirements" title="Permalink for 5.1 Interpreting Normative Requirements"><span>§</span></a></span></h3>
         		
         		<p>WCAG 2.1 の主要な内容は<a href="#dfn-normative" class="internalDFN" data-link-type="dfn">規定</a>であり適合表明を満たす要件を定義する。入門用資料、附録、「規定ではない」と示された節、図、事例と注記は<a href="#dfn-informative" class="internalDFN" data-link-type="dfn">参考情報</a> (規定ではない)である。規定ではない資料は、ガイドラインの解釈を手助けする参考情報を提供するが適合表明を満たす要件は提示しない。</p>
         		<p>キーワード「<em class="rfc2119" title="MAY">してもよい(MAY)</em>」、「<em class="rfc2119" title="MUST">しなければならない(MUST)</em>」、「<em class="rfc2119" title="MUST NOT">してはならない(MUST NOT)</em>」、「<em class="rfc2119" title="NOT RECOMMENDED">推奨されない(NOT RECOMENDED)</em>」、「<em class="rfc2119" title="RECOMMENDED">推奨される(RECOMMENDED)</em>」、「<em class="rfc2119" title="SHOULD">すべきである(SHOULD)</em>」、及び「<em class="rfc2119" title="SHOULD NOT">しないほうがよい(SHOULD NOT)</em>」は、[<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>]に述べられているように解釈される。</p>


### PR DESCRIPTION
closes #121 

「規定実装要件」を「規定要件の解釈」に調整しました。

ご確認のほど、よろしくお願いいたします。