### PR TITLE
WCAG 2.1 本体: jargonを「業界用語」とする

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2234,7 +2234,7 @@ details.respec-tests-details > li {
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/unusual-words.html">Understanding Unusual Words</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#unusual-words">How to Meet Unusual Words</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-idioms" class="internalDFN" data-link-type="dfn">慣用句</a>及び<a href="#dfn-jargon" class="internalDFN" data-link-type="dfn">専門用語</a>を含めて、一般的ではない、又は<a href="#dfn-used-in-an-unusual-or-restricted-way" class="internalDFN" data-link-type="dfn">限定された用法で使われている</a>単語、又は語句の、明確な定義を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。
+   <p><a href="#dfn-idioms" class="internalDFN" data-link-type="dfn">慣用句</a>及び<a href="#dfn-jargon" class="internalDFN" data-link-type="dfn">業界用語</a>を含めて、一般的ではない、又は<a href="#dfn-used-in-an-unusual-or-restricted-way" class="internalDFN" data-link-type="dfn">限定された用法で使われている</a>単語、又は語句の、明確な定義を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。
    </p>
    
 </section>
@@ -3263,12 +3263,12 @@ details.respec-tests-details > li {
 </dd>
 
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-jargon">専門用語 (jargon)</dfn></dt>
+                <dt><dfn data-dfn-type="dfn" id="dfn-jargon">業界用語 (jargon)</dfn></dt>
 <dd>
    
    <p>特定の分野の人々が特定の用法で用いる単語。</p>
    
-   <p class="example">固定キーという用語は、支援技術やアクセシビリティの分野における専門用語である。</p>
+   <p class="example">固定キーという用語は、支援技術やアクセシビリティの分野における業界用語である。</p>
    
 </dd>
 


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

jargonの訳を「業界用語」に変更しました。

closes #159 