### PR TITLE
問い合わせフォームリンク修正スクリプトを追加 (トップページのみ)

### DIFF
--- a/understanding/index.html
+++ b/understanding/index.html
@@ -14,10 +14,12 @@
 
       <link rel="stylesheet" type="text/css" href="understanding.css" />
 
+      <script src="https://waic.jp/docs/js/translation-contact.js"></script>
+
    </head>
 
    <body>
-<div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.1</a> の 2019 年 3 月 6 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/">翻訳に関するお問い合わせ</a>からご連絡ください。</p><p>【重要】 原文の Understanding WCAG 2.1 自体、ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は古くなっていることがあります。あくまでも参考程度にご覧ください。</p></div>
+<div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.1</a> の 2019 年 3 月 6 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/" id="file-issue">翻訳に関するお問い合わせ</a>からご連絡ください。</p><p>【重要】 原文の Understanding WCAG 2.1 自体、ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は古くなっていることがあります。あくまでも参考程度にご覧ください。</p></div>
       <div class="head"><a href="https://www.w3.org/" class="logo"> <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48" /> </a><h1 id="title" class="title p-name">WCAG 2.1 解説書</h1>
 
          <h2>Updated 6 March 2019</h2>

--- a/understanding/index.html
+++ b/understanding/index.html
@@ -14,12 +14,11 @@
 
       <link rel="stylesheet" type="text/css" href="understanding.css" />
 
-      <script src="https://waic.jp/docs/js/translation-contact.js"></script>
-
    </head>
 
    <body>
-<div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.1</a> の 2019 年 3 月 6 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/" id="file-issue">翻訳に関するお問い合わせ</a>からご連絡ください。</p><p>【重要】 原文の Understanding WCAG 2.1 自体、ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は古くなっていることがあります。あくまでも参考程度にご覧ください。</p></div>
+<div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.1</a> の 2019 年 3 月 6 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2fdocs%2fWCAG21%2fUnderstanding%2f" id="file-issue">翻訳に関するコメント (Google フォーム)</a>からご連絡ください。</p>
+<p>【重要】 原文の Understanding WCAG 2.1 自体、ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は古くなっていることがあります。あくまでも参考程度にご覧ください。</p></div>
       <div class="head"><a href="https://www.w3.org/" class="logo"> <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48" /> </a><h1 id="title" class="title p-name">WCAG 2.1 解説書</h1>
 
          <h2>Updated 6 March 2019</h2>


### PR DESCRIPTION
#235 への対応。
ひとまずUnderstandingのトップページのみスクリプトを追加してみました。
下層の個別ページをどうするか要検討。

