### PR TITLE
WCAG 2.1 本体: componentに関する訳を調整

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4100,19 +4100,19 @@ details.respec-tests-details > li {
 		<li><strong>transaction-amount</strong> - (例えば、ビッド又は販売価格を入力する時に) 利用者が取引したい金額</li>
 		<li><strong>language</strong> - 優先言語</li>
 		<li><strong>bday</strong> - 誕生日</li>
-		<li><strong>bday-day</strong> - 誕生日の日コンポーネント</li>
-		<li><strong>bday-month</strong> - 誕生日の月コンポーネント</li>
-		<li><strong>bday-year</strong> - 誕生日の年コンポーネント</li>
+		<li><strong>bday-day</strong> - 誕生日の日のコンポーネント</li>
+		<li><strong>bday-month</strong> - 誕生日の月のコンポーネント</li>
+		<li><strong>bday-year</strong> - 誕生日の年のコンポーネント</li>
 		<li><strong>sex</strong> - 性別認識 (例えば、女性、ファファフィネ)</li>
 		<li><strong>url</strong> - このフィールドに関連する他のフィールドに入力された会社、個人、住所、又は連絡先情報に対応するホームページ又はその他のウェブページ</li>
 		<li><strong>photo</strong> - 写真、アイコン、会社に対応する他の画像、人、アドレス、又はこのフィールドに関連付けられる他のフィールドの連絡先情報</li>
 		<li><strong>tel</strong> - 国コードを含む完全な電話番号</li>
-		<li><strong>tel-country-code</strong> - 電話番号の国コードコンポーネント</li>
-		<li><strong>tel-national</strong> - 適用される場合は国の内部の接頭辞とともに、国コードコンポーネントなしの電話番号</li>
-		<li><strong>tel-area-code</strong> - 適用される場合は国の内部の接頭辞とともに、電話番号のエリアコードコンポーネント</li>
-		<li><strong>tel-local</strong> - 国コードと市外局番コンポーネントなしの電話番号</li>
-		<li><strong>tel-local-prefix</strong> - 二つのコンポーネントに分割される場合、市外局番に続く電話番号のコンポーネントの最初の部分</li>
-		<li><strong>tel-local-suffix</strong> - 二つのコンポーネントに分割される場合、市外局番に続く電話番号のコンポーネントの 2 番目の部分</li>
+		<li><strong>tel-country-code</strong> - 電話番号の国コードのコンポーネント</li>
+		<li><strong>tel-national</strong> - 適用される場合は国の内部の接頭辞とともに、国コードのコンポーネントなしの電話番号</li>
+		<li><strong>tel-area-code</strong> - 適用される場合は国の内部の接頭辞とともに、電話番号のエリアコードのコンポーネント</li>
+		<li><strong>tel-local</strong> - 国コードと市外局番のコンポーネントなしの電話番号</li>
+		<li><strong>tel-local-prefix</strong> - コンポーネントが二つのコンポーネントに分割される場合の、市外局番に続く電話番号のコンポーネントの最初の部分</li>
+		<li><strong>tel-local-suffix</strong> - コンポーネントが二つのコンポーネントに分割される場合の、市外局番に続く電話番号のコンポーネントの 2 番目の部分</li>
 		<li><strong>tel-extension</strong> - 電話番号の内部拡張コード</li>
 		<li><strong>email</strong> - 電子メールアドレス</li>
 		<li><strong>impp</strong> - インスタントメッセージングプロトコルのエンドポイントを表す URL (例えば、"<strong>aim:goim?screenname=example</strong>"又は <strong>xmpp:fred@example.net</strong>")</li>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

7章以下のコンポーネントに関する訳を調整しました。

closes #157 