### PR TITLE
「(フィールドごとに 1 行)」部分の「line 1」が訳出されていないので追記（2,3行目も同様）

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4076,9 +4076,9 @@ details.respec-tests-details > li {
 		<li><strong>current-password</strong> - <strong>username</strong> フィールドによって識別されるアカウントに対する現在のパスワード (例えば、ログイン時)</li>
 		<li><strong>organization</strong> - 人、アドレス、又はこのフィールドに関連付けられた他のフィールドの連絡先情報に対応する会社名</li>
 		<li><strong>street-address</strong> - 所在地住所 (複数行、改行を保持)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、1行目)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、2行目)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、3行目)</li>
+		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、1 行目)</li>
+		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、2 行目)</li>
+		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、3 行目)</li>
 		<li><strong>address-level4</strong> - 四つの行政レベルでのアドレスの中で、最もきめ細かい行政レベル。</li>
 		<li><strong>address-level3</strong> - 三つ以上の行政レベルの住所で、第 3 行政レベル</li>
 		<li><strong>address-level2</strong> - 二つ以上の管理レベルの住所で、第 2 管理レベル。二つの行政レベルをもつ国で、これは通常、関連する所在地住所が見つけられる、市、町、村、又は他の地方になる</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4076,9 +4076,9 @@ details.respec-tests-details > li {
 		<li><strong>current-password</strong> - <strong>username</strong> フィールドによって識別されるアカウントに対する現在のパスワード (例えば、ログイン時)</li>
 		<li><strong>organization</strong> - 人、アドレス、又はこのフィールドに関連付けられた他のフィールドの連絡先情報に対応する会社名</li>
 		<li><strong>street-address</strong> - 所在地住所 (複数行、改行を保持)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 2 行)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 3 行)</li>
+		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、1行目)</li>
+		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、2行目)</li>
+		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、3行目)</li>
 		<li><strong>address-level4</strong> - 四つの行政レベルでのアドレスの中で、最もきめ細かい行政レベル。</li>
 		<li><strong>address-level3</strong> - 三つ以上の行政レベルの住所で、第 3 行政レベル</li>
 		<li><strong>address-level2</strong> - 二つ以上の管理レベルの住所で、第 2 管理レベル。二つの行政レベルをもつ国で、これは通常、関連する所在地住所が見つけられる、市、町、村、又は他の地方になる</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4077,8 +4077,8 @@ details.respec-tests-details > li {
 		<li><strong>organization</strong> - 人、アドレス、又はこのフィールドに関連付けられた他のフィールドの連絡先情報に対応する会社名</li>
 		<li><strong>street-address</strong> - 所在地住所 (複数行、改行を保持)</li>
 		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、1 行目)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、2 行目)</li>
-		<li><strong>address-line1</strong> - 所在地住所 (フィールドごとに 1 行、3 行目)</li>
+		<li><strong>address-line2</strong> - 所在地住所 (フィールドごとに 1 行、2 行目)</li>
+		<li><strong>address-line3</strong> - 所在地住所 (フィールドごとに 1 行、3 行目)</li>
 		<li><strong>address-level4</strong> - 四つの行政レベルでのアドレスの中で、最もきめ細かい行政レベル。</li>
 		<li><strong>address-level3</strong> - 三つ以上の行政レベルの住所で、第 3 行政レベル</li>
 		<li><strong>address-level2</strong> - 二つ以上の管理レベルの住所で、第 2 管理レベル。二つの行政レベルをもつ国で、これは通常、関連する所在地住所が見つけられる、市、町、村、又は他の地方になる</li>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
#156 からこのプルリクエスト表題のとおり作業しました