### PR TITLE
解説書表紙を2020年12月2日付けに更新

### DIFF
--- a/understanding/index.html
+++ b/understanding/index.html
@@ -17,12 +17,12 @@
    </head>
 
    <body>
-<div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.1</a> の 2019 年 3 月 6 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2fdocs%2fWCAG21%2fUnderstanding%2f" id="file-issue">翻訳に関するコメント (Google フォーム)</a>からご連絡ください。</p>
+<div><p>【注意】 この文書は、W3C エディターズドラフト <a href="https://w3c.github.io/wcag/understanding/">Understanding WCAG 2.1</a> の 2020 年 12 月 2 日版を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2fdocs%2fWCAG21%2fUnderstanding%2f" id="file-issue">翻訳に関するコメント (Google フォーム)</a>からご連絡ください。</p>
 <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
 <p>【重要】 原文の Understanding WCAG 2.1 自体、ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は古くなっていることがあります。あくまでも参考程度にご覧ください。</p></div>
       <div class="head"><a href="https://www.w3.org/" class="logo"> <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48" /> </a><h1 id="title" class="title p-name">WCAG 2.1 解説書</h1>
 
-         <h2>Updated 6 March 2019</h2>
+         <h2>Updated 2 December 2020</h2>
 
 
          <ul id="masthead">
@@ -40,7 +40,7 @@
          </ul>
 
 
-         <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017-2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+         <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017-2020 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
 
          <hr title="Separator for header" />
 
@@ -304,116 +304,119 @@
 
       </section>
 
-      		<section class="appendix" id="acknowledgments">
+      <section class="appendix informative section" id="acknowledgements">
     <h1>謝辞</h1>
     <p>Accessibility Guidelines Working Group (AG WG) への参加に関する詳細な情報は、<a href="https://www.w3.org/WAI/GL/">ワーキンググループのホームページ</a>を参照。</p>
 
     <section id="ack_participants-active">
         <h2>この文書の作成時にアクティブだった AG WG 参加者:</h2>
         <ul>
