### PR TITLE
解説書SC 2.5.3の2020年12月2日版への更新 

### DIFF
--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -73,27 +73,18 @@
 
                   <p>同様に、コンテンツ制作者が大なり記号 (">") を使用して右向きの矢印の外観を模倣した場合、テキストは自然言語で何も伝えない。これは記号であり、このシナリオでは、「再生」ボタン又は「次へ」矢印に使用されるアイコンを模倣することを意図した可能性がある。</p>
 
-                  <h4>Punctuation and capitalization</h4>
+                  <h4>句読点及び大文字の使用</h4>
 
                </section>
 
                <section id="">
 
-                  <p>The use of punctuation and capitalization in labels <em>may</em> also be considered optional for the same reason. For example, the colon conventionally
-                     added at the end of input labels does not express something in human language, and
-                     capitals on the first letter of each word in a label do not normally alter the words'
-                     meaning. This is particularly relevant in the context of this SC, since it is primarily
-                     aimed at users of speech recognition; capitals and most punctuation are frequently
-                     ignored when a user speaks a label as a means of interacting with a control.
+                  <p>ラベルにおける句読点の使用及び大文字の使用も、同じ理由でオプションと見なされてもよい</em>。例えば、入力ラベルの最後に従来追加されていたコロンは自然言語では何も表現せず、そしてラベルの各単語の最初の文字を大文字にしても、通常は単語の意味は変わらない。これは、主に音声認識の利用者を対象としているため、この達成基準のコンテキストに特に関係がある。利用者がコントロールとやりとりする手段としてラベルを話すとき、大文字及びほとんどの句読点は頻繁に無視される。
                   </p>
 
-                  <p>While it is certainly not an error to include the colon and capitalization in the
-                     accessible name, a computed name of "First name" should not be considered a failure
-                     of "First Name:".<br />
+                  <p>アクセシブルな名前 (accessible name) にコロン及び大文字を含めることは間違いなくエラーではないが、"First name" の計算された名前は、"First Name:" の失敗と見なされるべきではない。<br />
                      <label for="firstname">First Name: </label><input id="firstname" type="text" name="firstname" /><br />
-                     Likewise, "Next…" visibly shown on a button could have "Next" as the accessible name.
-                     When in doubt, where a meaningful visible label exists, match the string exactly for
-                     the accessible name.<br />
+                     同様に、ボタンに表示される "Next…" は、アクセシブルな名前 (accessible name) として "Next" を持つことができます。意味のある可視のラベルが存在するのか疑わしい場合、アクセシブルな名前 (accessible name) の文字列と正確に一致させる。<br />
                      <input type="submit" value="Next..." /></p>
 
                </section>
@@ -103,21 +94,7 @@
 
                   <h4>Mathematical expressions and formulae</h4>
 
-                  <p>Mathematical expressions are an exception to the previous subsection about symbolic
-                     characters. Math symbols can be used as labels; for example "11×3=33" and "A&gt;B" convey
-                     meaning. The label should not be overwritten in the accessible name, and substitutions
-                     of words where a formula is used should be avoided since there are multiple ways to
-                     express the same equation. For example, making the name "eleven multiplied by three
-                     is equivalent to thirty-three" might mean a user who said "eleven times three equals
-                     thirty-three" may not match. It is best to leave the formulas as used in the label
-                     and count on the user's familiarity with their speech software to achieve a match.
-                     Further, converting a mathematical formula label into an accessible name that is a
-                     spelled-out equivalent may create issues for translation. The name should match the
-                     label's formula text. Note that a consideration for authors is to use the proper symbol
-                     in the formula. For instance 11x3 (with a lower or upper case letter X), 11*3 (with
-                     the asterisk symbol), and 11×3 (with the <code>&amp;</code>times<code>;</code> symbol) are all easy for sighted users to interpret as meaning the same formula,
-                     but may not all be matched to "11 times 3" by the speech recognition software. The
-                     proper operator symbol (in this case the times symbol) should be used.<br />
+                  <p>数式は、記号文字に関する前のサブセクションの例外である。数学記号はラベルとして使用することができる。例えば、"11×3=33" 及び "A&gt;B" は意味を伝える。ラベルはアクセシブルな名前 (accessible name) で上書きすべきでなく、同じ方程式を表現する方法は複数あるため、式が使用されている単語の置換は避けるべきである。例えば、"11×3 は 33 に相当する" という名前 (name) を付けると、"11×3 は 33 に等しい" と言う利用者は一致しない可能性がある。ラベルで使用されている式をそのままにして、一致を達成するために利用者が音声ソフトウェアに精通していることを期待するのが最善である。さらに、数式のラベルを、スペルアウトされた同等のアクセシブルな名前 (accessible name) に変換すると、翻訳の問題が発生する可能性がある。名前 (name) は、ラベルの数式テキストと一致すべきである。コンテンツ制作者にとっての考慮事項は、数式で適切な記号を使用することであることに注意する。例えば、11x3 (小文字又は大文字のX)、11*3 (アスタリスク記号をもつ)、及び 11x3（<code>&amp;</code>times<code>;</code> 記号をもつ）は全て、目の見える利用者にとって同じ式を意味するものとして解釈するのは簡単であるが、音声認識ソフトウェアによって全てが "11×3" に一致するとは限らない。適切な演算子記号 (この場合は乗算記号) を使用すべきである。<br />
 
                      <input type="radio" name="equation" id="answer1" value="A&gt;B" /><label for="answer1">A&gt;B</label>
                      <input type="radio" name="equation" id="answer2" value="A=B" /><label for="answer2">A=B</label>

--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -92,7 +92,7 @@
                <section id="mathematical-expressions-and-formulae">
 
 
