### PR TITLE
「以下の入力コントロールの目的は、〜」の文の意味が分かりづらいので改善

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4060,7 +4060,7 @@ details.respec-tests-details > li {
   <div class="note" id="issue-container-generatedID-143"><div role="heading" class="note-title marker" id="h-note-143" aria-level="3"><span>注記</span></div><p class="">入力タイプの目的の一覧は、<a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 オートフィル の節</a> で定義されているコントロールの目的に基づいている。しかし、異なるウェブコンテンツ技術は、HTML 仕様で定義されているものと同じ概念の一部又は全部を持ってもよく、以下で示される意味に対応付けられているその概念のみが要求されることを理解することが重要である。</p></div>
   <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>この節での「セマンティック上の」という記載の趣旨は、ウェブを構成するシステムが意味的に正確に解釈できるような、というものである。</p></div>
 	    
-  <p>以下の入力コントロールの目的は、コンテンツの利用者に関連することを意図しており、その個人に関連する情報のみにふさわしいものである。</p>
+  <p>以下に示す入力コントロールの目的は、コンテンツの利用者に関連づけること、その個人に関連する情報にのみ適用することを意図している。</p>
 
 	<ul>
 		<li><strong>name</strong> - フルネーム</li>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
#150 から「7. ユーザインタフェース コンポーネントにおける入力目的」の「以下の入力コントロールの目的は、〜」の文が理解しにくいため、太田さん翻訳案に修正しました