-          	<li>Jake Abma (Invited Expert)</li>
-            <li>Shadi Abou-Zahra (W3C)</li>
-        	<li>Chuck Adams (Oracle Corporation)</li>
-        	<li>Amani Ali (Nomensa)</li>
-            <li>Jim Allan (Invited Expert)</li>
-            <li>Paul Adam (Deque Systems, Inc.)</li>
-        	<li>Christopher Auclair (VitalSource | Ingram Content Group)</li>
-            <li>Jon Avila (Level Access)</li>
-            <li>Tom Babinszki (IBM Corporation)</li>
-            <li>Bruce Bailey (U.S. Access Board)</li>
-            <li>Renaldo Bernard (University of Southampton)</li>
-        	<li>Chris Blouch (Level Access)</li>
-        	<li>Denis Boudreau (Deque Systems, Inc.)</li>
-            <li>Judy Brewer (W3C)</li>
-            <li>Shari Butler (Pearson plc)</li>
-            <li>Thaddeus Cambron (Invited Expert)</li>
-            <li>Alastair Campbell (Nomensa)</li>
-            <li>Laura Carlson (Invited Expert)</li>
-            <li>Louis Cheng (Google)</li>
-            <li>Pietro Cirrincione (Invited Expert)</li>
-            <li>Vivienne Conway (Web Key IT Pty Ltd)</li>
-            <li>Michael Cooper (W3C)</li>
-            <li>Romain Deltour (DAISY Consortium)</li>
-            <li>Wayne Dick (Knowbility, Inc)</li>
-            <li>Chaohai Ding (University of Southampton)</li>
-            <li>Kim Dirks (Thompson Reuters)</li>
-            <li>Shwetank Dixit (BarrierBreak Technologies)</li>
-            <li>Anthony Doran (TextHelp)</li>
-            <li>E.A. Draffan (University of Southampton)</li>
-            <li>Eric Eggert (W3C)</li>
-            <li>Michael Elledge (Invited Expert)</li>
-            <li>Wilco Fiers (Deque Systems, Inc.)</li>
-            <li>Detlev Fischer (Invited Expert)</li>
-            <li>John Foliot (Deque Systems, Inc.)</li>
-            <li>Matt Garrish (DAISY Consortium)</li>
-            <li>Alistair Garrison (Level Access)</li>
-            <li>Michael Gower (IBM Corporation)</li>
-            <li>Jon Gunderson</li>
-            <li>Markku Hakkinen (Educational Testing Service)</li>
-            <li>Katie Haritos-Shea (Knowbility, Inc)</li>
-           	<li>Andy Heath (Invited Expert)</li>
-            <li>Shawn Henry (W3C)</li>
-            <li>Thomas Hoffman (Educational Testing Service)</li>
-            <li>Sarah Horton (The Paciello Group, LLC)</li>
-            <li>Stefan Johansson (Invited Expert)</li>
-            <li>Marc Johlic (IBM Corporation)</li>
-            <li>Rick Johnson (VitalSource | Ingram Content Group)</li>
-          	<li>Crystal Jones (Microsoft Corporation)</li>
-            <li>Andrew Kirkpatrick (Adobe)</li>
-            <li>John Kirkwood (Invited Expert)</li>
-            <li>Jason Kiss (Department of Internal Affairs, New Zealand Government)</li>
-            <li>Maureen Kraft (IBM Corporation)</li>
-            <li>JaEun Ku (University of Illinois at Urbana-Champaign)</li>
-            <li>Patrick Lauke (The Paciello Group, LLC)</li>
-            <li>Shawn Lauriat (Google, Inc.)</li>
-            <li>Steve Lee (Invited Expert)</li>
-          	<li>Alex Li (Microsoft Corporation)</li>
-          	<li>Chris Loiselle (Invited Expert)</li>
-            <li>Greg Lowney (Invited Expert)</li>
-            <li>Adam Lund (Thomson Reuters)</li>
-            <li>David MacDonald (Invited Expert)</li>
-            <li>Erich Manser (IBM Corporation)</li>
-        	<li>Kurt Mattes (Deque Systems, Inc.)</li>
-            <li>Scott McCormack (Level Access)</li>
-            <li>Chris McMeeking (Deque Systems, Inc.)</li>
-            <li>Jan McSorley (Pearson plc)</li>
-            <li>Neil Milliken (Unify Software and Solutions)</li>
-            <li>Rachael Montgomery (MITRE Corporation)</li>
-            <li>Mary Jo Mueller (IBM Corporation)</li>
-          	<li>Brooks Newton (Thomson Reuters)</li>
-            <li>James Nurthen (Oracle Corporation)</li>
-            <li>Joshue O Connor (Invited Expert)</li>
-            <li>Sailesh Panchang (Deque Systems, Inc.)</li>
-            <li>Charu Pandhi (IBM Corporation)</li>
-            <li>Kim Patch (Invited Expert)</li>
-        	<li>Melanie Philipp (Deque Systems, Inc.)</li>
-            <li>Mike Pluke (Invited Expert)</li>
-            <li>Ian Pouncey (The Paciello Group, LLC)</li>
-          	<li>Ruoxi Ran (W3C)</li>
-            <li>Stephen Repsher (The Boeing Company)</li>
-            <li>Jan Richards (Invited Expert)</li>
-            <li>John Rochford (Invited Expert)</li>
-            <li>Marla Runyan (Invited Expert)</li>
-        	<li>Stefan Schnabel (SAP SE)</li>
-            <li>Ayelet Seeman (Invited Expert)</li>
-            <li>Lisa Seeman-Kestenbaum (Invited Expert)</li>
-            <li>Glenda Sims (Deque Systems, Inc.)</li>
-          	<li>Avneesh Singh (DAISY Consortium)</li>
-            <li>David Sloan (The Paciello Group, LLC)</li>
-            <li>Alan Smith (Invited Expert)</li>
-            <li>Jim Smith (Unify Software and Solutions)</li>
-            <li>Adam Solomon (Invited Expert)</li>
-            <li>Jaeil Song (National Information Society Agency (NIA))</li>
-            <li>Jeanne Spellman (The Paciello Group, LLC)</li>
-            <li>Makoto Ueki (Invited Expert)</li>
-        	<li>Jatin Vaishnav (Deque Systems, Inc.)</li>
-            <li>Gregg Vanderheiden (Raising the Floor)</li>
-            <li>Evangelos Vlachogiannis (Fraunhofer Gesellschaft)</li>
-            <li>Kathleen Wahlbin (Invited Expert)</li>
-            <li>Can Wang (Zhejiang University)</li>
-            <li>Léonie Watson (The Paciello Group, LLC)</li>
-            <li>Jason White (Educational Testing Service)</li>
-        	<li>Mark Wilcock (Unify Software and Solutions)</li>
+         <li>Jake Abma (Invited Expert)</li>
+         <li>Shadi Abou-Zahra (W3C)</li>
+         <li>Chuck Adams (Oracle Corporation)</li>
+         <li>Amani Ali (Nomensa)</li>
+         <li>Jim Allan (Invited Expert)</li>
+         <li>Paul Adam (Deque Systems, Inc.)</li>
+         <li>Christopher Auclair (VitalSource | Ingram Content Group)</li>
+         <li>Jon Avila (Level Access)</li>
+         <li>Tom Babinszki (IBM Corporation)</li>
+         <li>Bruce Bailey (U.S. Access Board)</li>
+         <li>Renaldo Bernard (University of Southampton)</li>
+         <li>Chris Blouch (Level Access)</li>
+         <li>Denis Boudreau (Deque Systems, Inc.)</li>
+         <li>Judy Brewer (W3C)</li>
+         <li>Shari Butler (Pearson plc)</li>
+         <li>Thaddeus Cambron (Invited Expert)</li>
+         <li>Alastair Campbell (Nomensa)</li>
+         <li>Laura Carlson (Invited Expert)</li>
+         <li>Louis Cheng (Google)</li>
+         <li>Pietro Cirrincione (Invited Expert)</li>
+         <li>Vivienne Conway (Web Key IT Pty Ltd)</li>
+         <li>Michael Cooper (W3C)</li>
+         <li>Jennifer Delisi (Invited Expert)</li>
+         <li>Romain Deltour (DAISY Consortium)</li>
+         <li>Wayne Dick (Knowbility, Inc)</li>
+         <li>Chaohai Ding (University of Southampton)</li>
+         <li>Kim Dirks (Thomson Reuters)</li>
+         <li>Shwetank Dixit (BarrierBreak Technologies)</li>
+         <li>Anthony Doran (TextHelp)</li>
+         <li>E.A. Draffan (University of Southampton)</li>
+         <li>Eric Eggert (W3C)</li>
+         <li>Michael Elledge (Invited Expert)</li>
+         <li>David Fazio (Invited Expert)</li>
+         <li>Wilco Fiers (Deque Systems, Inc.)</li>
+         <li>Detlev Fischer (Invited Expert)</li>
+         <li>John Foliot (Deque Systems, Inc.)</li>
+         <li>Matt Garrish (DAISY Consortium)</li>
+         <li>Alistair Garrison (Level Access)</li>
+         <li>Michael Gower (IBM Corporation)</li>
+         <li>Jon Gunderson</li>
+         <li>Markku Hakkinen (Educational Testing Service)</li>
+         <li>Katie Haritos-Shea (Knowbility, Inc)</li>
+         <li>Andy Heath (Invited Expert)</li>
+         <li>Shawn Henry (W3C)</li>
+         <li>Thomas Hoffman (Educational Testing Service)</li>
+         <li>Sarah Horton (The Paciello Group, LLC)</li>
+         <li>Stefan Johansson (Invited Expert)</li>
+         <li>Marc Johlic (IBM Corporation)</li>
+         <li>Rick Johnson (VitalSource | Ingram Content Group)</li>
+         <li>Crystal Jones (Microsoft Corporation)</li>
+         <li>Andrew Kirkpatrick (Adobe)</li>
+         <li>John Kirkwood (Invited Expert)</li>
+         <li>Jason Kiss (Department of Internal Affairs, New Zealand Government)</li>
+         <li>Maureen Kraft (IBM Corporation)</li>
+         <li>JaEun Ku (University of Illinois at Urbana-Champaign)</li>
+         <li>Patrick Lauke (The Paciello Group, LLC)</li>
+         <li>Shawn Lauriat (Google, Inc.)</li>
+         <li>Steve Lee (Invited Expert)</li>
+         <li>Alex Li (Microsoft Corporation)</li>
+         <li>Chris Loiselle (Invited Expert)</li>
+         <li>Greg Lowney (Invited Expert)</li>
+         <li>Adam Lund (Thomson Reuters)</li>
+         <li>David MacDonald (Invited Expert)</li>
+         <li>Erich Manser (IBM Corporation)</li>
+         <li>Kurt Mattes (Deque Systems, Inc.)</li>
+         <li>Scott McCormack (Level Access)</li>
+         <li>Chris McMeeking (Deque Systems, Inc.)</li>
+         <li>Jan McSorley (Pearson plc)</li>
+         <li>Neil Milliken (Unify Software and Solutions)</li>
+         <li>Rachael Montgomery (Invited Expert)</li>
+         <li>Mary Jo Mueller (IBM Corporation)</li>
+         <li>Brooks Newton (Thomson Reuters)</li>
+         <li>James Nurthen (Oracle Corporation)</li>
+         <li>Joshue O Connor (Invited Expert)</li>
+         <li>Sailesh Panchang (Deque Systems, Inc.)</li>
+         <li>Charu Pandhi (IBM Corporation)</li>
+         <li>Kim Patch (Invited Expert)</li>
+         <li>Melanie Philipp (Deque Systems, Inc.)</li>
+         <li>Mike Pluke (Invited Expert)</li>
+         <li>Ian Pouncey (The Paciello Group, LLC)</li>
+         <li>Ruoxi Ran (W3C)</li>
+         <li>Stephen Repsher (Invited Expert)</li>
+         <li>Jan Richards (Invited Expert)</li>
+         <li>John Rochford (Invited Expert)</li>
+         <li>Marla Runyan (Invited Expert)</li>
+         <li>Stefan Schnabel (SAP SE)</li>
+         <li>Ayelet Seeman (Invited Expert)</li>
+         <li>Lisa Seeman-Kestenbaum (Invited Expert)</li>
+         <li>Glenda Sims (Deque Systems, Inc.)</li>
+         <li>Avneesh Singh (DAISY Consortium)</li>
+         <li>David Sloan (The Paciello Group, LLC)</li>
+         <li>Alan Smith (Invited Expert)</li>
+         <li>Jim Smith (Unify Software and Solutions)</li>
+         <li>Andrew Somers (Invited Expert)</li>
+         <li>Adam Solomon (Invited Expert)</li>
+         <li>Jaeil Song (National Information Society Agency (NIA))</li>
+         <li>Jeanne Spellman (The Paciello Group, LLC)</li>
+         <li>Makoto Ueki (Invited Expert)</li>
+         <li>Jatin Vaishnav (Deque Systems, Inc.)</li>
+         <li>Gregg Vanderheiden (Raising the Floor)</li>
+         <li>Evangelos Vlachogiannis (Fraunhofer Gesellschaft)</li>
+         <li>Kathleen Wahlbin (Invited Expert)</li>
+         <li>Can Wang (Zhejiang University)</li>
+         <li>Léonie Watson (The Paciello Group, LLC)</li>
+         <li>Jason White (Educational Testing Service)</li>
+         <li>Mark Wilcock (Unify Software and Solutions)</li>
         </ul>
     </section>
 


### PR DESCRIPTION
Close #1077

解説書の表紙を2020年12月2日版に更新します

- 現状の原文（この版の原文と一致しないことに注意）
  - https://www.w3.org/WAI/WCAG21/Understanding/
- 差分
  - [index.htmlの差分](https://github.com/waic/w3c-wcag/compare/433b1cf...1a05939#diff-ce698577a94baf8cbf90a9882b8bed4991fb573fccc6839e5d67240154c46da6)
- 現時点のWAIC公開サーバーの解説書
  - https://waic.jp/docs/WCAG21/Understanding/

## 更新内容

- 日付の更新
- 謝辞の更新
