### PR TITLE
WCAG 2.1 本体: トリガ刺激→トリガ

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -3917,7 +3917,7 @@ details.respec-tests-details > li {
                 <dt class="new"><dfn data-dfn-type="dfn" id="dfn-up-event">アップイベント (up-event)</dfn></dt>
 <dd class="new">
   
-  <p>ポインタのトリガ刺激が解除されたときに生じるプラットフォームイベント。</p>
+  <p>ポインタのトリガが解除されたときに生じるプラットフォームイベント。</p>
 	<p>アップイベントは、プラットフォームによっては「タッチエンド」や「マウスアップ」などの異なる名称で呼ばれている場合がある。</p>
 </dd>
 


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

コメントの通り、「トリガ」としました。

キーボードショートカットでは「トリガー」となっているようなので、どちらかに統一したほうがよさそうです...

> 一つ以上のキーを押すことによる、動作のトリガーの代替手段

https://waic.jp/docs/WCAG21/#dfn-keyboard-shortcuts

closes #145 