-                  <h4>Mathematical expressions and formulae</h4>
+                  <h4>数式及び式</h4>
 
                   <p>数式は、記号文字に関する前のサブセクションの例外である。数学記号はラベルとして使用することができる。例えば、"11×3=33" 及び "A&gt;B" は意味を伝える。ラベルはアクセシブルな名前 (accessible name) で上書きすべきでなく、同じ方程式を表現する方法は複数あるため、式が使用されている単語の置換は避けるべきである。例えば、"11×3 は 33 に相当する" という名前 (name) を付けると、"11×3 は 33 に等しい" と言う利用者は一致しない可能性がある。ラベルで使用されている式をそのままにして、一致を達成するために利用者が音声ソフトウェアに精通していることを期待するのが最善である。さらに、数式のラベルを、スペルアウトされた同等のアクセシブルな名前 (accessible name) に変換すると、翻訳の問題が発生する可能性がある。名前 (name) は、ラベルの数式テキストと一致すべきである。コンテンツ制作者にとっての考慮事項は、数式で適切な記号を使用することであることに注意する。例えば、11x3 (小文字又は大文字のX)、11*3 (アスタリスク記号をもつ)、及び 11x3（<code>&amp;</code>times<code>;</code> 記号をもつ）は全て、目の見える利用者にとって同じ式を意味するものとして解釈するのは簡単であるが、音声認識ソフトウェアによって全てが "11×3" に一致するとは限らない。適切な演算子記号 (この場合は乗算記号) を使用すべきである。<br />
 
@@ -106,48 +106,26 @@
             <section id="accessible-name-and-description-computation-specification">
 
 
-               <h3>Accessible Name and Description Computation specification</h3>
+               <h3>Accessible Name and Description Computation 仕様</h3>
 
-               <p>It is important to understand how the accessible name is derived. The <a href="https://www.w3.org/TR/accname-1.1/">Accessible Name and Description Computation 1.1</a> and the <a href="https://w3c.github.io/html-aam/#accessible-name-and-description-computation">HTML Accessibility API Mappings 1.0</a> describe how the accessible name is computed, including which attributes are considered
-                  in its calculation, and in what order of preference. If a component has multiple possible
-                  attribute values that could be used for its accessible name, only the most preferred
-                  of those values will be computed. None of the other, less preferred values will be
-                  part of the name. For the most part, existing established programmatic relationships
-                  between labels and controls are reinforced by the specification.
-               </p>
+               <p>アクセシブルな名前 (accessible name) がどのように派生するかを理解することが重要である。<a href="https://www.w3.org/TR/accname-1.1/">Accessible Name and Description Computation 1.1</a> 及び <a href="https://w3c.github.io/html-aam/#accessible-name-and-description-computation">HTML Accessibility API Mappings 1.0</a> は、アクセシブルな名前 (accessible name) の計算方法を説明する。これには、計算で考慮される属性や優先順位などが含まれる。コンポーネントに、アクセシブルな名前 (accessible name) に使用できる複数の属性値がある場合、それらの値の中で最も優先されるものだけが計算される。他のあまり好ましくない値は名前 (name) の一部にはならない。ほとんどの場合、ラベルとコントロールの間に確立された既存のプログラム上の関係が仕様によって強化されている。</p>
 
-               <p>Other text displayed on the screen that is correctly coded to meet 1.3.1: Info and
-                  Relationships is <strong>not</strong> normally factored into the calculation for the accessible name of a UI component
-                  without author intervention (via ARIA labeling techniques). The most common of these
-                  are:
-               </p>
+               <p>1.3.1: 情報及び関係性を満たすように正しくコーディングされた画面に表示されるその他のテキストは、通常、作成者の介入なしに（ARIAラベル付け手法を通して）UI コンポーネントのアクセシブルな名前 (accessible name) の計算に考慮<strong>されない</strong>。これらの中で最も一般的なものは次のとおり:</p>
 
                <ul>
 
-                  <li>headings and instructions</li>
+                  <li>見出し及び指示</li>
 
-                  <li>group labels for sets of components (i.e., used with <code>legend</code>/<code>fieldset</code> or with role of <code>group</code> or <code>radiogroup</code>)
-                  </li> 
+                  <li>コンポーネントのセットのグループラベル (すなわち、<code>legend</code>/<code>fieldset</code> で使用される、又は <code>group</code> もしくは <code>radiogroup</code> の役割 (role) で使用される)</li> 
 
                </ul>
 
-               <p>Such textual information may constitute part of the component's <em>description</em>. So from both a programmatic viewpoint, and from the conservative tactic of only
-                  considering a label to be "adjacent text," neither headings, instructions, nor group
-                  'labels' should normally be considered <strong>labels</strong> for the purpose of this Success Criterion.
+               <p>そのようなテキスト情報は、コンポーネントの<em>説明</em>の一部を構成する場合がある。したがって、プログラムの観点からと、ラベルを「隣接するテキスト」と見なすという保守的な戦術の両方から、通常、見出し、指示、グループの「ラベル」のいずれも、この達成基準の目的の<strong>ラベル</strong>と見なされるべきではない。
                </p>
 
-               <p>It is important to note that the specification allows authors to override the name
-                  calculated through native semantics. Both <code>aria-label</code> and <code>aria-labelledby</code> take precedence in the name calculation, overriding the visible text as the accessible
-                  name even when the visible text label is programmatically associated with the control.
-                  For this reason, when a visible label already exists, <code>aria-label</code> should be avoided or used carefully, and <code>aria-labelledby</code> should be used as a supplement with care.
-               </p>
+               <p>この仕様では、作成者がネイティブセマンティクスによって計算された名前 (name) を上書きできることに注意することが重要である。名前 (name) の計算では、<code>aria-label</code> と <code>aria-labelledby</code> の両方が優先され、表示されるテキストラベルがプログラムでコントロールに関連付けられている場合でも、アクセシブルな名前 (accessible name) として表示されるテキストが上書きされる。このため、可視ラベルがすでに存在する場合、<code>aria-label</code> を避ける又は慎重に使用すべきであり、<code>aria-labelledby</code> は注意して補足として使用すべきである。</p>
 
-               <p>Finally, <code>aria-describedby</code> is not included in the Accessible Name computation (instead it is part of the Accessible
-                  Description computation). By convention, text associated with a control through <code>aria-describedby</code> is announced immediately after the accessible name by screen readers. Therefore,
-                  the context of headings, instructions, and group labels can be provided through the
-                  accessible description to assist users of screen readers without affecting the experience
-                  of those who navigate using speech recognition software.
-               </p>
+               <p>最後に、<code>aria-describedby</code> はアクセシブルな名前 (accessible name) 計算には含まれない（代わりに、アクセシブルな説明の計算の一部となる）。慣例により、<code>aria-describedby</code> によってコントロールに関連付けられたテキストは、スクリーンリーダーによってアクセシブルな名前 (accessible name) の直後に通知される。したがって、見出し、指示、及びグループラベルのコンテキストは、音声認識ソフトウェアを用いてナビゲートする利用者のエクスペリエンスに影響を与えることなく、スクリーンリーダーの利用者を支援するために、アクセシブルな説明を通して提供される。</p>
 
             </section>
          </section>
