### PR TITLE
解説書SC 2.5.5の2020年12月2日版への更新

### DIFF
--- a/understanding/target-size.html
+++ b/understanding/target-size.html
@@ -128,17 +128,17 @@
                
                <li><a href="https://developer.apple.com/ios/human-interface-guidelines/visual-design/layout/">Apple touch target size recommendations</a></li>
                
-               <li><a href="https://developers.google.com/speed/docs/insights/SizeTapTargetsAppropriately">Android touch target size recommendations</a></li>
+               <li><a href="https://docs.microsoft.com/en-us/windows/uwp/design/input/guidelines-for-targeting">Windows UWP Guidelines for touch targets</a></li>
                
-               <li><a href="http://download.microsoft.com/download/2/4/A/24A81A29-77CF-4AA5-967E-64E42554F21B/UWP%20app%20design%20guidelines%20v1509.pdf">Microsoft&#39;s Windows Phone UI Design and Interaction Guide (PDF)</a></li>
+               <li><a href="https://material.io/design/layout/spacing-methods.html#touch-targets">Google Material Design Touch targets</a></li>
+               
+               <li><a href="https://web.dev/accessible-tap-targets/">web.dev Accessible tap targets</a></li>
                
                <li><a href="http://touchlab.mit.edu/publications/2003_009.pdf">Human Fingertips to Investigate the Mechanics of Tactile Sense (PDF)</a></li>
                
-               <li><a href="http://hcil.cs.umd.edu/trs/2006-11/2006-11.htm">One-Handed Thumb Use on Small Touchscreen Devices</a></li>
+               <li><a href="http://www.cs.umd.edu/hcil/trs/2006-11/2006-11.htm">One-Handed Thumb Use on Small Touchscreen Devices</a></li>
                
-               <li><a href="http://blogs.msdn.com/b/ie/archive/2012/04/20/guidelines-for-building-touch-friendly-sites.aspx">Microsoft Guidelines for Building Touch Friendly Sites</a></li>
-               
-               <li><a href="https://developer.microsoft.com/en-us/windows/design/microsoft-design-language">Microsoft Design Language (PDF)</a></li>
+               <li><a href="https://docs.microsoft.com/en-us/archive/blogs/ie/guidelines-for-building-touch-friendly-sites">Microsoft Guidelines for Building Touch Friendly Sites</a></li>
                
             </ul>
          </section>
@@ -182,9 +182,6 @@
             <dd><definition xmlns="">
                   					
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">New</p>
-                  					
-                  
                   <p xmlns="http://www.w3.org/1999/xhtml">約 0.0213 度の視野角。</p>
                   					
                   
@@ -206,9 +203,6 @@
             <dd><definition xmlns="">
                   					
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">New</p>
-                  					
-                  
                   <p xmlns="http://www.w3.org/1999/xhtml">マウス、ペン、タッチ接触のように、画面上の特定の (1 つ又は複数の) 地点を指すことができる入力デバイス。</p>
                   					
                   
@@ -219,9 +213,6 @@
             </dd>
             <dt id="dfn-target">ターゲット (target)</dt>
             <dd><definition xmlns="">
-                  					
-                  
-                  <p xmlns="http://www.w3.org/1999/xhtml" class="change">New</p>
                   					
                   
                   <p xmlns="http://www.w3.org/1999/xhtml">ユーザインタフェース コンポーネントのインタラクティブな領域のような、ポインタアクションを受け入れるディスプレイの領域</p> 

--- a/understanding/target-size.html
+++ b/understanding/target-size.html
@@ -119,7 +119,7 @@
                <li><strong>例 7: ヘルプアイコン</strong><br /> 文中又は文末にあるヘルプアイコンは、44 × 44 CSS ピクセルの要件を満たす必要はない。文末のアイコンは文の一部とみなされる。</li>
                
             </ul>
-            <section class="example" id=""></section>
+
          </section>
          <section id="resources">
             <h2>関連リソース</h2>
@@ -226,5 +226,7 @@
             </dd>
          </section>
       </main>
+      <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>


### PR DESCRIPTION
解説書SC 2.5.5を2020年12月2日版に更新します

related #1077

- 現状の原文（この版の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/target-size
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-4b7067ee9d30c65660076f1ebfe2e2d3ac982871dbd9fc8e546e37229c9eb232)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/target-size.html

## 更新内容

- 空の`section`の削除
- 達成方法のリンクの更新
- "new"の削除
- 訳注の付与


## プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

