### PR TITLE
WCAG 2.1 本体: 「ジェスチャ」or「ジェスチャー」表記ゆれの解消

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2091,7 +2091,7 @@ details.respec-tests-details > li {
    					
    
    					
-   <p>マルチポイント又は軌跡ベースのジェスチャを使って操作する<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>はすべて、軌跡ベースのジェスチャーなしの<a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn">シングルポインタ</a>で操作することができる。ただし、マルチポイント又は軌跡ベースのジェスチャが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である場合は例外とする。</p>
+   <p>マルチポイント又は軌跡ベースのジェスチャを使って操作する<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>はすべて、軌跡ベースのジェスチャなしの<a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn">シングルポインタ</a>で操作することができる。ただし、マルチポイント又は軌跡ベースのジェスチャが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である場合は例外とする。</p>
    					
    <div class="note" id="issue-container-generatedID-22"><div role="heading" class="note-title marker" id="h-note-22" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツに適用される (ユーザエージェントや支援技術の操作に必要なアクションには適用されない)。</p></div>
 	
@@ -3773,7 +3773,7 @@ details.respec-tests-details > li {
    					
    
    	
-   <p>シングルタップやクリック、ダブルタップやクリック、長押し及びパスを基点としたジェスチャーを含む、画面と 一つの接点で動作するポインタ入力</p>
+   <p>シングルタップやクリック、ダブルタップやクリック、長押し及びパスを基点としたジェスチャを含む、画面と 一つの接点で動作するポインタ入力</p>
   				
 </dd>
 


### PR DESCRIPTION
issue #240 に基づき、「ジェスチャ」（長音なし）で表記統一します。