### PR TITLE
 解説書SC 2.2.2を2020年12月2日版に更新

### DIFF
--- a/understanding/pause-stop-hide.html
+++ b/understanding/pause-stop-hide.html
@@ -326,5 +326,7 @@
             </dd>
          </section>
       </main>
+            <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>

--- a/understanding/pause-stop-hide.html
+++ b/understanding/pause-stop-hide.html
@@ -29,14 +29,14 @@
       </nav>
       <h1>達成基準 2.2.2: 一時停止、停止、非表示を理解する</h1>
       <blockquote class="scquote">
-         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#pause-stop-hide" style="font-weight: bold;">2.2.2 一時停止、停止、非表示</a> (レベル A): 動きのある、<a href="#dfn-blinking" >点滅している</a>、スクロールする、又は自動更新する情報は、次のすべての事項を満たしている</p>
+         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#pause-stop-hide" style="font-weight: bold;">2.2.2 一時停止、停止、非表示</a> (レベル A): 動きのある、<a href="#dfn-blinking">点滅している</a>、スクロールする、又は自動更新する情報は、次のすべての事項を満たしている</p>
          <dl>
             
             
             <dt>動き、点滅、スクロール</dt>
             
             
-            <dd><p>動きのある、点滅している、又はスクロールしている情報が、(1) 自動的に開始し、(2) 5 秒よりも長く継続し、かつ、(3) その他のコンテンツと並行して提示される場合、利用者がそれらを<a href="#dfn-paused" >一時停止</a>、停止、又は非表示にすることのできるメカニズムがある。ただし、その動き、点滅、又はスクロールが<a href="#dfn-essential" >必要不可欠</a>な動作の一部である場合は除く。</p>
+            <dd><p>動きのある、点滅している、又はスクロールしている情報が、(1) 自動的に開始し、(2) 5 秒よりも長く継続し、かつ、(3) その他のコンテンツと並行して提示される場合、利用者がそれらを<a href="#dfn-paused">一時停止</a>、停止、又は非表示にすることのできるメカニズムがある。ただし、その動き、点滅、又はスクロールが<a href="#dfn-essential">必要不可欠</a>な動作の一部である場合は除く。</p>
                
                
             </dd>
@@ -68,8 +68,7 @@
                <li>コンテンツが自動的に更新される際に、コンテンツ制作者が利用者に更新頻度を制御する手段を提供するという選択肢がある。</li>
                
                
-               <li>5 秒間だけ自動更新をして，その後に停止するのはほとんど意味がないので、自動更新には 5 秒という例外はない。
-                  <div class="note"><div role="heading" class="note-title marker" aria-level="3">訳注</div><p>原文では &quot;three second&quot; と記述されているが、達成基準に記載されている内容から「5 秒」が正しい値であると判断し、秒数を修正している。</p></li>
+               <li>数秒間だけ自動更新をして，その後に停止するのはほとんど意味がないので、自動更新には 5 秒という例外はない。</li>
                
                
             </ul>
@@ -240,9 +239,6 @@
                   <li><a class="script" href="https://waic.jp/docs/WCAG21/Techniques/client-side-script/SCR33">SCR33: コンテンツをスクロールし、かつそれを一時停止するメカニズムを提供するためにスクリプトを使用する</a></li>
                   
                   
-                  <li><a class="flash" href="https://waic.jp/docs/WCAG21/Techniques/flash/FLASH35">FLASH35: Flash コンテンツをスクロールさせて、それを停止させるメカニズムを提供するために、スクリプトを使用する</a></li>
-                  
-                  
                   <li><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G11">G11: 5 秒未満で点滅するコンテンツを制作する</a></li>
                   
                   
@@ -253,9 +249,6 @@
                   
                   
                   <li><a class="script" href="https://waic.jp/docs/WCAG21/Techniques/client-side-script/SCR22">SCR22: 点滅を制御し、5 秒以内に停止させるために、スクリプトを使用する</a></li>
-                  
-                  
-                  <li><a class="flash" href="https://waic.jp/docs/WCAG21/Techniques/flash/FLASH36">FLASH36: 点滅を制御し、5 秒以内に点滅を停止させるために、スクリプトを使用する</a></li>
                   
                   
                   <li><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G186">G186: 動きのあるコンテンツ、点滅するコンテンツ、又は自動更新するコンテンツを停止させるコントロールを使用する</a></li>


### PR DESCRIPTION
follow  up #1004
related #1077

 解説書SC 2.2.2を2020年12月2日版に更新します

- 現状の原文（この班の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-ceaf7042677062e750470d87a996c9c4188e88839ba8cc0cab43a13934ce4d2a)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/pause-stop-hide.html

## 更新内容

- 原文の修正に伴うFLASHの削除
- 原文の修正に伴う本文の変更
- 訳注の付与
- その他編集的な作業