### PR TITLE
達成基準 1.1.1 の翻訳漏れと思われる文章の追加

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1052,7 +1052,7 @@ details.respec-tests-details > li {
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html">Understanding Non-text Content</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#non-text-content">How to Meet Non-text Content</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>利用者に提示されるすべての<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn">非テキストコンテンツ</a>には、同等の目的を果たす<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn">テキストによる代替</a>が提供されている。ただし、以下に挙げる状況は除く。
+   <p>利用者に提示されるすべての<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn">非テキストコンテンツ</a>には、同等の目的を果たす<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn">テキストによる代替</a>が提供されている。ただし、次の場合は除く:
    </p>
    
    <dl>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1052,7 +1052,7 @@ details.respec-tests-details > li {
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html">Understanding Non-text Content</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#non-text-content">How to Meet Non-text Content</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>利用者に提示されるすべての<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn">非テキストコンテンツ</a>には、同等の目的を果たす<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn">テキストによる代替</a>が提供されている。
+   <p>利用者に提示されるすべての<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn">非テキストコンテンツ</a>には、同等の目的を果たす<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn">テキストによる代替</a>が提供されている。ただし、以下に挙げる状況は除く。
    </p>
    
    <dl>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

「達成基準 1.1.1 非テキストコンテンツ」内の、以下の原文にあたる翻訳が無いように思えたため、文章を追加しました。

> except for the situations listed below.
