### PR TITLE
解説書SC 2.5.2の2020年12月2日版への更新

### DIFF
--- a/understanding/pointer-cancellation.html
+++ b/understanding/pointer-cancellation.html
@@ -22,25 +22,24 @@
             <li><a href="#intent">意図</a></li>
             <li><a href="#benefits">メリット</a></li>
             <li><a href="#examples">事例</a></li>
-            <li><a href="#resources">関連リソース</a></li>
             <li><a href="#techniques">達成方法</a></li>
             <li><a href="#key-terms">重要な用語</a></li>
          </ul>
       </nav>
       <h1>達成基準 2.5.2: ポインタのキャンセルを理解する</h1>
       <blockquote class="scquote">
-         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#pointer-cancellation" style="font-weight: bold;">2.5.2 ポインタのキャンセル</a> (レベル A): <a href="#dfn-single-pointer" >シングルポインタ</a>を使って操作できる<a href="#dfn-functionality" >機能</a>は、以下の要件の少なくとも 1 つを満たす。</p>
+         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#pointer-cancellation" style="font-weight: bold;">2.5.2 ポインタのキャンセル</a> (レベル A): <a href="#dfn-single-pointer">シングルポインタ</a>を使って操作できる<a href="#dfn-functionality">機能</a>は、以下の要件の少なくとも 1 つを満たす。</p>
          <dl>
             
             
             <dt>ダウンイベントがない</dt>
             
-            <dd>機能を実行する目的でポインタの<a href="#dfn-down-event" >ダウンイベント</a>を使用していない。</dd>
+            <dd>機能を実行する目的でポインタの<a href="#dfn-down-event">ダウンイベント</a>を使用していない。</dd>
             						
             
             <dt>中止又は元に戻すことができる</dt>
             
-            <dd>機能の完了には<a href="#dfn-up-event" >アップイベント</a>を使用し、かつ機能の完了前に中止する、又は機能の完了後に元に戻すための<a href="#dfn-mechanism" >メカニズム</a>が利用できる。</dd>
+            <dd>機能の完了には<a href="#dfn-up-event">アップイベント</a>を使用し、かつ機能の完了前に中止する、又は機能の完了後に元に戻すための<a href="#dfn-mechanism">メカニズム</a>が利用できる。</dd>
             						
             
             <dt>アップイベントで反転</dt>
@@ -149,15 +148,6 @@
                			
             </ul>
          </section>
-         <section id="resources">
-            <h2>関連リソース</h2>
-            <p>リソースは、情報提供のみを目的としており、推奨を意味するものではない。</p>
-            <ul>
-               				
-               <li>リソース</li>
-               			
-            </ul>
-         </section>
          <section id="techniques">
             <h2>達成方法</h2>
             <p>この節にある番号付きの各項目は、WCAG ワーキンググループがこの達成基準を満たすのに十分であると判断する達成方法、又は複数の達成方法の組み合わせを表している。しかしながら、必ずしもこれらの達成方法を用いる必要はない。その他の達成方法についての詳細は、<a href="understanding-techniques.html">WCAG 達成基準の達成方法を理解する</a>の「その他の達成方法」を参照のこと。</p>
@@ -165,9 +155,11 @@
                <h3>十分な達成方法</h3>
                <ul>
                   						
-                  <li>HTML、iOS、及び Android において、アップイベントを用いてコントロールを動作させる</li>
+                  <li><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G210">G210: ドラッグ＆ドロップ操作をキャンセルできるようにする</a></li>
                   						
-                  <li><a href="https://www.w3.org/WAI/GL/mobile-a11y-tf/wiki/M029">M029(wiki) Touch events are only triggered when touch is removed from a control</a></li>		
+                  <li><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G212">G212: ネイティブコントロールを使用して、アップイベントで機能がトリガーされるようにする</a></li>
+
+                  <li>@@ タッチイベントは、タッチがコントロールから削除されたときにのみトリガーされる。</li>		
                   
                </ul>
             </section>
@@ -180,7 +172,7 @@
                <p>以下に挙げるものは、WCAG ワーキンググループが達成基準の失敗例とみなした、よくある間違いである。</p>
                <ul>
                   
-                  <li><a href="http://w3c.github.io/Mobile-A11y-TF-Note/Techniques/FM001">FM001: 達成基準 2.5.3 の失敗例 － 最終的なタッチ位置ではなく最初のタッチ位置でボタンを動作させる</a></li>         
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/failures/F101">F101: 達成基準 2.5.2 の失敗例 － ダウンイベントでコントロールを動作させる</a></li>       
                   
                </ul>
             </section>
@@ -189,8 +181,6 @@
             <h2>重要な用語</h2>
             <dt id="dfn-down-event">ダウンイベント (down-event)</dt>
             <dd><definition xmlns="">
-                  
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">new</p>
                   
                   <p xmlns="http://www.w3.org/1999/xhtml">ポインタのトリガが押された時に生じるプラットフォームイベント。</p>
                   	        
@@ -239,9 +229,6 @@
             <dd><definition xmlns="">
                   					
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">new</p>
-                  	
-                  
                   <p xmlns="http://www.w3.org/1999/xhtml">シングルタップやクリック、ダブルタップやクリック、長押し及びパスを基点としたジェスチャを含む、画面と 1 つの接点で動作するポインタ入力</p>
                   				
                   
@@ -249,8 +236,6 @@
             </dd>
             <dt id="dfn-up-event">アップイベント (up-event)</dt>
             <dd><definition xmlns="">
-                  
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">new</p>
                   
                   <p xmlns="http://www.w3.org/1999/xhtml">ポインタのトリガ刺激が解除されたときに生じるプラットフォームイベント。</p>
                   	        
@@ -260,5 +245,7 @@
             </dd>
          </section>
       </main>
+      <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>


### PR DESCRIPTION
解説書SC 2.5.2を2020年12月2日版に更新します

related #1077

- 現状の原文（この版の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-9c637824364bf6cf7a06145aed63fbea1d64808514fadf42d4dc0367c9798d39)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/pointer-cancellation.html

## 更新内容

- 関連リソースのセクションの削除
- 達成方法のリンクの更新
- "new"の削除
- 訳注の付与
- その他編集的な作業