@@ -201,7 +179,7 @@
 
                <ul>
 
-                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/general/G162">G162: Positioning labels to maximize predictability of relationships</a></li>
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/general/G162">G162: 関係性を最大限に予測できるようにするためにラベルを配置する</a></li>
                   <li>@@ アイコンに付随するテキストがない場合、アクセシブルな名前 (accessible name) としてそのホバーテキストを用いることを検討する。</li>
                </ul>
             </section>

--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -35,10 +35,7 @@
       <main>
          <section id="intent">
             <h2>意図</h2>
-            <p>The intent of this Success Criterion is to ensure that the words which visually label
-               a component are also the words associated with the component programmatically. This
-               helps ensure that people with disabilities can rely on visible labels as a means to
-               interact with the components.
+            <p>この達成基準の意図は、コンポーネントに視覚的にラベルを付ける単語が、コンポーネントにプログラムにより関連付けられる単語でもあることを確実にすることである。これは、障害のある人がコンポーネントとやりとりする手段として可視ラベルを確実に信頼できるようにするのを助ける。
             </p>
             <p>Most controls are accompanied by a visible text <strong>label</strong>. Those same controls have a programmatic <strong>name</strong>, also known as the <a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name</a>. Users typically have a much better experience if the words and characters in the
                visible label of a control match or are contained within the accessible name. When

--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -35,65 +35,24 @@
       <main>
          <section id="intent">
             <h2>意図</h2>
-            <p>この達成基準の意図は、コンポーネントに視覚的にラベルを付ける単語が、コンポーネントにプログラムにより関連付けられる単語でもあることを確実にすることである。これは、障害のある人がコンポーネントとやりとりする手段として可視ラベルを確実に信頼できるようにするのを助ける。
-            </p>
-            <p>ほとんどのコントロールは、可視のテキスト<strong>ラベル</strong>を伴う。この同じコントロールには、アクセシブルな名前 (<a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name</a>) とも呼ばれるプログラムの<strong>名前</strong>がある。コントロールの可視ラベルの単語及び文字が一致する、又はアクセシブルな名前 (accessible name) に含まれている場合、利用者は一般に、はるかに優れた体験をする。これらが一致するとき、音声入力の利用者 (すなわち、音声認識アプリケーションの利用者) は、画面に表示されるメニュー、リンク、ボタンなどのコンポーネントの可視のテキストラベルを話すことによってナビゲートできる。テキスト読み上げ (スクリーンリーダーなど) を使用する視力のある利用者も、聞こえるテキストが画面に表示されるテキストと一致する場合に、よりよい体験をする。
-            </p>
-            <p>コンポーネントに可視のテキストラベルが存在しない場合、この達成基準はそのコンポーネントには適用されないことに注意する。
-            </p>
-            <p>テキストラベルが存在し、確立されたオーサリングプラクティスを通じてユーザーインタフェースコンポーネントに適切にリンクされている場合、ラベルと名前は通常一致する。それらが一致しない場合、ナビゲーション又は選択の手段として可視のテキストラベルを使用しようとする音声入力の利用者 (「パスワードに移動」など) は失敗する。利用者が話す可視ラベルが、音声入力コマンドとして有効であるアクセシブルな名前 (accessible name) と一致しない (又はその一部ではない) ため、音声ベースのナビゲーションは失敗する。さらに、アクセシブルな名前 (accessible name) が可視ラベルと異なる場合、音声入力の利用者によって誤って作動される可能性のある非表示のコマンドとして機能することがある。
-            </p>
-            <p>Mismatches between visible labels and programmatic names for controls are even more
-               of an issue for speech-input and text-to-speech users who also have cognitive challenges.
-               Mismatches create an extra cognitive load for speech-input users, who must remember
-               to say a speech command that is different from the visible label they see on a control.
-               It also creates extra cognitive load for a text-to-speech user to absorb and understand
-               speech output that does not match the visible label.
-            </p>
-            <p>In order for the label text and accessible name to be matched, it is first necessary
-               to determine which text on the screen should be considered a label for any given control.
-               There are often multiple text strings in a user interface that may be relevant to
-               a control. However, there are reasons why it is best to conservatively interpret the
-               label as being only the text in close proximity.
-            </p>
-            <p>Conventionally the label for user interface components is the adjacent text string.
-               The typical positioning for left to right languages is:
-            </p>
+            <p>この達成基準の意図は、コンポーネントに視覚的にラベルを付ける単語が、コンポーネントにプログラムにより関連付けられる単語でもあることを確実にすることである。これは、障害のある人がコンポーネントとやりとりする手段として可視ラベルを確実に信頼できるようにするのを助ける。</p>
+            <p>ほとんどのコントロールは、可視のテキスト<strong>ラベル</strong>を伴う。この同じコントロールには、アクセシブルな名前 (<a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name</a>) とも呼ばれるプログラムの<strong>名前</strong>がある。コントロールの可視ラベルの単語及び文字が一致する、又はアクセシブルな名前 (accessible name) に含まれている場合、利用者は一般に、はるかに優れた体験が得られる。これらが一致するとき、音声入力の利用者 (すなわち、音声認識アプリケーションの利用者) は、画面に表示されるメニュー、リンク、ボタンなどのコンポーネントの可視のテキストラベルを話すことによってナビゲートできる。テキスト読み上げ (スクリーンリーダーなど) を使用する視力のある利用者も、聞こえるテキストが画面に表示されるテキストと一致する場合に、よりよい体験が得られる。</p>
+            <p>コンポーネントに可視のテキストラベルが存在しない場合、この達成基準はそのコンポーネントには適用されないことに注意する。</p>
+            <p>テキストラベルが存在し、確立されたオーサリングプラクティスを通じてユーザインタフェースコンポーネントに適切にリンクされている場合、ラベルと名前は通常一致する。それらが一致しない場合、ナビゲーション又は選択の手段として可視のテキストラベルを使用しようとする音声入力の利用者 (「パスワードに移動」など) は失敗する。利用者が話す可視ラベルが、音声入力コマンドとして有効であるアクセシブルな名前 (accessible name) と一致しない (又はその一部ではない) ため、音声ベースのナビゲーションは失敗する。さらに、アクセシブルな名前 (accessible name) が可視ラベルと異なる場合、音声入力の利用者によって誤って作動される可能性のある非表示のコマンドとして機能することがある。</p>
+            <p>コントロールの可視ラベルとプログラム名との間の不一致は、認知の問題も抱えている音声入力の利用者及びテキスト読み上げの利用者にとってさらに問題になる。不一致は、音声入力の利用者に余分な認知的負荷を引き起こす。その利用者は、コントロールに表示される可視ラベルとは異なる音声コマンドを言うことを忘れてはならない。また、テキスト読み上げの利用者が、可視ラベルと一致しない音声出力を吸収して理解するための追加の認知的負荷を引き起こす。</p>
+            <p>ラベルテキストとアクセシブルな名前 (accessible name) を一致させるには、まず画面上のどのテキストを与えられたコントロールのラベルと見なすかを決定する必要がある。多くの場合、ユーザインタフェースには、コントロールに関連する可能性のある複数のテキスト文字列がある。しかし、ラベルを近接したテキストのみであると保守的に解釈することが最良である理由がいくつか存在する。</p>
+            <p>ユーザインタフェース コンポーネントの伝統的なラベルは隣接するテキスト文字列である。左から右への言語の一般的な配置は次のとおりである:</p>
             <ul>
