### PR TITLE
解説書SC 2.2.6の2020年12月2日版への更新

### DIFF
--- a/understanding/timeouts.html
+++ b/understanding/timeouts.html
@@ -102,8 +102,6 @@
             <dt id="dfn-user-inactivity">利用者の無操作 (user inactivity)</dt>
             <dd><definition xmlns="">
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">new</p>
-                  
                   <p xmlns="http://www.w3.org/1999/xhtml">利用者がいかなる操作も行わない時間が続くこと。</p>
                   	        
                   <p xmlns="http://www.w3.org/1999/xhtml">そのトラッキングの方法は、ウェブサイトやアプリケーションによって決定される。</p>
@@ -112,5 +110,7 @@
             </dd>
          </section>
       </main>
+      <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>


### PR DESCRIPTION
related #1077

解説書SC 2.2.6を2020年12月2日版に更新します

- 現状の原文（この班の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/timeouts
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-8b702f2a5040b92622729b40e1453d847ca81b29cbe68376bcfd6f926a914dc4)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/timeouts.html

## 更新内容

- "new"の削除
- 訳注の付与

