### PR TITLE
github.ioへのリンクを置換

### DIFF
--- a/techniques/client-side-script/SCR28.html
+++ b/techniques/client-side-script/SCR28.html
@@ -148,7 +148,7 @@
                
                <li><a href="../html/H69">H69: Providing heading elements at the beginning of each section of content</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques//H50">H50: </a></li>
+               <li><a href="../html/H50">H50: </a></li>
                
                <li><a href="../html/H70">H70: Using frame elements to group blocks of repeated material</a></li>
                

--- a/techniques/client-side-script/SCR36.html
+++ b/techniques/client-side-script/SCR36.html
@@ -68,7 +68,7 @@
                <div>
                   
                   <p>This technique can be used in combination with a style switching technique to present
-                     a page that is a <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a> for non-conforming content. Refer to <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a> and <a href="https://waic.jp/docs/WCAG21/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a> for more information. 
+                     a page that is a <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a> for non-conforming content. Refer to <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a> and <a href="https://waic.jp/docs/WCAG21/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a> for more information. 
                   </p>
                   
                </div>

--- a/techniques/client-side-script/SCR38.html
+++ b/techniques/client-side-script/SCR38.html
@@ -261,7 +261,7 @@
                      Version".
                   </li>
                   
-                  <li>Check that the alternate version is a <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a> of the original page and that it conforms to WCAG 2.0 at the claimed conformance
+                  <li>Check that the alternate version is a <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a> of the original page and that it conforms to WCAG 2.0 at the claimed conformance
                      level.
                   </li>
                   

--- a/techniques/css/C33.html
+++ b/techniques/css/C33.html
@@ -77,7 +77,7 @@
                </ul><pre>    a {overflow-wrap: break-word;}</pre><div class="note">
                   <div role="heading" class="note-title marker" aria-level="4">注記</div>
                   <p>* (ワイルドカード) セレクタを用いた場合のこの宣言は、IE 及び Edge のみサポートしている。</p>
-               </div><pre>    * { word-wrap: break-word;}</pre><p><a href="https://w3c.github.io/wcag/working-examples/css-reflow-url/">実装例</a></p>
+               </div><pre>    * { word-wrap: break-word;}</pre><p><a href="https://www.w3.org/WAI/WCAG21/working-examples/css-reflow-url/">実装例</a></p>
             </section>
          </section>
          <section id="tests">

--- a/techniques/css/C38.html
+++ b/techniques/css/C38.html
@@ -29,7 +29,7 @@
       <h1><code>CSS width</code>、<code>max-width</code>、及び <code>flexbox</code> を用いたラベルと入力欄の配置</h1>
       <section id="important-information">
          <h2>達成方法に関する重要な情報</h2>
-         <p>これらの達成方法 (参考) の使用法及び、それらが WCAG 2.1 達成基準 (規定) とどのように関係するかに関する重要な情報については、<a href="https://w3c.github.io/wcag/understanding/understanding-techniques">WCAG 達成基準の達成方法を理解する</a>を参照のこと。適用 (対象) セクションは、その達成方法の範囲について説明しており、特定の技術に関する達成方法があるからといって、WCAG 2.1 を満たすコンテンツを作成する際に、常にその技術が使用可能であるわけではない。</p>
+         <p>これらの達成方法 (参考) の使用法及び、それらが WCAG 2.1 達成基準 (規定) とどのように関係するかに関する重要な情報については、<a href="https://waic.jp/docs/WCAG21/Understanding/understanding-techniques">WCAG 達成基準の達成方法を理解する</a>を参照のこと。適用 (対象) セクションは、その達成方法の範囲について説明しており、特定の技術に関する達成方法があるからといって、WCAG 2.1 を満たすコンテンツを作成する際に、常にその技術が使用可能であるわけではない。</p>
       </section>
       <main>
          <section id="applicability">

--- a/techniques/css/C39.html
+++ b/techniques/css/C39.html
@@ -29,7 +29,7 @@
       <h1>モーションの防止に CSS reduce-motion クエリを使用する</h1>
       <section id="important-information">
          <h2>達成方法に関する重要な情報</h2>