-               <li>immediately to the left of comboboxes, dropdown lists, text inputs, and other widgets
-                  (or in the absence of left-side labels, immediately above and aligned with the left
-                  edge of each input)
-               </li>
+               <li>コンボボックス、ドロップダウンリスト、テキスト入力、及びその他のウィジェットのすぐ左 (又は、左側のラベルがない場合、各入力のすぐ上で左端に揃えられる)</li>
 
-               <li>immediately to the right of checkboxes and radio buttons</li>
+               <li>チェックボックス及びラジオボタンのすぐ右側</li>
 
-               <li>inside buttons and tabs or immediately below icons serving as buttons</li>
+               <li>ボタン及びタブの内側、又はボタンとして機能するアイコンのすぐ下</li>
 
             </ul>
-            <p>The rationale for some of these conventions is explained in <a href="https://waic.jp/docs/WCAG21/Techniques/general/G162">G162: Positioning labels to maximize predictability of relationships</a>.
-
-            </p>
-            <p>It is important to bias towards treating only the adjacent text as a label because
-               liberal interpretations of what constitutes a text label can jeopardize the value
-               of this Success Criterion (SC) by lessening predictability. Isolating the label to
-               the single string in close proximity to the component makes it easier for developers,
-               testers, and end users to identify the label targeted for evaluation in this SC. Predictable
-               interpretation of labeling allows users of speech recognition technologies to interact
-               with the element via its conventionally positioned label, and allows users of screen
-               reading technologies to enjoy consistency between the nearby visible label and the
-               announced name of the component.
-            </p>
-            <p>Note that placeholder text within an input field is not considered an appropriate
-               means of providing a label. The <a href="https://www.w3.org/TR/html52/sec-forms.html#the-placeholder-attribute">HTML5 specification</a> states <q>The placeholder attribute should not be used as an alternative to a &lt;label&gt;.</q> However, it is worth noting that "label" in that HTML5 statement is in code brackets
-               and links to the <code>label</code> element. For the purposes of this Label in Name Success Criterion, "label" is not
-               used in such a programmatic sense but is simply referring to a text string in close
-               visual proximity to a component. As such, in the absence of any other nearby text
-               string (as described in the preceding list), if an input contains placeholder text,
-               such text may be a candidate for Label in Name. This is supported both through the
-               accessible name calculation (discussed later) and from the practical sense that where
-               a visible label is not otherwise provided, it is likely that a speech-input user may
-               attempt to use the placeholder text value as a means of interacting with the input.
-            </p>
+            <p>これらの規則のいくつかの根本原理は、<a href="https://waic.jp/docs/WCAG21/Techniques/general/G162">G162: 関係性を最大限に予測できるようにするためにラベルを配置する</a>で説明されている。</p>
+            <p>テキストラベルを構成するものを自由に解釈すると、予測可能性の低下によりこの達成基準の価値が危険にさらされる可能性があるため、隣接するテキストのみをラベルとして扱うようにバイアスをかけることが重要である。コンポーネントに近接した単一の文字列にラベルを分離すると、開発者、テスター、およびエンドユーザがこの達成基準で評価の対象となるラベルを簡単に特定できるようになる。ラベル付けの予測可能な解釈により、音声認識技術の利用者は、伝統的な位置にあるラベルを通して要素とやりとりでき、画面読み上げ技術の利用者は、近くに表示されるラベルとコンポーネントの通知された名前との間の一貫性を得ることを可能にする。</p>
+            <p>入力フィールド内のプレースホルダーテキストは、ラベルを提供する適切な手段とは見なされないことに注意する。<a href="https://www.w3.org/TR/html52/sec-forms.html#the-placeholder-attribute">HTML5 仕様</a> では、<q>プレースホルダー属性を&lt;label&gt;の代わりに使用すべきでない</q>と記述されている。しかし、その HTML5 ステートメントの "ラベル" はコードブラケット内にあり、<code>label</code>要素にリンクしていることに注意する。名前 (name) のラベルの成功基準の目的のために、"ラベル" はそのようなプログラム的な意味で使用されないが、単にコンポーネントに視覚的に近接したテキスト文字列を指す。そのため、 (前述のリストで説明したように) 近くに他のテキスト文字列がない場合に、入力にプレースホルダーテキストが含まれているならば、そのようなテキストは名前 (name) のラベルの候補になることがある。これは、アクセシブルな名前の計算 (後で説明) と、可視ラベルが他に提供されない場合、音声入力の利用者が入力をともなうやりとりの手段としてプレースホルダーテキストの値を使用しようとする可能性があるという実際的な意味の両方でサポートされる。</p>
             <section id="text-labels-&#34;express-something-in-human-language&#34;">
 
                <h3>Text labels "express something in human language"</h3>

