### PR TITLE
[add]1038行目アクセシビリティガイドラインワーキンググループのワーキングの前に半角スペースを挿入

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1035,7 +1035,7 @@ details.respec-tests-details > li {
 			</section>
         	<section id="later-versions-of-accessibility-guidelines">
         		<h3 id="x0-6-later-versions-of-accessibility-guidelines"><span class="secno">0.6 </span>アクセシビリティガイドラインの後続版<span class="permalink"><a href="#later-versions-of-accessibility-guidelines" aria-label="Permalink for 0.6 Later Versions of Accessibility Guidelines" title="Permalink for 0.6 Later Versions of Accessibility Guidelines"><span>§</span></a></span></h3>
-        		<p>WCAG 2.1 と並行して、アクセシビリティガイドラインワーキンググループは、アクセシビリティガイドラインの別の主要版を開発している。この作業の結果は、WCAG 2 のドットリリースに現実的であるよりも、ウェブアクセシビリティガイダンスのより実質的な再構築になると期待されている。この作業は、コンテンツ制作、ユーザエージェントのサポート、及びオーサリングツールのサポートの役割を含む、最も効果的かつ柔軟な結果を生むために、研究に焦点を合わせた、ユーザ中心設計の方法論に従う。これは長年にわたる努力であるため、WCAG 2.0 の公開からのウェブ上の変化を反映するための最新のウェブアクセシビリティガイダンスを提供するための暫定措置として WCAG 2.1 が必要とされる。ワーキンググループは、主要版が完成するまでの間、同様に短いタイムラインで追加のサポートを提供するために、WCAG 2.2 及びそれに続く暫定版を開発するかもしれない。</p><!--OddPage-->
+        		<p>WCAG 2.1 と並行して、アクセシビリティガイドライン ワーキンググループは、アクセシビリティガイドラインの別の主要版を開発している。この作業の結果は、WCAG 2 のドットリリースに現実的であるよりも、ウェブアクセシビリティガイダンスのより実質的な再構築になると期待されている。この作業は、コンテンツ制作、ユーザエージェントのサポート、及びオーサリングツールのサポートの役割を含む、最も効果的かつ柔軟な結果を生むために、研究に焦点を合わせた、ユーザ中心設計の方法論に従う。これは長年にわたる努力であるため、WCAG 2.0 の公開からのウェブ上の変化を反映するための最新のウェブアクセシビリティガイダンスを提供するための暫定措置として WCAG 2.1 が必要とされる。ワーキンググループは、主要版が完成するまでの間、同様に短いタイムラインで追加のサポートを提供するために、WCAG 2.2 及びそれに続く暫定版を開発するかもしれない。</p><!--OddPage-->
         	</section>
         </section>
         <section class="principle" id="perceivable">


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
issues #107 に基づき「アクセシビリティガイドラインワーキンググループ」の「ワーキング」の前に半角スペースを入れ、長いカタカナ語句を改善しました(該当1箇所)。また、すでに同位置に半角スペースが入っていた同語が1箇所あり、表記揺れでもありました。
「ウェブアクセシビリティガイダンス」については半角スペースを入れず、ママとしています(該当2箇所)。
よろしくお願いいたします。