### PR TITLE
達成基準1.1.1 Test Rulesの翻訳漏れを修正

### DIFF
--- a/understanding/non-text-content.html
+++ b/understanding/non-text-content.html
@@ -24,7 +24,7 @@
             <li><a href="#examples">事例</a></li>
             <li><a href="#resources">関連リソース</a></li>
             <li><a href="#techniques">達成方法</a></li>
-            <li><a href="#testing-rules">Testing Rules</a></li>
+            <li><a href="#testing-rules">テストルール</a></li>
             <li><a href="#key-terms">重要な用語</a></li>
          </ul>
       </nav>
@@ -716,11 +716,8 @@
             </section>
          </section>
          <section id="testing-rules">
-            <h2>Testing Rules</h2>
-            <p>The following are testing rules for certain aspects of this Success Criterion. It
-               is not necessary to use these particular rules to check for conformance with WCAG,
-               but they are defined and approved test methods. For information on using Accessibility
-               Conformance Testing (ACT) Rules, see <a href="understanding-act-rules.html">Understanding ACT Rules for WCAG Success Criteria</a>.
+            <h2>テストルール</h2>
+            <p>以下は、この達成基準の特定の側面に関するテストルールである。この特定のルールを使用して WCAG に適合しているかどうかを確認する必要はないが、これらのルールは定義され、承認されたテスト方法である。Accessibility Conformance Testing (ACT) ルールの使用については、<a href="understanding-act-rules.html">WCAG 達成基準の ACT ルールを理解する</a>を参照のこと。</a>
             </p>
             <ul>
                <li><a href="/standards-guidelines/act/rules/image-button-accessible-name-59796f/">Image button has accessible name</a></li>


### PR DESCRIPTION
fix #1152

解説書1.1.1の翻訳漏れの修正です。テキストは
https://dev.waic.jp/docs/WCAG21/Understanding/page-titled.html#testing-rules
と同一です。