-         <p>これらの達成方法 (参考) の使用法及び、それらが WCAG 2.1 達成基準 (規定) とどのように関係するかに関する重要な情報については、<a href="https://w3c.github.io/wcag/understanding/understanding-techniques">WCAG 達成基準の達成方法を理解する</a>を参照のこと。適用 (対象) セクションは、その達成方法の範囲について説明しており、特定の技術に関する達成方法があるからといって、WCAG 2.1 を満たすコンテンツを作成する際に、常にその技術が使用可能であるわけではない。</p>
+         <p>これらの達成方法 (参考) の使用法及び、それらが WCAG 2.1 達成基準 (規定) とどのように関係するかに関する重要な情報については、<a href="https://waic.jp/docs/WCAG21/Understanding/understanding-techniques">WCAG 達成基準の達成方法を理解する</a>を参照のこと。適用 (対象) セクションは、その達成方法の範囲について説明しており、特定の技術に関する達成方法があるからといって、WCAG 2.1 を満たすコンテンツを作成する際に、常にその技術が使用可能であるわけではない。</p>
       </section>
       <main>
          <section id="applicability">

--- a/techniques/failures/F65.html
+++ b/techniques/failures/F65.html
@@ -129,17 +129,17 @@
                   
                   <li>
                      Check if <code class="att">aria-labelledby</code> attribute is present AND references one or more id elements in the page AND check
-                     if <code class="att">aria-labelledby</code> is <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">accessibility supported</a>.
+                     if <code class="att">aria-labelledby</code> is <a href="https://waic.jp/docs/WCAG21/#dfn-accessibility-supported">accessibility supported</a>.
                      								       
                   </li>
                   
                   <li>
-                     Check if the <code class="att">aria-label</code> attribute is present AND check if <code class="att">aria-label</code> is <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">accessibility supported</a>.
+                     Check if the <code class="att">aria-label</code> attribute is present AND check if <code class="att">aria-label</code> is <a href="https://waic.jp/docs/WCAG21/#dfn-accessibility-supported">accessibility supported</a>.
                      
                   </li>
                   
                   <li>
-                     Check if the <code class="att">title</code> attribute is present AND check if <code class="att">title</code> is <a href="https://w3c.github.io/wcag/guidelines/#" target="terms"> accessibility supported</a>.
+                     Check if the <code class="att">title</code> attribute is present AND check if <code class="att">title</code> is <a href="https://waic.jp/docs/WCAG21/#dfn-accessibility-supported"> accessibility supported</a>.
                      
                   </li>
                   

--- a/techniques/failures/F72.html
+++ b/techniques/failures/F72.html
@@ -49,7 +49,7 @@
          </section>
          <section id="description">
             <h2>Description</h2>
-            <p>The objective of this failure condition is to avoid the use of <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">ASCII art</a> when a text alternative is not provided. Although ASCII art is implemented as a character
+            <p>The objective of this failure condition is to avoid the use of <a href="https://waic.jp/docs/WCAG21/#dfn-ascii-art">ASCII art</a> when a text alternative is not provided. Although ASCII art is implemented as a character
                string, its meaning comes from the pattern of glyphs formed by a visual presentation
                of that string, not from the text itself. Therefore ASCII art is non-text content
                and requires a text alternative. Text alternatives, or links to them, should be placed

--- a/techniques/general/G136.html
+++ b/techniques/general/G136.html
@@ -81,7 +81,7 @@
                   <li>そのページには、そのページの適合している代替版へのリンクが含まれているかどうかを確認する。</li>
                   
                   <li>代替版が、オリジナルページの
-                     <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">適合している代替版</a>
+                     <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">適合している代替版</a>
                      であり、かつ要求された適合レベルで WCAG 2.0 に適合しているかどうかを判断する。
                   </li>
                   

--- a/techniques/general/G159.html
+++ b/techniques/general/G159.html
@@ -10,8 +10,8 @@
    <body>
       <nav>
          <ul id="navigation">
