### PR TITLE
WAIC翻訳文書のライセンスへのリンクを追加

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -296,6 +296,7 @@ details.respec-tests-details > li {
     <body class="h-entry">
 <aside class="trnote">
 <p>この文書は、<a href="https://www.w3.org/TR/2018/REC-WCAG21-20180605/">2018 年 6 月 5 日付けの W3C 勧告 Web Content Accessibility Guidelines (WCAG) 2.1</a>を、<a href="https://waic.jp/committee/wg4/">ウェブアクセシビリティ基盤委員会 (WAIC) の翻訳ワーキンググループ</a>が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/">翻訳に関するお問い合わせ</a>からご連絡ください。</p>
+<p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
 <p>この文書内にあるリンクのうち、「Understanding WCAG 2.1」「How to Meet WCAG 2.1」へのリンクについては、W3C が策定作業中であるため、まだ日本語版を作成していません。ご注意ください。</p>
 </aside>
     <div class="head">


### PR DESCRIPTION
冒頭の訳注にWAIC翻訳文書のライセンスへのリンクを追加してみました。