### PR TITLE
PDF3で英文の削除忘れとリンク先がWCAG20になっていた箇所があったので、修正しました。

### DIFF
--- a/techniques/pdf/PDF3.html
+++ b/techniques/pdf/PDF3.html
@@ -93,9 +93,8 @@
                   
                   
                </figure>
-               <p class="working-example">This example is shown in operation in the <a href="../../working-examples/pdf-reading-order/reading-order-2cols-word.docx">working example of 2-column document using Word 2007 (Word file)</a> and <a href="../../working-examples/pdf-reading-order/reading-order-2cols-word.pdf">working example of 2-column document using Word 2007 (PDF file)</a>.
-                 この事例のサンプルとして、<a href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/PDF3/reading-order-2cols-word.docx">Word 2007 を使用した 2 段組み文書のサンプル (Word ファイル)</a> と </a href-"https://www.w3.org/WAI/WCAG20/Techniques/working-examples/PDF3/reading-order-2cols-word.pdf">Word 2007 を使用した 2 段組み文書のサンプル (PDF ファイル)</a> がある。
-               </p>
+               <p class="working-example">この事例のサンプルとして、<a href="https://www.w3.org/WAI/WCAG21/working-examples/pdf-reading-order/reading-order-2cols-word.docx">Word 2007 を使用した 2 段組み文書のサンプル (Word ファイル)</a> と <a href-"https://www.w3.org/WAI/WCAG21/working-examples/pdf-reading-order/reading-order-2cols-word.pdf">Word 2007 を使用した 2 段組み文書のサンプル (PDF ファイル)</a> がある。
+                                </p>
             </section>
             <section class="example" id="example-2-creating-a-2-column-document-using-openoffice.org-writer&#xA;----&#x9;&#x9;&#x9;&#x9;2.2">
                <h3>事例 2: OpenOffice.org Writer 2.2 を使用して 2 段組みの文書を作成する
@@ -119,7 +118,7 @@
                   
                   
                </figure>
-               <p class="working-example">この事例のサンプルとして、<a href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/PDF3/reading-order-2cols-oo.odt">OpenOffice Writer を使用した 2 段組み文書のサンプル (OpenOffice ファイル)</a> と <a href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/PDF3/reading-order-2cols-oo.pdf">OpenOffice Writer を使用した 2 段組み文書のサンプル (PDF ファイル)</a> がある。
+               <p class="working-example">この事例のサンプルとして、<a href="https://www.w3.org/WAI/WCAG21/working-examples/pdf-reading-order/reading-order-2cols-oo.odt">OpenOffice Writer を使用した 2 段組み文書のサンプル (OpenOffice ファイル)</a> と <a href="https://www.w3.org/WAI/WCAG21/working-examples/pdf-reading-order/reading-order-2cols-oo.pdf">OpenOffice Writer を使用した 2 段組み文書のサンプル (PDF ファイル)</a> がある。
                </p>
             </section>
             <section class="example" id="example-3-setting-the-tab-order-for-one-or-more-pages-using-adobe&#xA;----&#x9;&#x9;&#x9;&#x9;acrobat-9-pro">
@@ -245,7 +244,7 @@
                   
                   
                </figure>
-               <p class="working-example">この事例のサンプルとして、<a href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/PDF3/reading-order.docx">タブ順序設定のサンプル (Word ファイル)</a> と <a href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/PDF3/reading-order.pdf">タブ順序設定のサンプル (PDF ファイル)</a> がある。
+               <p class="working-example">この事例のサンプルとして、<a href="https://www.w3.org/WAI/WCAG21/working-examples/pdf-reading-order/reading-order.docx">タブ順序設定のサンプル (Word ファイル)</a> と <a href="https://www.w3.org/WAI/WCAG21/working-examples/pdf-reading-order/reading-order.pdf">タブ順序設定のサンプル (PDF ファイル)</a> がある。
                </p>
             </section>
             <section class="example" id="example-4-repairing-the-reading-order-using-the-tags-panel-in-adobe&#xA;----&#x9;&#x9;&#x9;&#x9;acrobat-9-pro">


### PR DESCRIPTION
PDF3を見返していたところ、英文の削除忘れとリンク先がWCAG20になっていた箇所があったので、修正しました。
ご面倒をおかけしてすいません。

# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