-            <li><a href="https://w3c.github.io/wcag/techniques/#techniques" title="Table of Contents">目次</a></li>
-            <li><a href="https://w3c.github.io/wcag/techniques/#introduction" title="Introduction to Techniques">イントロダクション</a></li>
+            <li><a href="../#techniques" title="Table of Contents">目次</a></li>
+            <li><a href="../#introduction" title="Introduction to Techniques">イントロダクション</a></li>
             <li><a href="G158">前の達成方法: G158</a></li>
             <li><a href="G160">次の達成方法: G160</a></li>
          </ul>

--- a/techniques/general/G160.html
+++ b/techniques/general/G160.html
@@ -11,8 +11,8 @@
    <body>
       <nav>
          <ul id="navigation">
-            <li><a href="https://w3c.github.io/wcag/techniques/#techniques" title="Table of Contents">目次</a></li>
-            <li><a href="https://w3c.github.io/wcag/techniques/#introduction" title="Introduction to Techniques">イントロダクション</a></li>
+            <li><a href="..#techniques" title="Table of Contents">目次</a></li>
+            <li><a href="../#introduction" title="Introduction to Techniques">イントロダクション</a></li>
             <li><a href="G159">前の達成方法: G159</a></li>
             <li><a href="G161">次の達成方法: G161</a></li>
          </ul>

--- a/techniques/general/G160.html
+++ b/techniques/general/G160.html
@@ -11,7 +11,7 @@
    <body>
       <nav>
          <ul id="navigation">
-            <li><a href="..#techniques" title="Table of Contents">目次</a></li>
+            <li><a href="..#/techniques" title="Table of Contents">目次</a></li>
             <li><a href="../#introduction" title="Introduction to Techniques">イントロダクション</a></li>
             <li><a href="G159">前の達成方法: G159</a></li>
             <li><a href="G161">次の達成方法: G161</a></li>

--- a/techniques/general/G160.html
+++ b/techniques/general/G160.html
@@ -11,7 +11,7 @@
    <body>
       <nav>
          <ul id="navigation">
-            <li><a href="..#/techniques" title="Table of Contents">目次</a></li>
+            <li><a href="../#techniques" title="Table of Contents">目次</a></li>
             <li><a href="../#introduction" title="Introduction to Techniques">イントロダクション</a></li>
             <li><a href="G159">前の達成方法: G159</a></li>
             <li><a href="G161">次の達成方法: G161</a></li>

--- a/techniques/general/G161.html
+++ b/techniques/general/G161.html
@@ -10,8 +10,8 @@
    <body>
       <nav>
          <ul id="navigation">
-            <li><a href="https://w3c.github.io/wcag/techniques/#techniques" title="Table of Contents">目次</a></li>
-            <li><a href="https://w3c.github.io/wcag/techniques/#introduction" title="Introduction to Techniques">イントロダクション</a></li>
+            <li><a href="../#techniques" title="Table of Contents">目次</a></li>
+            <li><a href="../#introduction" title="Introduction to Techniques">イントロダクション</a></li>
             <li><a href="G160">前の達成方法: G160</a></li>
             <li><a href="G162">次の達成方法: G162</a></li>
          </ul>

--- a/techniques/general/G17.html
+++ b/techniques/general/G17.html
@@ -312,12 +312,12 @@
                            <ul>
                               
                               <li>L1 is the
-                                 <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">relative luminance</a>
+                                 <a href="https://waic.jp/docs/WCAG21/#dfn-relative-luminance">relative luminance</a>
                                  of the lighter of the foreground or background colors, and
                               </li>
                               
                               <li>L2 is the
-                                 <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">relative luminance</a>
+                                 <a href="https://waic.jp/docs/WCAG21/#dfn-relative-luminance">relative luminance</a>
                                  of the darker of the foreground or background colors.
                               </li>
                               

--- a/techniques/general/G172.html
+++ b/techniques/general/G172.html
@@ -60,7 +60,7 @@
                   
                   <p>This technique can be used in combination with a style switching technique to present
                      a page that is a
-                     <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a>
+                     <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a>
                      for non-conforming content. Refer to
                      <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a>
                      and

--- a/techniques/general/G174.html
+++ b/techniques/general/G174.html
@@ -97,7 +97,7 @@
                   
                   <p>This technique can be used in combination with a style switching technique to present
                      a page that is a