--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -55,35 +55,23 @@
             <p>入力フィールド内のプレースホルダーテキストは、ラベルを提供する適切な手段とは見なされないことに注意する。<a href="https://www.w3.org/TR/html52/sec-forms.html#the-placeholder-attribute">HTML5 仕様</a> では、<q>プレースホルダー属性を&lt;label&gt;の代わりに使用すべきでない</q>と記述されている。しかし、その HTML5 ステートメントの "ラベル" はコードブラケット内にあり、<code>label</code>要素にリンクしていることに注意する。名前 (name) のラベルの成功基準の目的のために、"ラベル" はそのようなプログラム的な意味で使用されないが、単にコンポーネントに視覚的に近接したテキスト文字列を指す。そのため、 (前述のリストで説明したように) 近くに他のテキスト文字列がない場合に、入力にプレースホルダーテキストが含まれているならば、そのようなテキストは名前 (name) のラベルの候補になることがある。これは、アクセシブルな名前の計算 (後で説明) と、可視ラベルが他に提供されない場合、音声入力の利用者が入力をともなうやりとりの手段としてプレースホルダーテキストの値を使用しようとする可能性があるという実際的な意味の両方でサポートされる。</p>
             <section id="text-labels-&#34;express-something-in-human-language&#34;">
 
-               <h3>Text labels "express something in human language"</h3>
+               <h3>「自然言語で何かを表現している」テキストラベル</h3>
 
                <section id="symbolic-text-characters">
 
-                  <h4>Symbolic text characters</h4>
+                  <h4>記号的な文字</h4>
 
-                  <p>For the purposes of this SC, text should not be considered a visible label if it is
-                     used in a symbolic manner, rather than directly <q>expressing something in human language</q> as per the definition of <a href="#dfn-text">text</a> in WCAG. For example, <a href="https://waic.jp/docs/WCAG21/#images-of-text">1.4.5 Images of Text</a> describes considerations for "symbolic text characters." In the images of text example
-                     "B", "I", and "ABC" appear on icons in a text editor, where they are meant to symbolize
-                     the functions for Bold, Italics, and Spelling, respectively. In such a case, the accessible
-                     name should be the function the button serves (e.g., "Spell check" or "Check spelling"),
-                     not the visible symbolic characters. A similar text editor is shown in the figure
-                     below.
-                  </p>
+                  <p>この達成基準のために、テキストは、WCAG の<a href="#dfn-text">テキスト</a>の定義に従って直接<q>自然言語で何かを表現しているもの</q>よりむしろ、記号的な方法で使用される場合、可視のラベルと見なされるべきでない。例えば、<a href="https://waic.jp/docs/WCAG21/#images-of-text">1.4.5 文字画像</a>は、「記号的な文字」に関する考慮事項を説明している。文字画像の例では、「B」、「I」、及び「ABC」がテキストエディタのアイコンに表示される。これらは、それぞれ太字、斜体、およびスペルの機能を表すことを目的としている。そのような場合、アクセシブルな名前 (accessible name) は、表示されている記号的な文字ではなく、ボタンが提供する機能 (「スペルチェック」や「スペルをチェックする」など) とするべきである。同様のテキストエディタを次の図に示す。</p>
 
                   <figure id="figure-RTE-github">
-                     	<img alt="Icons for transforming text, including heading, bold, italic, quote, code, and link, along with icons for ordered and unordered lists and other controls" src="img/rich-text-editor-detail.png" />
+                     	<img alt="見出し、太字、斜体、引用、コード、リンクなどのテキストを変換するためのアイコン、順序付き及び順序なしのリスト並びにその他のコントロールのアイコン" src="img/rich-text-editor-detail.png" />
 
-                     <figcaption>Figure 1A detail of the rich text editor in Github, showing a variety of unlabeled icons,
-                        including icons resembling text characters.
+                     <figcaption>図 1 Github のリッチテキストエディタの詳細。文字に似たアイコンなど、ラベルのないさまざまなアイコンが表示されている。
                      </figcaption>
 
                   </figure>
 
-                  <p>Likewise, where an author has used a greater-than symbol ("&gt;") to mimic the appearance
-                     of the right-facing arrow, the text does not convey something in human language. It
-                     is a symbol, in this scenario likely meant to mimic the icons used for a "Play" button
-                     or a "Next" arrow.
-                  </p>
+                  <p>同様に、コンテンツ制作者が大なり記号 (">") を使用して右向きの矢印の外観を模倣した場合、テキストは自然言語で何も伝えない。これは記号であり、このシナリオでは、「再生」ボタン又は「次へ」矢印に使用されるアイコンを模倣することを意図した可能性がある。</p>
 
                   <h4>Punctuation and capitalization</h4>
 

--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -35,12 +35,214 @@
       <main>
          <section id="intent">
             <h2>意図</h2>
