### PR TITLE
解説書SC 2.3.3の2020年12月2日版への更新

### DIFF
--- a/understanding/animation-from-interactions.html
+++ b/understanding/animation-from-interactions.html
@@ -92,10 +92,20 @@
             <h2>関連リソース</h2>
             <p>リソースは、情報提供のみを目的としており、推奨を意味するものではない。</p>
             <ul>
+
+               <li><a href="//developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion">Mozilla documentation for 'prefers-reduced-motion'</a></li>
+
+               <li><a href="//webkit.org/blog-files/prefers-reduced-motion/prm.htm">Demonstration of 'prefers-reduced-motion' in Webkit</a></li>
                
                <li><a href="https://css-tricks.com/introduction-reduced-motion-media-query/">An Introduction to the Reduced Motion Media Query</a></li>
                
                <li><a href="http://alistapart.com/article/designing-safer-web-animation-for-motion-sensitivity">Designing Safer Web Animations for Motion Sensitivity</a></li>
+
+               <li><a href="https://support.apple.com/en-gb/HT202655"><strong>iOS:</strong> Reduce Motion on iPhone, iPad or iPod touch</a></li>
+
+               <li><a href="https://apple.stackexchange.com/questions/253756/speed-up-mission-control-animations-in-macos-sierra"><strong>Mac:</strong> Reduce Motion</a></li>
+
+               <li><a href="//www.laptopmag.com/articles/disable-minimize-maximize-animations-windows-10"><strong>Windows 10:</strong> Reduce motion</a></li>
                			
             </ul>
          </section>
@@ -128,9 +138,6 @@
             <dd><definition xmlns="">
                   					
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">New</p>
-                  					
-                  
                   <p xmlns="http://www.w3.org/1999/xhtml">動いているような錯覚やスムーズに移動しているように感じさせるために作る、状態と状態の間にステップを加えること。</p>
                   	        
                   <p xmlns="http://www.w3.org/1999/xhtml" class="example">例えば、別の場所に移動したりサイズが変わる要素はアニメーションしていると考えられる。推移せずに即座に表示される要素は、アニメーションを用いていない。モーションアニメーションには、色、ぼかし又は不透明度の変更は含まれない。</p>
@@ -140,5 +147,7 @@
             </dd>
          </section>
       </main>
+      <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>


### PR DESCRIPTION
解説書SC 2.3.3を2020年12月2日版に更新します

related #1077

- 現状の原文（この版の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-27c5a6c7c20287b5770c181457f823502aff0b11b2a8c897be4c09ae70f6ee71)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/animation-from-interactions.html

## 更新内容

- 関連リソースの追加
- "new"の削除
- 訳注の付与

## プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

