### PR TITLE
解説書SC 1.3.5の2020年12月2日版に更新

### DIFF
--- a/understanding/identify-input-purpose.html
+++ b/understanding/identify-input-purpose.html
@@ -48,10 +48,7 @@
             <p>HTML の autocomplete 属性は、一定数の特定の明確に定義された固定値のみを受け入れる。これにより、例えばコンテンツ制作者が特定のタイプの名前 (名前 (autocomplete="name")、 Given Name (autocomplete="given-name")、 Family Name (autocomplete="family-name")、に加えてユーザ名 (autocomplete="username")及びニックネーム (autocomplete="nickname")) を指定できるようにすることで、type 属性よりもよりきめ細かい定義又は目的の特定が可能になる。</p>
             <p>この所定の定義の分類法を採用して再利用することで、ユーザエージェントと支援技術は、異なるモダリティで利用者に入力の目的を提示できる。例えば、読むのが困難な利用者を助けるために、支援技術は入力フィールドの隣に見慣れたアイコンを表示してもよい。誕生日ケーキのアイコンを autocomplete="bday" の入力フィールドの前に表示してもよいし、電話のアイコンを autocomplete="tel" の入力フィールドの前に表示してもよい。</p>
             <p>この分類法を再利用することに加えて、 autocomplete 属性を使用してこの達成基準を満たす場合、ブラウザ及び他のユーザエージェントは、ブラウザに保存された過去の利用者の入力に基づいてこれらのフィールドを自動補完して正しいコンテンツを提案及び「自動入力」できる。一般的な入力目的のより詳細な定義、例えば「Birthday」 (autocomplete="bday") を定義することによって、ブラウザはこれらの各フィールド (利用者の誕生日) にパーソナライズされた値を保存できる。利用者は情報を入力する必要がなくなり、代わりに入力値を確認又は必要に応じてフィールドの値を変更できる。これは記憶の問題、失読症、その他の障害を持つ利用者にとって著しい恩恵である。autocomplete の値は言語に依存しないため、ユーザ入力フィールドを視覚的に特定するために利用されるテキスト (ラベル) に馴染みのない利用者は、用語の固定された分類法によって、その目的を一貫して特定できる。</p>
-            <p>If an input field accepts two different types of input purpose (as in combined user
-               name/user email fields) and the technology used does not allow multiple purpose values
-               to be defined, it is valid to provide either one or the other value or leave out the
-               designation of input purpose altogether.
+            <p>入力フィールドが二つの異なる種類の入力目的を受け入れ (利用者名/利用者の電子メールフィールドの組み合わせなど)、かつ使用されている技術で複数の目的の値を定義できない場合、どちらか一方の値を提供する、又は入力目的の指定を完全に省略するのが妥当である。
             </p>
             <p>他のメタデータフォーマットに対するユーザエージェントと支援技術のサポートが成熟すると、入力フィールドの目的を特定するために HTML の autocomplete 属性に加えて、又はその代わりに <a href="https://w3c.github.io/personalization-semantics/content/">Personalization Semantics Content Module</a> のようなメタデータスキームが使用される。それらのメタデータスキームはまた、コンテンツ制作者が提供した入力ラベルを特定して、入力のラベルづけの代わりに使用される定義済みの語彙又は記号に一致させる自動適応もサポートできる。</p>
          </section>
@@ -93,18 +90,17 @@
                <h3>十分な達成方法</h3>
                <ul>
                   
-                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/html/H98">H98: Using HTML 5.2 autocomplete attributes</a></li>
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/html/H98">H98: HTML 5.2 autocomplete 属性を使用する</a></li>
                   
                </ul>
             </section>
             <section id="failure">
-               <h3>Failures</h3>
-               <p>The following are common mistakes that are considered failures of this Success Criterion
-                  by the WCAG Working Group.
+               <h3>失敗例</h3>
+               <p>以下に挙げるものは、WCAG ワーキンググループが達成基準の失敗例とみなした、よくある間違いである。
                </p>
                <ul>
 
-                  <li><a href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F107">F107: Failure of Success Criterion 1.3.5 due to incorrect autocomplete attribute values</a></li>
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/failures/F107">F107: 達成基準 1.3.5 の失敗例 － 誤った autocomplete 属性値</a></li>
 
                </ul>
             </section>
