### PR TITLE
達成基準横のリンク以外も対象になるようにした

### DIFF
--- a/guidelines/waic_link.js
+++ b/guidelines/waic_link.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', function(){
 	const lastTrNote = document.querySelector("aside.trnote>p:last-child");
 	if(lastTrNote) lastTrNote.textContent = trNote;
 
-	const w3cDocumentAnchors = document.querySelectorAll(".doclinks a[href*=https\\:\\/\\/www\\.w3\\.org\\/WAI\\/WCAG21]");
+	const w3cDocumentAnchors = document.querySelectorAll("a[href*=https\\:\\/\\/www\\.w3\\.org\\/WAI\\/WCAG21]");
 	for(let i = 0; i < w3cDocumentAnchors.length; i++){
 		const anchor = w3cDocumentAnchors[i];
 		const href = anchor.getAttribute('href');


### PR DESCRIPTION
達成基準の横にある以外のリンク(「WCAG 2 ガイダンスのレイヤー」の本文内のものなど) にも日本語訳リンクが出るように修正しました。