-            <p>この達成基準の意図は、可視ラベルに依存する障害者が、プログラムでもこのラベルを使用できるようにすることである。多くの場合、コントロールには視認できるテキストのラベルが付けられる。コントロールには、加えて、アクセシブルな名前 (<a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name</a>) と呼ばれるプログラムによって利用可能なラベルもある。コントロール上の可視テキストラベルが、アクセシブルな名前 (accessible name) と一致している場合、利用者ははるかにより優れた体験が得られる。</p>
-            <p>音声入力を行う利用者は、画面に表示されるメニュー、リンク、及びボタンのテキストラベルを読み上げることで、ナビゲートすることができる。音声入力を行う利用者が、目にした可視テキストラベルを読み上げながらも、音声入力コマンドとして有効なアクセシブルな名前 (accessible name) がその可視ラベルと一致していないがために音声入力が正常に機能しない場合、利用者は混乱してしまう。</p>
-            <p>さらに、コントロールのアクセシブルな名前 (accessible name) が視覚的に隠されている場合、音声入力を行う利用者がたまたま、この隠されたアクセシブルな名前 (accessible name) に対応した語を発話してしまうと、このコントロールを誤って動作させてしまうことがある。</p>
-            <p>また、テキスト読み上げツールの利用者の場合、聞き取ったテキストが画面に表示されているテキストと一致していることによって、よりよい体験が得られるだろう。</p>
-            <p>コンテンツ制作者は、リンク又は他のコントロールに文脈を付加して、支援技術の利用者にとってよりわかりやすいものにするために、テキストを追加したくなることがあるだろう。この場合は、アクセシブルな名前 (accessible name) が可視ラベルで始まるように、可視ラベルの<strong>後に</strong>そのテキストを追加することが推奨される。検索（search）ボタンであれば、アクセシブルな名前 (accessible name) は "search this site" になり、ホーム（home）へのリンクであれば、テキストは "home - go to start page" という具合である。いずれの場合でも、ラベルの隠された部分は異なる手段、例えば、CSS を介してアクセシブルな形で隠されたテキストとして、又は aria-label もしくは aria-labelledby 属性を使用することによって、提供してもよい。</p>
-            <p>この問題は、音声入力及びテキスト読み上げツールの利用者で、認知の問題も抱える人たちにとって、さらに重要なものとなる。音声入力の利用者にとって、コントロール上に表示される可視ラベルとは異なる音声コマンドを記憶して発話することは、余計な認知負荷となる。また、テキスト読み上げツールの利用者にとって、可視ラベルと一致しない音声出力を吸収して理解することは、余計な認知負荷となる。</p>
+            <p>The intent of this Success Criterion is to ensure that the words which visually label
+               a component are also the words associated with the component programmatically. This
+               helps ensure that people with disabilities can rely on visible labels as a means to
+               interact with the components.
+            </p>
+            <p>Most controls are accompanied by a visible text <strong>label</strong>. Those same controls have a programmatic <strong>name</strong>, also known as the <a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name</a>. Users typically have a much better experience if the words and characters in the
+               visible label of a control match or are contained within the accessible name. When
+               these match, speech-input users (i.e., users of speech recognition applications) can
+               navigate by speaking the visible text labels of components, such as menus, links,
+               and buttons, that appear on the screen. Sighted users who use text-to-speech (e.g.,
+               screen readers) will also have a better experience if the text they hear matches the
+               text they see on the screen.
+            </p>
+            <p>Note that where a visible text label does not exist for a component, this Success
+               Criterion does not apply to that component.
+            </p>
+            <p>Where text labels exist and are properly linked to the user interface components through
+               established authoring practices, the label and name will normally match. When they
+               don't match, speech-input users who attempt to use the visible text label as a means
+               of navigation or selection (e.g., "move to Password") will be unsuccessful.  The speech-based
+               navigation fails because the visible label spoken by the users does not match (or
+               is not part of) the accessible name that is enabled as a speech-input command. In
+               addition, when the accessible name is different from the visible label, it may function
+               as a hidden command that can be accidentally activated by speech-input users.
+            </p>
+            <p>Mismatches between visible labels and programmatic names for controls are even more
+               of an issue for speech-input and text-to-speech users who also have cognitive challenges.
+               Mismatches create an extra cognitive load for speech-input users, who must remember
+               to say a speech command that is different from the visible label they see on a control.
+               It also creates extra cognitive load for a text-to-speech user to absorb and understand
+               speech output that does not match the visible label.
+            </p>
+            <p>In order for the label text and accessible name to be matched, it is first necessary
+               to determine which text on the screen should be considered a label for any given control.
+               There are often multiple text strings in a user interface that may be relevant to
+               a control. However, there are reasons why it is best to conservatively interpret the
+               label as being only the text in close proximity.
+            </p>
+            <p>Conventionally the label for user interface components is the adjacent text string.
+               The typical positioning for left to right languages is:
+            </p>
+            <ul>
+               <li>immediately to the left of comboboxes, dropdown lists, text inputs, and other widgets
+                  (or in the absence of left-side labels, immediately above and aligned with the left
+                  edge of each input)
+               </li>
+
+               <li>immediately to the right of checkboxes and radio buttons</li>
+
+               <li>inside buttons and tabs or immediately below icons serving as buttons</li>
+
+            </ul>
+            <p>The rationale for some of these conventions is explained in <a href="https://waic.jp/docs/WCAG21/Techniques/general/G162">G162: Positioning labels to maximize predictability of relationships</a>.
+
+            </p>
+            <p>It is important to bias towards treating only the adjacent text as a label because
+               liberal interpretations of what constitutes a text label can jeopardize the value
+               of this Success Criterion (SC) by lessening predictability. Isolating the label to
+               the single string in close proximity to the component makes it easier for developers,
+               testers, and end users to identify the label targeted for evaluation in this SC. Predictable
+               interpretation of labeling allows users of speech recognition technologies to interact
+               with the element via its conventionally positioned label, and allows users of screen
+               reading technologies to enjoy consistency between the nearby visible label and the
+               announced name of the component.
+            </p>
+            <p>Note that placeholder text within an input field is not considered an appropriate
+               means of providing a label. The <a href="https://www.w3.org/TR/html52/sec-forms.html#the-placeholder-attribute">HTML5 specification</a> states <q>The placeholder attribute should not be used as an alternative to a &lt;label&gt;.</q> However, it is worth noting that "label" in that HTML5 statement is in code brackets
+               and links to the <code>label</code> element. For the purposes of this Label in Name Success Criterion, "label" is not
+               used in such a programmatic sense but is simply referring to a text string in close
+               visual proximity to a component. As such, in the absence of any other nearby text
+               string (as described in the preceding list), if an input contains placeholder text,
+               such text may be a candidate for Label in Name. This is supported both through the
+               accessible name calculation (discussed later) and from the practical sense that where
+               a visible label is not otherwise provided, it is likely that a speech-input user may
+               attempt to use the placeholder text value as a means of interacting with the input.
+            </p>
+            <section id="text-labels-&#34;express-something-in-human-language&#34;">
+
+               <h3>Text labels "express something in human language"</h3>
+
+               <section id="symbolic-text-characters">
+
+                  <h4>Symbolic text characters</h4>
+
+                  <p>For the purposes of this SC, text should not be considered a visible label if it is
+                     used in a symbolic manner, rather than directly <q>expressing something in human language</q> as per the definition of <a href="#dfn-text">text</a> in WCAG. For example, <a href="https://waic.jp/docs/WCAG21/#images-of-text">1.4.5 Images of Text</a> describes considerations for "symbolic text characters." In the images of text example
+                     "B", "I", and "ABC" appear on icons in a text editor, where they are meant to symbolize
+                     the functions for Bold, Italics, and Spelling, respectively. In such a case, the accessible
+                     name should be the function the button serves (e.g., "Spell check" or "Check spelling"),
+                     not the visible symbolic characters. A similar text editor is shown in the figure
+                     below.
+                  </p>
+
+                  <figure id="figure-RTE-github">
+                     	<img alt="Icons for transforming text, including heading, bold, italic, quote, code, and link, along with icons for ordered and unordered lists and other controls" src="img/rich-text-editor-detail.png" />
+
+                     <figcaption>Figure 1A detail of the rich text editor in Github, showing a variety of unlabeled icons,
+                        including icons resembling text characters.
+                     </figcaption>
+
+                  </figure>
+
+                  <p>Likewise, where an author has used a greater-than symbol ("&gt;") to mimic the appearance
+                     of the right-facing arrow, the text does not convey something in human language. It
+                     is a symbol, in this scenario likely meant to mimic the icons used for a "Play" button
+                     or a "Next" arrow.
+                  </p>
+
+                  <h4>Punctuation and capitalization</h4>
+
+               </section>
+
+               <section id="">
+
+                  <p>The use of punctuation and capitalization in labels <em>may</em> also be considered optional for the same reason. For example, the colon conventionally
+                     added at the end of input labels does not express something in human language, and
+                     capitals on the first letter of each word in a label do not normally alter the words'
+                     meaning. This is particularly relevant in the context of this SC, since it is primarily
+                     aimed at users of speech recognition; capitals and most punctuation are frequently
+                     ignored when a user speaks a label as a means of interacting with a control.
+                  </p>
+
+                  <p>While it is certainly not an error to include the colon and capitalization in the
+                     accessible name, a computed name of "First name" should not be considered a failure
+                     of "First Name:".<br />
+                     <label for="firstname">First Name: </label><input id="firstname" type="text" name="firstname" /><br />
+                     Likewise, "Next…" visibly shown on a button could have "Next" as the accessible name.
+                     When in doubt, where a meaningful visible label exists, match the string exactly for
+                     the accessible name.<br />
+                     <input type="submit" value="Next..." /></p>
+
+               </section>
+
+               <section id="mathematical-expressions-and-formulae">
+
+
+                  <h4>Mathematical expressions and formulae</h4>
+
+                  <p>Mathematical expressions are an exception to the previous subsection about symbolic
+                     characters. Math symbols can be used as labels; for example "11×3=33" and "A&gt;B" convey
+                     meaning. The label should not be overwritten in the accessible name, and substitutions
+                     of words where a formula is used should be avoided since there are multiple ways to
+                     express the same equation. For example, making the name "eleven multiplied by three
+                     is equivalent to thirty-three" might mean a user who said "eleven times three equals
+                     thirty-three" may not match. It is best to leave the formulas as used in the label
+                     and count on the user's familiarity with their speech software to achieve a match.
+                     Further, converting a mathematical formula label into an accessible name that is a
+                     spelled-out equivalent may create issues for translation. The name should match the
+                     label's formula text. Note that a consideration for authors is to use the proper symbol
+                     in the formula. For instance 11x3 (with a lower or upper case letter X), 11*3 (with
+                     the asterisk symbol), and 11×3 (with the <code>&amp;</code>times<code>;</code> symbol) are all easy for sighted users to interpret as meaning the same formula,
+                     but may not all be matched to "11 times 3" by the speech recognition software. The
+                     proper operator symbol (in this case the times symbol) should be used.<br />
+
+                     <input type="radio" name="equation" id="answer1" value="A&gt;B" /><label for="answer1">A&gt;B</label>
+                     <input type="radio" name="equation" id="answer2" value="A=B" /><label for="answer2">A=B</label>
+                     <input type="radio" name="equation" id="answer3" value="A&lt;B" /><label for="answer3">A&lt;B</label></p>
+
+               </section>
+
+            </section>
+            <section id="accessible-name-and-description-computation-specification">
+
+
+               <h3>Accessible Name and Description Computation specification</h3>
+
+               <p>It is important to understand how the accessible name is derived. The <a href="https://www.w3.org/TR/accname-1.1/">Accessible Name and Description Computation 1.1</a> and the <a href="https://w3c.github.io/html-aam/#accessible-name-and-description-computation">HTML Accessibility API Mappings 1.0</a> describe how the accessible name is computed, including which attributes are considered
+                  in its calculation, and in what order of preference. If a component has multiple possible
+                  attribute values that could be used for its accessible name, only the most preferred
+                  of those values will be computed. None of the other, less preferred values will be
+                  part of the name. For the most part, existing established programmatic relationships
+                  between labels and controls are reinforced by the specification.
+               </p>
+
+               <p>Other text displayed on the screen that is correctly coded to meet 1.3.1: Info and
+                  Relationships is <strong>not</strong> normally factored into the calculation for the accessible name of a UI component
+                  without author intervention (via ARIA labeling techniques). The most common of these
+                  are:
+               </p>
+
+               <ul>
+
+                  <li>headings and instructions</li>
+
+                  <li>group labels for sets of components (i.e., used with <code>legend</code>/<code>fieldset</code> or with role of <code>group</code> or <code>radiogroup</code>)
+                  </li> 
+
+               </ul>
+
+               <p>Such textual information may constitute part of the component's <em>description</em>. So from both a programmatic viewpoint, and from the conservative tactic of only
+                  considering a label to be "adjacent text," neither headings, instructions, nor group
+                  'labels' should normally be considered <strong>labels</strong> for the purpose of this Success Criterion.
+               </p>
+
+               <p>It is important to note that the specification allows authors to override the name
+                  calculated through native semantics. Both <code>aria-label</code> and <code>aria-labelledby</code> take precedence in the name calculation, overriding the visible text as the accessible
+                  name even when the visible text label is programmatically associated with the control.
+                  For this reason, when a visible label already exists, <code>aria-label</code> should be avoided or used carefully, and <code>aria-labelledby</code> should be used as a supplement with care.
+               </p>
+
+               <p>Finally, <code>aria-describedby</code> is not included in the Accessible Name computation (instead it is part of the Accessible
+                  Description computation). By convention, text associated with a control through <code>aria-describedby</code> is announced immediately after the accessible name by screen readers. Therefore,
+                  the context of headings, instructions, and group labels can be provided through the
+                  accessible description to assist users of screen readers without affecting the experience
+                  of those who navigate using speech recognition software.
+               </p>
+
+            </section>
          </section>
          <section id="benefits">
             <h2>メリット</h2>
