### PR TITLE
解説書SC 2.5.6の2020年12月2日版への更新

### DIFF
--- a/understanding/concurrent-input-mechanisms.html
+++ b/understanding/concurrent-input-mechanisms.html
@@ -90,9 +90,9 @@
                <h3>十分な達成方法</h3>
                <ul>
                   
-                  <li>JavaScript において、高レベルの、特定の入力方法に依存しないイベントハンドラ (<code>focus</code>、<code>blur</code>、<code>click</code>) のみを使用する  (オペレーティングシステム／ユーザエージェントは、すべての入力メカニズムに対してこれらのイベントを発火させる)。</li>
+                  <li>@@ JavaScript において、高レベルの、特定の入力方法に依存しないイベントハンドラ (<code>focus</code>、<code>blur</code>、<code>click</code>) のみを使用する (オペレーティングシステム／ユーザエージェントは、すべての入力メカニズムに対してこれらのイベントを発火させる)。</li>
                   
-                  <li>Javascript において、キーボードもしくはキーボードのような入力、及びポインタ入力のためのイベントハンドラを、同時に登録する (<a href="https://w3c.github.io/pointerevents/#examples">Pointer Events Level 2 の EXAMPLE 1</a> を参照のこと)。</li>
+                  <li>@@ Javascript において、キーボードもしくはキーボードのような入力、及びポインタ入力のためのイベントハンドラを、同時に登録する (<a href="https://w3c.github.io/pointerevents/#examples">Pointer Events Level 2 の EXAMPLE 1</a> を参照のこと)。</li>
                   
                </ul>
             </section>
@@ -101,9 +101,7 @@
                <p>以下に挙げるものは、WCAG ワーキンググループが達成基準の失敗例とみなした、よくある間違いである。</p>
                <ul>
                   
-                  <li>検出された入力メカニズムの存在に基づいてイベントハンドラを制限する。</li>
-                  
-                  <li>CSS Media Queries Level 4 の Interaction Media Features を使用して、ユーザエージェントが「主たる」入力メカニズムであると見なすものを決定し、他の入力メカニズムが存在しない／追加できない／使用できないと仮定する。</li>
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/failures/F98">F98: 達成基準 2.5.6 の失敗例 － タッチスクリーンデバイスにおいてインタラクションがタッチのみに限定されている</a></li>
                   
                </ul>
             </section>
@@ -121,5 +119,7 @@
             </dd>
          </section>
       </main>
+      <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>


### PR DESCRIPTION
解説書SC 2.5.6を2020年12月2日版に更新します

related #1077

- 現状の原文（この版の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-c091f3fa9d7c0044dd69b4e2b0053a93f2dc369e5ad1997fdbda9ee60f00c8ab)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/concurrent-input-mechanisms.html

## 更新内容

- 達成方法のリンクの更新