@@ -132,5 +128,7 @@
             </dd>
          </section>
       </main>
+      <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>

--- a/understanding/identify-input-purpose.html
+++ b/understanding/identify-input-purpose.html
@@ -48,6 +48,11 @@
             <p>HTML の autocomplete 属性は、一定数の特定の明確に定義された固定値のみを受け入れる。これにより、例えばコンテンツ制作者が特定のタイプの名前 (名前 (autocomplete="name")、 Given Name (autocomplete="given-name")、 Family Name (autocomplete="family-name")、に加えてユーザ名 (autocomplete="username")及びニックネーム (autocomplete="nickname")) を指定できるようにすることで、type 属性よりもよりきめ細かい定義又は目的の特定が可能になる。</p>
             <p>この所定の定義の分類法を採用して再利用することで、ユーザエージェントと支援技術は、異なるモダリティで利用者に入力の目的を提示できる。例えば、読むのが困難な利用者を助けるために、支援技術は入力フィールドの隣に見慣れたアイコンを表示してもよい。誕生日ケーキのアイコンを autocomplete="bday" の入力フィールドの前に表示してもよいし、電話のアイコンを autocomplete="tel" の入力フィールドの前に表示してもよい。</p>
             <p>この分類法を再利用することに加えて、 autocomplete 属性を使用してこの達成基準を満たす場合、ブラウザ及び他のユーザエージェントは、ブラウザに保存された過去の利用者の入力に基づいてこれらのフィールドを自動補完して正しいコンテンツを提案及び「自動入力」できる。一般的な入力目的のより詳細な定義、例えば「Birthday」 (autocomplete="bday") を定義することによって、ブラウザはこれらの各フィールド (利用者の誕生日) にパーソナライズされた値を保存できる。利用者は情報を入力する必要がなくなり、代わりに入力値を確認又は必要に応じてフィールドの値を変更できる。これは記憶の問題、失読症、その他の障害を持つ利用者にとって著しい恩恵である。autocomplete の値は言語に依存しないため、ユーザ入力フィールドを視覚的に特定するために利用されるテキスト (ラベル) に馴染みのない利用者は、用語の固定された分類法によって、その目的を一貫して特定できる。</p>
+            <p>If an input field accepts two different types of input purpose (as in combined user
+               name/user email fields) and the technology used does not allow multiple purpose values
+               to be defined, it is valid to provide either one or the other value or leave out the
+               designation of input purpose altogether.
+            </p>
             <p>他のメタデータフォーマットに対するユーザエージェントと支援技術のサポートが成熟すると、入力フィールドの目的を特定するために HTML の autocomplete 属性に加えて、又はその代わりに <a href="https://w3c.github.io/personalization-semantics/content/">Personalization Semantics Content Module</a> のようなメタデータスキームが使用される。それらのメタデータスキームはまた、コンテンツ制作者が提供した入力ラベルを特定して、入力のラベルづけの代わりに使用される定義済みの語彙又は記号に一致させる自動適応もサポートできる。</p>
          </section>
          <section id="benefits">
@@ -90,6 +95,17 @@
                   
                   <li><a href="https://waic.jp/docs/WCAG21/Techniques/html/H98">H98: Using HTML 5.2 autocomplete attributes</a></li>
                   
+               </ul>
+            </section>
+            <section id="failure">
+               <h3>Failures</h3>
+               <p>The following are common mistakes that are considered failures of this Success Criterion
+                  by the WCAG Working Group.
+               </p>
+               <ul>
+
+                  <li><a href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F107">F107: Failure of Success Criterion 1.3.5 due to incorrect autocomplete attribute values</a></li>
+
                </ul>
             </section>
          </section>


### PR DESCRIPTION
related #1077

解説書SC 1.3.5を2020年12月2日版に更新します

- 現状の原文（この版の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-091494d1cf46b10c79795ed5af2e0693c1cd1e8de175647a6523e78cd189684d)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/identify-input-purpose.html

## 更新内容

- 原文の修正に伴う本文の追加
- 原文の修正に伴う本文の達成方法の追加
- 達成方法のリンクテキストの日本語化

## プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした
