### PR TITLE
解説書ヘッダーのリンクの修正

### DIFF
--- a/understanding/audio-only-and-video-only-prerecorded.html
+++ b/understanding/audio-only-and-video-only-prerecorded.html
@@ -12,7 +12,7 @@
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
             <li><a href="time-based-media.html"><abbr title="Guideline">GL</abbr>: 時間依存メディア</a></li>
-            <li><a href="non-text-content.html">Previous <abbr title="Success Criterion">SC</abbr>: </a></li>
+            <li><a href="non-text-content.html">Previous <abbr title="Success Criterion">SC</abbr>: 非テキストコンテンツ</a></li>
             <li><a href="captions-prerecorded.html">Next <abbr title="Success Criterion">SC</abbr>: キャプション (収録済) を理解する</a></li>
          </ul>
       </nav>

--- a/understanding/audio-only-and-video-only-prerecorded.html
+++ b/understanding/audio-only-and-video-only-prerecorded.html
@@ -13,7 +13,7 @@
             <li><a href="." title="目次">目次</a></li>
             <li><a href="time-based-media.html"><abbr title="Guideline">GL</abbr>: 時間依存メディア</a></li>
             <li><a href="non-text-content.html">Previous <abbr title="Success Criterion">SC</abbr>: 非テキストコンテンツ</a></li>
-            <li><a href="captions-prerecorded.html">Next <abbr title="Success Criterion">SC</abbr>: キャプション (収録済) を理解する</a></li>
+            <li><a href="captions-prerecorded.html">Next <abbr title="Success Criterion">SC</abbr>: キャプション (収録済)</a></li>
          </ul>
       </nav>
       <nav class="navtoc">

--- a/understanding/info-and-relationships.html
+++ b/understanding/info-and-relationships.html
@@ -12,7 +12,7 @@
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
             <li><a href="adaptable.html"><abbr title="Guideline">GL</abbr>: 適応可能</a></li>
-            <li><a href="audio-only-audio-only-live.html">Previous <abbr title="Success Criterion">SC</abbr>: 音声のみ (ライブ)</a></li>
+            <li><a href="audio-only-live.html">Previous <abbr title="Success Criterion">SC</abbr>: 音声のみ (ライブ)</a></li>
             <li><a href="meaningful-sequence.html">Next <abbr title="Success Criterion">SC</abbr>: 意味のある順序</a></li>
          </ul>
       </nav>


### PR DESCRIPTION
Fix #1151

ヘッダーナビゲーション部分について
- 達成基準1.2.1のリンクテキスト
- 達成基準1.3.1のリンクURL

を修正しています。