@@ -58,7 +260,7 @@
                				
                <li><strong>アクセシブルな名前 (accessible name) が可視ラベルと一致する:</strong> アクセシブルな名前 (accessible name) とコントロールの可視ラベルが一致する。</li>
                				
-               <li><strong><strong>アクセシブルな名前 (accessible name) が可視ラベルで始まる:</strong> "Buy Now (今すぐ購入する)" ボタンのアクセシブルな名前 (accessible name) は、可視ラベルと同じテキストで始まっている。</li>
+               <li><strong>アクセシブルな名前 (accessible name) が可視ラベルで始まる:</strong> アクセシブルな名前 (accessible name) "Search for a value" は、可視ラベルのテキスト "Search" で始まっている。</li>
                			
             </ul>
          </section>
@@ -80,16 +282,19 @@
                <h3>十分な達成方法</h3>
                <ul>
                   					
-                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/general/G208">G208: "アクセシブルな名前 (accessible name)" が可視テキストを含むようにする</a></li>
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/general/G208">G208: アクセシブルな名前 (accessible name) の一部として可視ラベルのテキストを含める</a></li>
                   					
-                  <li>@@ アクセシブルな名前 (accessible name) が可視ラベルのテキストと一致するようにする</li>
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/general/G211">G211: アクセシブルな名前 (accessible name) を視覚的なラベルと一致させる</a></li>
                   				
                </ul>
             </section>
             <section id="advisory">
                <h3>参考達成方法</h3>
                <p>適合のために必須ではないが、コンテンツをよりアクセシブルにするために、次の追加の達成方法を検討することが望ましい。ただし、すべての状況において、すべての達成方法が使用可能、又は効果的であるとは限らない。</p>
