### PR TITLE
5.3.1 適合表明 の修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2550,7 +2550,7 @@ details.respec-tests-details > li {
                     <p>適合表明は、<strong>必須ではない</strong>。コンテンツ制作者は、適合表明をしなくても、WCAG 2.1 に適合することができる。しかし、もし適合表明をする場合には、その適合表明には以下の情報が含まれてい<strong>なければならない</strong>:</p>
                     <ol>
                         <li>表明<strong>日</strong></li>
-                        <li><strong>ガイドライン名、バージョン、及び URI</strong> "Web Content Accessibility Guidelines 2.1 at <a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>" <span class="ednote">In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec.</span></li>
+                        <li><strong>ガイドライン名、バージョン、及び URI</strong> "Web Content Accessibility Guidelines 2.1 (<a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>)"</li>
                         <li>満たしている<strong>適合レベル</strong>: (レベル A、AA、又は AAA)</li>
                         <li>
                             <p>対象となる<strong>ウェブページに関する簡潔な説明</strong>: 例えば、サブドメインも表明の対象に含まれているかどうかも含む、表明の対象となっている URI のリスト。</p>


### PR DESCRIPTION
ドラフト編集時のメモの消し忘れと思われる <span class="ednote"> を削除しました。また、URI 表記のしかたとして、英語の前置詞 at を日本語版読者は用いないと思いましたので、URI を括弧で括る形に変更してみました。

# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