-                     <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a>
+                     <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a>
                      for non-conforming content. Refer to
                      <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a>
                      and

--- a/techniques/general/G18.html
+++ b/techniques/general/G18.html
@@ -336,12 +336,12 @@
                            <ul>
                               
                               <li>L1 is the
-                                 <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">relative luminance</a>
+                                 <a href="https://waic.jp/docs/WCAG21/#dfn-relative-luminance">relative luminance</a>
                                  of the lighter of the foreground or background colors, and
                               </li>
                               
                               <li>L2 is the
-                                 <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">relative luminance</a>
+                                 <a href="https://waic.jp/docs/WCAG21/#dfn-relative-luminance">relative luminance</a>
                                  of the darker of the foreground or background colors.
                               </li>
                               

--- a/techniques/general/G183.html
+++ b/techniques/general/G183.html
@@ -62,7 +62,7 @@
                or have low vision can identify them.
             </p>
             <p>With this technique, a
-               <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">relative luminance</a>
+               <a href="https://waic.jp/docs/WCAG21/#dfn-relative-luminance">relative luminance</a>
                (lightness) difference of 3:1 or greater with the text around it can be used if additional
                visual confirmation is available when a user points or tabs to the link. Visual highlights
                may, for example, take the form of underline, a change in font style such as bold

--- a/techniques/general/G188.html
+++ b/techniques/general/G188.html
@@ -58,7 +58,7 @@
                   
                   <p>This technique can be used in combination with a style switching technique to present
                      a page that is a
-                     <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a>
+                     <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a>
                      for non-conforming content. Refer to
                      <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a>
                      and

--- a/techniques/general/G189.html
+++ b/techniques/general/G189.html
@@ -78,7 +78,7 @@
                   
                   <p>This technique can be used in combination with a style switching technique to present
                      a page that is a
-                     <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a>
+                     <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a>
                      for non-conforming content. Refer to
                      <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a>
                      and

--- a/techniques/general/G191.html
+++ b/techniques/general/G191.html
@@ -69,7 +69,7 @@
                   
                   <p>This technique can be used in combination with a style switching technique to present
                      a page that is a
-                     <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a>
+                     <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a>
                      for non-conforming content. Refer to
                      <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a>
                      and

--- a/techniques/general/G202.html
+++ b/techniques/general/G202.html
@@ -52,7 +52,7 @@
                who must use alternate keyboards or input devices that act as keyboard emulators like
                speech input software or on-screen keyboards.
             </p>
-            <p>A <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">keyboard interface</a> allows users to provide keystroke input to programs even if the computing device
+            <p>A <a href="https://waic.jp/docs/WCAG21/#dfn-keyboard-interface">keyboard interface</a> allows users to provide keystroke input to programs even if the computing device
                that they are using does not contain a hardware keyboard. For example, many mobile
                devices have keyboard interfaces within their operating system as well the option
                to connect external wireless keyboards. Applications can use the interface to obtain

--- a/techniques/general/G206.html
+++ b/techniques/general/G206.html
@@ -74,7 +74,7 @@
                <div>
                   
                   <p>This technique can be used in combination with a style switching technique to present
-                     a page that is a <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a> for non-conforming content. Refer to <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a> and <a href="https://waic.jp/docs/WCAG21/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a> for more information. 
+                     a page that is a <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a> for non-conforming content. Refer to <a href="../css/C29">C29: Using a style switcher to provide a conforming alternate version</a> and <a href="https://waic.jp/docs/WCAG21/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a> for more information. 
                   </p>
                   
                </div>

--- a/techniques/general/G55.html
+++ b/techniques/general/G55.html
@@ -85,7 +85,7 @@
                <h3>Example 4</h3>
                <p>The word
                   <em>
-                     <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">jargon</a>
+                     <a href="https://waic.jp/docs/WCAG21/#dfn-jargon">jargon</a>
                      </em>
                   is linked to its definition in the WCAG2 Glossary.
                </p>

--- a/techniques/html/H54.html
+++ b/techniques/html/H54.html
@@ -39,7 +39,7 @@
          <section id="applicability">
             <h2>適用 (対象)</h2>
             <p>HTML 及び XHTML</p>