+
                <ul>
+
+                  <li><a href="https://waic.jp/docs/WCAG21/Techniques/general/G162">G162: Positioning labels to maximize predictability of relationships</a></li>
                   <li>@@ アイコンに付随するテキストがない場合、アクセシブルな名前 (accessible name) としてそのホバーテキストを用いることを検討する。</li>
                </ul>
             </section>
@@ -202,5 +407,7 @@
             </dd>
          </section>
       </main>
+      <hr>
+      <div><p>訳注: このページは、2020 年 12 月 2 日版の Understanding WCAG 2.1 の翻訳です。2020 年 12 月 2 日版の原文は <a href="https://github.com/waic/w3c-wcag">WAIC の管理するレポジトリ</a>から入手可能です。</p></div>
    </body>
 </html>

--- a/understanding/label-in-name.html
+++ b/understanding/label-in-name.html
@@ -37,25 +37,11 @@
             <h2>意図</h2>
             <p>この達成基準の意図は、コンポーネントに視覚的にラベルを付ける単語が、コンポーネントにプログラムにより関連付けられる単語でもあることを確実にすることである。これは、障害のある人がコンポーネントとやりとりする手段として可視ラベルを確実に信頼できるようにするのを助ける。
             </p>
-            <p>Most controls are accompanied by a visible text <strong>label</strong>. Those same controls have a programmatic <strong>name</strong>, also known as the <a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name</a>. Users typically have a much better experience if the words and characters in the
-               visible label of a control match or are contained within the accessible name. When
-               these match, speech-input users (i.e., users of speech recognition applications) can
-               navigate by speaking the visible text labels of components, such as menus, links,
-               and buttons, that appear on the screen. Sighted users who use text-to-speech (e.g.,
-               screen readers) will also have a better experience if the text they hear matches the
-               text they see on the screen.
+            <p>ほとんどのコントロールは、可視のテキスト<strong>ラベル</strong>を伴う。この同じコントロールには、アクセシブルな名前 (<a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name</a>) とも呼ばれるプログラムの<strong>名前</strong>がある。コントロールの可視ラベルの単語及び文字が一致する、又はアクセシブルな名前 (accessible name) に含まれている場合、利用者は一般に、はるかに優れた体験をする。これらが一致するとき、音声入力の利用者 (すなわち、音声認識アプリケーションの利用者) は、画面に表示されるメニュー、リンク、ボタンなどのコンポーネントの可視のテキストラベルを話すことによってナビゲートできる。テキスト読み上げ (スクリーンリーダーなど) を使用する視力のある利用者も、聞こえるテキストが画面に表示されるテキストと一致する場合に、よりよい体験をする。
             </p>
-            <p>Note that where a visible text label does not exist for a component, this Success
-               Criterion does not apply to that component.
+            <p>コンポーネントに可視のテキストラベルが存在しない場合、この達成基準はそのコンポーネントには適用されないことに注意する。
             </p>
-            <p>Where text labels exist and are properly linked to the user interface components through
-               established authoring practices, the label and name will normally match. When they
-               don't match, speech-input users who attempt to use the visible text label as a means
-               of navigation or selection (e.g., "move to Password") will be unsuccessful.  The speech-based
-               navigation fails because the visible label spoken by the users does not match (or
-               is not part of) the accessible name that is enabled as a speech-input command. In
-               addition, when the accessible name is different from the visible label, it may function
-               as a hidden command that can be accidentally activated by speech-input users.
+            <p>テキストラベルが存在し、確立されたオーサリングプラクティスを通じてユーザーインタフェースコンポーネントに適切にリンクされている場合、ラベルと名前は通常一致する。それらが一致しない場合、ナビゲーション又は選択の手段として可視のテキストラベルを使用しようとする音声入力の利用者 (「パスワードに移動」など) は失敗する。利用者が話す可視ラベルが、音声入力コマンドとして有効であるアクセシブルな名前 (accessible name) と一致しない (又はその一部ではない) ため、音声ベースのナビゲーションは失敗する。さらに、アクセシブルな名前 (accessible name) が可視ラベルと異なる場合、音声入力の利用者によって誤って作動される可能性のある非表示のコマンドとして機能することがある。
             </p>
             <p>Mismatches between visible labels and programmatic names for controls are even more
                of an issue for speech-input and text-to-speech users who also have cognitive challenges.


### PR DESCRIPTION
解説書SC 2.5.3を2020年12月2日版に更新します

related #1077

- 現状の原文（この版の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/label-in-name
- 差分
  - [waic/w3c-wcag@433b1cf...1a05939](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-b6c495791968f399fd29bbaa2615783092b144a02314744a49a4972eec41c71e)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/label-in-name.html

## 更新内容

- 原文の更新にともなう本文の変更（未訳）
- 訳注の付与

## プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

現時点での作業としては、Intentが全面書き換えになっているので、差分を取り込こんだだけとなっています。
（引き継いでくれる方がいれば歓迎します）
