### PR TITLE
2.1関連文書日本語版へのリンクを追加するJSを追加

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4258,4 +4258,9 @@ details.respec-tests-details > li {
 </dd><dt id="bib-UAAG10">[UAAG10]</dt><dd><a href="https://www.w3.org/TR/UAAG10/"><cite>User Agent Accessibility Guidelines 1.0</cite></a>. Ian Jacobs; Jon Gunderson; Eric Hansen. W3C. 17 December 2002. W3C Recommendation. URL: <a href="https://www.w3.org/TR/UAAG10/">https://www.w3.org/TR/UAAG10/</a>
 </dd><dt id="bib-UNESCO">[UNESCO]</dt><dd><a href="http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm"><cite>International Standard Classification of Education</cite></a>. 1997. URL: <a href="http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm">http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm</a>
 </dd><dt id="bib-WAI-WEBCONTENT">[WAI-WEBCONTENT]</dt><dd><a href="https://www.w3.org/TR/WAI-WEBCONTENT/"><cite>Web Content Accessibility Guidelines 1.0</cite></a>. Wendy Chisholm; Gregg Vanderheiden; Ian Jacobs. W3C. 5 May 1999. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WAI-WEBCONTENT/">https://www.w3.org/TR/WAI-WEBCONTENT/</a>
-</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>
+</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+<script type="text/javascript" src="waic_link.js"></script>
+
+</body></html>

--- a/guidelines/waic_link.js
+++ b/guidelines/waic_link.js
@@ -1,5 +1,5 @@
 $(function(){
-	$("body>div:first-child>p:first-child").after("<p>この文書内にあるリンクのうち、「Understanding WCAG 2.1」「Techniques for WCAG 2.1」「How to Meet WCAG 2.1」へのリンクについては、WAIC の公開する日本語版にリンク先を追加しています。WAIC の日本語訳は、 W3C の公開する英語版より内容が古い可能性がありますのでご注意ください。</p>");
+	$("aside.trnote>p:last-child").text("この文書内にあるリンクのうち、「Understanding WCAG 2.1」へのリンクについては、WAIC の公開する日本語版にリンク先を追加しています。WAIC の日本語訳は、 W3C の公開する英語版より内容が古い可能性がありますのでご注意ください。");
 	$("a[href*=https\\:\\/\\/www\\.w3\\.org\\/WAI\\/WCAG21]").each(function(){		
 		if( $(this).attr('href').indexOf("Understanding")!=-1 ){
 			var url = $(this).attr('href').replace('\/\/www.w3.org\/WAI\/WCAG21\/Understanding','//waic.jp/docs/WCAG21/Understanding');

--- a/guidelines/waic_link.js
+++ b/guidelines/waic_link.js
@@ -1,0 +1,20 @@
+$(function(){
+	$("body>div:first-child>p:first-child").after("<p>この文書内にあるリンクのうち、「Understanding WCAG 2.1」「Techniques for WCAG 2.1」「How to Meet WCAG 2.1」へのリンクについては、WAIC の公開する日本語版にリンク先を追加しています。WAIC の日本語訳は、 W3C の公開する英語版より内容が古い可能性がありますのでご注意ください。</p>");
+	$("a[href*=https\\:\\/\\/www\\.w3\\.org\\/WAI\\/WCAG21]").each(function(){		
+		if( $(this).attr('href').indexOf("Understanding")!=-1 ){
+			var url = $(this).attr('href').replace('\/\/www.w3.org\/WAI\/WCAG21\/Understanding','//waic.jp/docs/WCAG21/Understanding');
+			var text = $(this).text();
+			$(this).after(" <a href='"+url+"' title='"+text+"の日本語訳'>[日本語訳]</a>");
+		}		
+		// if( $(this).attr('href').indexOf("WCAG20-TECHS")!=-1 ){
+		// 	var url = $(this).attr('href').replace('\/\/www.w3.org\/TR\/WCAG20-TECHS','//waic.jp/docs/WCAG-TECHS');
+		// 	var text = $(this).text();
+		// 	$(this).after(" <a href='"+url+"' title='"+text+"の日本語訳'>[日本語訳]</a>");
+		// }
+		// if( $(this).attr('href').indexOf("quickref")!=-1 ){
+		// 	var url = $(this).attr('href').replace('\/\/www.w3.org\/WAI\/WCAG20','//waic.jp/docs/WCAG20');
+		// 	var text = $(this).text();
+		// 	$(this).after(" <a href='"+url+"' title='"+text+"の日本語訳'>[日本語訳]</a>");
+		// }
+	});
+});


### PR DESCRIPTION
2.0で動作していたものをほぼそのまま持ってきました。
元のものがjQueryで動作していたので、そこもそのままです。