### PR TITLE
「7. ユーザインタフェース コンポーネントの入力目的」内、urlの項の説明文を修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4104,7 +4104,7 @@ details.respec-tests-details > li {
 		<li><strong>bday-month</strong> - 誕生日の月コンポーネント</li>
 		<li><strong>bday-year</strong> - 誕生日の年コンポーネント</li>
 		<li><strong>sex</strong> - 性別認識 (例えば、女性、ファファフィネ)</li>
-		<li><strong>url</strong> - ホームページや会社に対応する他のウェブページ、人、アドレス、又はこのフィールドに関連付けられる他のフィールドでの連絡先情報</li>
+		<li><strong>url</strong> - このフィールドに関連する他のフィールドに入力された会社、個人、住所、又は連絡先情報に対応するホームページ又はその他のウェブページ</li>
 		<li><strong>photo</strong> - 写真、アイコン、会社に対応する他の画像、人、アドレス、又はこのフィールドに関連付けられる他のフィールドの連絡先情報</li>
 		<li><strong>tel</strong> - 国コードを含む完全な電話番号</li>
 		<li><strong>tel-country-code</strong> - 電話番号の国コードコンポーネント</li>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
#158 から、分かりにくかった翻訳の説明文を分かりやすくするものに差し替えました