-            <p>これは<span><a href="../general/G112">達成基準 3.1.3: 一般的ではない用語</a></span> (<a href="https://waic.github.io/wcag21/techniques/general/G112">G112: インラインの定義を使用する</a>の達成方法として十分) に関する達成方法である。
+            <p>これは<span><a href="../general/G112">達成基準 3.1.3: 一般的ではない用語</a></span> (<a href="../general/G112">G112: インラインの定義を使用する</a>の達成方法として十分) に関する達成方法である。
             </p>
          </section>
          <section id="description">

--- a/techniques/server-side-script/SVR2.html
+++ b/techniques/server-side-script/SVR2.html
@@ -178,7 +178,7 @@ ErrorDocument 403 http://example.com/documents/index.html
                      
                      <ol>
                         
-                        <li>a <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a> for the non-conforming content
+                        <li>a <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a> for the non-conforming content
                         </li>
                         
                         <li>a page that includes a link to both the conforming alternate version and the non-conforming

--- a/techniques/server-side-script/SVR3.html
+++ b/techniques/server-side-script/SVR3.html
@@ -181,7 +181,7 @@ header("Location: conforming.php");
                      
                      <ol>
                         
-                        <li>a <a href="https://w3c.github.io/wcag/guidelines/#" target="terms">conforming alternate version</a> for the non-conforming content
+                        <li>a <a href="https://waic.jp/docs/WCAG21/#dfn-conforming-alternate-version">conforming alternate version</a> for the non-conforming content
                         </li>
                         
                         <li>a page that includes a link to both the conforming alternate version and the non-conforming

--- a/techniques/silverlight/SL12.html
+++ b/techniques/silverlight/SL12.html
@@ -198,9 +198,9 @@ private void MuteMedia(object sender, RoutedEventArgs e)
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
+               <li><a href="SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL24">SL24: Using AutoPlay to Keep Silverlight Media from Playing Automatically</a></li>
+               <li><a href="SL24">SL24: Using AutoPlay to Keep Silverlight Media from Playing Automatically</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL14.html
+++ b/techniques/silverlight/SL14.html
@@ -347,9 +347,9 @@
                
                <li><a href="../general/G90">G90: Providing keyboard-triggered event handlers</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL9">SL9: Handling Key Events to Enable Keyboard Functionality in Silverlight</a></li>
+               <li><a href="SL9">SL9: Handling Key Events to Enable Keyboard Functionality in Silverlight</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL19">SL19: Providing User Instructions With AutomationProperties.HelpText in Silverlight</a></li>
+               <li><a href="SL19">SL19: Providing User Instructions With AutomationProperties.HelpText in Silverlight</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL15.html
+++ b/techniques/silverlight/SL15.html
@@ -275,7 +275,7 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL9">SL9: Handling Key Events to Enable Keyboard Functionality in Silverlight</a></li>
+               <li><a href="SL9">SL9: Handling Key Events to Enable Keyboard Functionality in Silverlight</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL16.html
+++ b/techniques/silverlight/SL16.html
@@ -179,9 +179,9 @@ private void OnMarkerReached(object sender, TimelineMarkerRoutedEventArgs e)
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
+               <li><a href="SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL28">SL28: Using Separate Text-Format Text Captions for MediaElement Content</a></li>
+               <li><a href="SL28">SL28: Using Separate Text-Format Text Captions for MediaElement Content</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL18.html
+++ b/techniques/silverlight/SL18.html
@@ -157,7 +157,7 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL30">SL30: Using Silverlight Control Compositing and AutomationProperties.Name</a></li>
+               <li><a href="SL30">SL30: Using Silverlight Control Compositing and AutomationProperties.Name</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL19.html
+++ b/techniques/silverlight/SL19.html
@@ -231,7 +231,7 @@ door, and one file cabinet against the same wall as the door.”/&gt;
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL8">SL8: Displaying HelpText in Silverlight User Interfaces</a></li>
+               <li><a href="SL8">SL8: Displaying HelpText in Silverlight User Interfaces</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL24.html
+++ b/techniques/silverlight/SL24.html
@@ -184,7 +184,7 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
+               <li><a href="SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL26.html
+++ b/techniques/silverlight/SL26.html
@@ -144,7 +144,7 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL35">SL35: Using the Validation and ValidationSummary APIs to Implement Client Side Forms Validation
+               <li><a href="SL35">SL35: Using the Validation and ValidationSummary APIs to Implement Client Side Forms Validation
                      in Silverlight</a></li>
                
             </ul>

