### PR TITLE
日本語訳リンクの処理でTechniquesのURLも置換対象にした

### DIFF
--- a/guidelines/waic_link.js
+++ b/guidelines/waic_link.js
@@ -1,6 +1,7 @@
 const trNote = "この文書内にあるリンクのうち、「Understanding WCAG 2.1」へのリンクについては、WAIC の公開する日本語版にリンク先を追加しています。WAIC の日本語訳は、 W3C の公開する英語版より内容が古い可能性がありますのでご注意ください。";
 const jaLinkText = '[日本語訳]';
 const jaLinkTitleSuffix = 'の日本語訳';
+const taregtUrlString = ['Understanding', 'Techniques'];
 
 document.addEventListener('DOMContentLoaded', function(){
 	const lastTrNote = document.querySelector("aside.trnote>p:last-child");
@@ -10,15 +11,17 @@ document.addEventListener('DOMContentLoaded', function(){
 	for(let i = 0; i < w3cDocumentAnchors.length; i++){
 		const anchor = w3cDocumentAnchors[i];
 		const href = anchor.getAttribute('href');
-		if(href.indexOf("Understanding")!=-1 ){
-			const jaLinkUrl = href.replace('\/\/www.w3.org\/WAI\/WCAG21\/Understanding','//waic.jp/docs/WCAG21/Understanding');
-			const jaLinkTitle = '"' + anchor.textContent + '"' + jaLinkTitleSuffix;
-			const jaAnchor = document.createElement('a');
-			jaAnchor.setAttribute('href', jaLinkUrl);
-			jaAnchor.setAttribute('title', jaLinkTitle);
-			jaAnchor.textContent = jaLinkText;
-			anchor.parentNode.insertBefore(jaAnchor, anchor.nextSibling);
-			jaAnchor.parentNode.insertBefore(document.createTextNode(" "), jaAnchor);
-		}
+		taregtUrlString.forEach(taregtString => {
+			if(href.indexOf(taregtString)!=-1 ){
+				const jaLinkUrl = href.replace('\/\/www.w3.org\/WAI\/WCAG21\/', '//waic.jp/docs/WCAG21/');
+				const jaLinkTitle = '"' + anchor.textContent + '"' + jaLinkTitleSuffix;
+				const jaAnchor = document.createElement('a');
+				jaAnchor.setAttribute('href', jaLinkUrl);
+				jaAnchor.setAttribute('title', jaLinkTitle);
+				jaAnchor.textContent = jaLinkText;
+				anchor.parentNode.insertBefore(jaAnchor, anchor.nextSibling);
+				jaAnchor.parentNode.insertBefore(document.createTextNode(" "), jaAnchor);
+			}
+		})
 	}
 });


### PR DESCRIPTION
日本語訳リンクを追加するJavaScriptを更新し、TechniquesのURLも置換対象にしました。
(汎用処理として実装しましたが、蓋開けてみたらTechniquesのリンクは一箇所しかありませんでした)