### PR TITLE
解説書の達成方法のセクションでの未訳箇所の修正

### DIFF
--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -219,7 +219,7 @@
                   <ol>
                      
                      
-                     <li><p>下記の技術固有の達成方法を用いて、<a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G10">G10: 変化のアクセシビリティ通知をサポートするウェブコンテンツ技術を用いて、コンポーネントを作成する</a>:</p>
+                     <li><p>下記の技術固有の達成方法を用いて、<a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G10">名前 (name) 及び役割 (role) を取得し、利用者が設定可能なプロパティを直接設定可能にし、変化を通知するためにユーザエージェントが動作する、プラットフォームのアクセシビリティ API 機能をサポートするウェブコンテンツ技術を用いて、コンポーネントを作成する/a>:</p>
                         
                         
                         <ul>

--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -114,7 +114,7 @@
                      <li><a class="aria" href="https://waic.jp/docs/WCAG21/Techniques/aria/ARIA16">ARIA16: ユーザインターフェース コントロールの名前 (name) を提供するために、aria-labelledby を使用する</a></li>
                      
                      
-                     <li><p><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G108">G108: 名前 (name) 及び役割 (role) を公開し、利用者が設定可能なプロパティを直接設定可能にして、変化の通知を提供するために、マークアップを用いる</a> using technology-specific techniques below:</p>
+                     <li><p>下記の技術固有の達成方法を用いて、<a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G108">G108: 名前 (name) 及び役割 (role) を公開し、利用者が設定可能なプロパティを直接設定可能にして、変化の通知を提供するために、マークアップを用いる</a>:</p>
                         
                         
                         <ul>
@@ -182,7 +182,7 @@
                   <ol>
                      
                      
-                     <li><p>以下の技術固有の達成方法を用いて<a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G135">G135: 名前 (name) 及び変更の通知を公開するためのアクセシビリティ API 機能を使用する</a>:</p>
+                     <li><p>下記の技術固有の達成方法を用いて<a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G135">G135: 名前 (name) 及び変更の通知を公開するためのアクセシビリティ API 機能を使用する</a>:</p>
                         
                         
                         <ul>
@@ -219,7 +219,7 @@
                   <ol>
                      
                      
-                     <li><p><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G10">G10: Creating components using a technology that supports the accessibility notification of changes</a> using technology-specific techniques below:</p>
+                     <li><p>下記の技術固有の達成方法を用いて、<a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G10">G10: 変化のアクセシビリティ通知をサポートするウェブコンテンツ技術を用いて、コンポーネントを作成する</a>:</p>
                         
                         
                         <ul>

--- a/understanding/page-titled.html
+++ b/understanding/page-titled.html
@@ -135,7 +135,7 @@
                <ol>
                   
                   
-                  <li><p><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G88">G88: Providing descriptive titles for Web pages</a> <strong>AND</strong> associating a title with a Web page using one of the following techniques:</p>
+                  <li><p><a class="general" href="https://waic.jp/docs/WCAG21/Techniques/general/G88">G88: ウェブページに説明的なタイトルを提供する</a>、<strong>かつ</strong> 下記の達成方法の一つを使ってウェブページにタイトルを結びつける:</p>
                      
                      
                      <ul>


### PR DESCRIPTION
Close #1148

G10のタイトルについて、解説書では変更ありますが、達成方法ではママですので、達成方法集に従っています。