--- a/techniques/silverlight/SL28.html
+++ b/techniques/silverlight/SL28.html
@@ -568,9 +568,9 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
+               <li><a href="SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL16">SL16: Providing Script-Embedded Text Captions for MediaElement Content</a></li>
+               <li><a href="SL16">SL16: Providing Script-Embedded Text Captions for MediaElement Content</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL29.html
+++ b/techniques/silverlight/SL29.html
@@ -242,7 +242,7 @@
                <li><a href="../general/G123">G123: Adding a link at the beginning of a block of repeated content to go to the end of
                      the block</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL25">SL25: Using Controls and Programmatic Focus to Bypass Blocks of Content in Silverlight</a></li>
+               <li><a href="SL25">SL25: Using Controls and Programmatic Focus to Bypass Blocks of Content in Silverlight</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL3.html
+++ b/techniques/silverlight/SL3.html
@@ -204,9 +204,9 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
+               <li><a href="SL17">SL17: Providing Static Alternative Content for Silverlight Media Playing in a MediaElement</a></li>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL24">SL24: Using AutoPlay to Keep Silverlight Media from Playing Automatically</a></li>
+               <li><a href="SL24">SL24: Using AutoPlay to Keep Silverlight Media from Playing Automatically</a></li>
                
             </ul>
          </section>

--- a/techniques/silverlight/SL30.html
+++ b/techniques/silverlight/SL30.html
@@ -198,7 +198,7 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL18">SL18: Providing Text Equivalent for Nontext Silverlight Controls With AutomationProperties.Name</a></li>
+               <li><a href="SL18">SL18: Providing Text Equivalent for Nontext Silverlight Controls With AutomationProperties.Name</a></li>
                
                <li><a href="../html/H2">H2: Combining adjacent image and text links for the same resource</a></li>
                

--- a/techniques/silverlight/SL4.html
+++ b/techniques/silverlight/SL4.html
@@ -120,7 +120,7 @@
                   					many aspects of how Silverlight works with language and culture information
                   					at run time are not determined by HTML Lang, and are instead determined
                   					by the operating system and which culture that operating system is
-                  					running. For more information, see <a href="https://w3c.github.io/wcag/techniques/silverlight/SL27">SL27: Using Language/Culture Properties as Exposed by Silverlight Applications and Assistive
+                  					running. For more information, see <a href="SL27">SL27: Using Language/Culture Properties as Exposed by Silverlight Applications and Assistive
                      Technologies</a>. 
                </p>
                	
@@ -252,7 +252,7 @@
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL27">SL27: Using Language/Culture Properties as Exposed by Silverlight Applications and Assistive
+               <li><a href="SL27">SL27: Using Language/Culture Properties as Exposed by Silverlight Applications and Assistive
                      Technologies</a></li>
                
                <li><a href="../html/H58">H58: Using language attributes to identify changes in the human language </a></li>

--- a/techniques/silverlight/SL8.html
+++ b/techniques/silverlight/SL8.html
@@ -298,7 +298,7 @@ door, and one file cabinet against the same wall as the door.”/&gt;
             <h2>Related Techniques</h2>
             <ul>
                
-               <li><a href="https://w3c.github.io/wcag/techniques/silverlight/SL19">SL19: Providing User Instructions With AutomationProperties.HelpText in Silverlight</a></li>
+               <li><a href="SL19">SL19: Providing User Instructions With AutomationProperties.HelpText in Silverlight</a></li>
                
             </ul>
          </section>


### PR DESCRIPTION
Fix #1044 

FLASHを除く達成方法集について、
github.ioに向いている（ほとんどの）リンクを、waic.jpに張り直しました。

@caztcha お手数ですがレビューをお願いします。