### PR TITLE
関連文書の訳注にライセンスへのリンクを追加

### DIFF
--- a/techniques/index.html
+++ b/techniques/index.html
@@ -18,6 +18,7 @@
    	
    <body>
 <div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/techniques/">Techniques for WCAG 2.1</a> の 2019 年 10 月 1 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2fdocs%2fWCAG21%2fUnderstanding%2f" id="file-issue">翻訳に関するコメント (Google フォーム)</a>からご連絡ください。</p>
+<p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
 <p>【重要】 原文の Techniques for WCAG 2.1 自体、ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は古くなっていることがあります。あくまでも参考程度にご覧ください。</p></div>      		
       <div class="head">
          			<a href="https://www.w3.org/" class="logo">

--- a/understanding/index.html
+++ b/understanding/index.html
@@ -18,6 +18,7 @@
 
    <body>
 <div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.1</a> の 2019 年 3 月 6 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2fdocs%2fWCAG21%2fUnderstanding%2f" id="file-issue">翻訳に関するコメント (Google フォーム)</a>からご連絡ください。</p>
+<p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
 <p>【重要】 原文の Understanding WCAG 2.1 自体、ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は古くなっていることがあります。あくまでも参考程度にご覧ください。</p></div>
       <div class="head"><a href="https://www.w3.org/" class="logo"> <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48" /> </a><h1 id="title" class="title p-name">WCAG 2.1 解説書</h1>
 


### PR DESCRIPTION
達成方法集、解説書の冒頭訳注にライセンスへのリンクを追加しました。