### PR TITLE
additional-nameとfamily-nameの説明の修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4066,8 +4066,8 @@ details.respec-tests-details > li {
 		<li><strong>name</strong> - フルネーム</li>
 		<li><strong>honorific-prefix</strong> -敬称又は称号 (例えば、"Mr."、"Ms."、"Dr."、"M<sup>lle</sup>")</li>
 		<li><strong>given-name</strong> - Given name (一部の西洋文化において、<i>first name</i> として知られる)</li>
-		<li><strong>additional-name</strong> - 決済手段に与えられるような Additional names (一部の西洋文化において、<i>middle names</i> として知られる)</li>
-		<li><strong>family-name</strong> - 決済手段に与えられるような Family name (一部の西洋文化において、<i>last  name</i> 又は <i>surname</i> として知られる)</li>
+		<li><strong>additional-name</strong> - Additional names (一部の西洋文化において、<i>middle names</i> として知られる)</li>
+		<li><strong>family-name</strong> - Family name (一部の西洋文化において、<i>last  name</i> 又は <i>surname</i> として知られる)</li>
 		<li><strong>honorific-suffix</strong> - 接尾語 (例えば、"Jr."、"B.Sc."、"MBASW"、"II")</li>
 		<li><strong>nickname</strong> - ニックネーム、スクリーンネーム、ハンドル: フルネームの代わりに使用する一般的に短い名前</li>
 		<li><strong>organization-title</strong> - 職種 (例えば"Software Engineer"、"Senior Vice President"、"Deputy Managing Director")</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4066,7 +4066,7 @@ details.respec-tests-details > li {
 		<li><strong>name</strong> - フルネーム</li>
 		<li><strong>honorific-prefix</strong> -敬称又は称号 (例えば、"Mr."、"Ms."、"Dr."、"M<sup>lle</sup>")</li>
 		<li><strong>given-name</strong> - Given name (一部の西洋文化において、<i>first name</i> として知られる)</li>
-		<li><strong>additional-name</strong> - Additional names (一部の西洋文化において、<i>middle names</i> として知られる)</li>
+		<li><strong>additional-name</strong> - Additional names (一部の西洋文化において、<i>middle names</i> として知られる、姓の前にあるファーストネームではない名前)</li>
 		<li><strong>family-name</strong> - Family name (一部の西洋文化において、<i>last  name</i> 又は <i>surname</i> として知られる)</li>
 		<li><strong>honorific-suffix</strong> - 接尾語 (例えば、"Jr."、"B.Sc."、"MBASW"、"II")</li>
 		<li><strong>nickname</strong> - ニックネーム、スクリーンネーム、ハンドル: フルネームの代わりに使用する一般的に短い名前</li>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
#153 から、原文に「決済手段に与えられるような」に相当する文はないため削除しました

#154 から、Additional namesのところの原文訳出「、姓の前にあるファーストネームではない名前」を追記しました