### PR TITLE
ガイドライン 3.1「読みやすさ」を「読み取り可能」に修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -727,7 +727,7 @@ details.respec-tests-details > li {
               <ol class="toc">
                 <li class="tocline">
                   <a href="#readable" class="tocxref"><span class=
-                  "secno">3.1</span> 読みやすさ</a>
+                  "secno">3.1</span> 読み取り可能</a>
                   <ol class="toc">
                     <li class="tocline">
                       <a href="#language-of-page" class="tocxref"><span class=
@@ -2204,8 +2204,8 @@ details.respec-tests-details > li {
             <p>情報及びユーザインタフェースの操作は理解可能でなければならない。</p>
 
             <section class="guideline" id="readable">
-                <h3 id="x3-1-readable"><span class="secno">ガイドライン 3.1 </span>読みやすさ<span class="permalink"><a href="#readable" aria-label="Permalink for 3.1 Readable" title="Permalink for 3.1 Readable"><span>§</span></a></span></h3>
-                <p>テキストのコンテンツを読みやすく理解可能にすること。</p>
+                <h3 id="x3-1-readable"><span class="secno">ガイドライン 3.1 </span>読み取り可能<span class="permalink"><a href="#readable" aria-label="Permalink for 3.1 Readable" title="Permalink for 3.1 Readable"><span>§</span></a></span></h3>
+                <p>テキストコンテンツの読み取りと理解を可能にすること。</p>
 
                 <section class="sc" id="language-of-page">
    

--- a/understanding/abbreviations.html
+++ b/understanding/abbreviations.html
@@ -11,7 +11,7 @@
       <nav>
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
-            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
             <li><a href="unusual-words.html">Previous <abbr title="Success Criterion">SC</abbr>: 一般的ではない用語</a></li>
             <li><a href="reading-level.html">Next <abbr title="Success Criterion">SC</abbr>: 読解レベル</a></li>
          </ul>

--- a/understanding/index.html
+++ b/understanding/index.html
@@ -243,7 +243,7 @@
          </ol>
       </li>
       <li class="tocline">理解可能<ol class="toc">
-            <li class="tocline"><a href="readable.html" class="tocxref"><span class="secno">3.1</span> 読みやすさ</a><ol class="toc">
+            <li class="tocline"><a href="readable.html" class="tocxref"><span class="secno">3.1</span> 読み取り可能</a><ol class="toc">
                   <li class="tocline"><a href="language-of-page.html" class="tocxref"><span class="secno">3.1.1</span> ページの言語</a></li>
                   <li class="tocline"><a href="language-of-parts.html" class="tocxref"><span class="secno">3.1.2</span> 一部分の言語</a></li>
                   <li class="tocline"><a href="unusual-words.html" class="tocxref"><span class="secno">3.1.3</span> 一般的ではない用語</a></li>

--- a/understanding/input-modalities.html
+++ b/understanding/input-modalities.html
@@ -13,7 +13,7 @@
             <li><a href="." title="目次">目次</a></li>
             <li><a href="navigable.html">Previous <abbr title="Guideline">GL</abbr>: ナビゲーション可能</a></li>
             <li><a href="pointer-gestures.html">First <abbr title="Success Criterion">SC</abbr>: ポインタのジェスチャ</a></li>
-            <li><a href="readable.html">Next <abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html">Next <abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
          </ul>
       </nav>
       <nav class="navtoc">

--- a/understanding/language-of-page.html
+++ b/understanding/language-of-page.html
@@ -11,7 +11,7 @@
       <nav>
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
-            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
             <li><a href="concurrent-input-mechanisms.html">Previous <abbr title="Success Criterion">SC</abbr>: 入力メカニズム非依存</a></li>
             <li><a href="language-of-parts.html">Next <abbr title="Success Criterion">SC</abbr>: 一部分の言語</a></li>
          </ul>

--- a/understanding/language-of-parts.html
+++ b/understanding/language-of-parts.html
@@ -11,7 +11,7 @@
       <nav>
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
-            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
             <li><a href="language-of-page.html">Previous <abbr title="Success Criterion">SC</abbr>: ページの言語</a></li>
             <li><a href="unusual-words.html">Next <abbr title="Success Criterion">SC</abbr>: 一般的ではない用語</a></li>
          </ul>

--- a/understanding/predictable.html
+++ b/understanding/predictable.html
@@ -11,7 +11,7 @@
       <nav>
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
-            <li><a href="readable.html">Previous <abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html">Previous <abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
             <li><a href="on-focus.html">First <abbr title="Success Criterion">SC</abbr>: フォーカス時</a></li>
             <li><a href="input-assistance.html">Next <abbr title="Guideline">GL</abbr>: 入力支援</a></li>
          </ul>

--- a/understanding/pronunciation.html
+++ b/understanding/pronunciation.html
@@ -11,7 +11,7 @@
       <nav>
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
-            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
             <li><a href="reading-level.html">Previous <abbr title="Success Criterion">SC</abbr>: 読解レベル</a></li>
             <li><a href="on-focus.html">Next <abbr title="Success Criterion">SC</abbr>: フォーカス時</a></li>
          </ul>

--- a/understanding/readable.html
+++ b/understanding/readable.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja">
    <head>
       <meta charset="UTF-8" />
-      <title>ガイドライン 3.1: 読みやすさを理解する</title>
+      <title>ガイドライン 3.1: 読み取り可能を理解する</title>
       <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base" />
       <link rel="stylesheet" type="text/css" href="understanding.css" />
       <link rel="stylesheet" type="text/css" href="slicenav.css" />
@@ -23,9 +23,9 @@
             <li><a href="#success-criteria">達成基準</a></li>
          </ul>
       </nav>
-      <h1>ガイドライン 3.1: 読みやすさを理解する</h1>
+      <h1>ガイドライン 3.1: 読み取り可能を理解する</h1>
       <blockquote class="scquote">
-         <p>ガイドライン <a href="https://waic.jp/docs/WCAG21/#readable" style="font-weight: bold;">3.1 読みやすさ</a>: テキストのコンテンツを読みやすく理解可能にすること。</p>
+         <p>ガイドライン <a href="https://waic.jp/docs/WCAG21/#readable" style="font-weight: bold;">3.1 読み取り可能</a>: テキストコンテンツの読み取りと理解を可能にすること。</p>
       </blockquote>
       <main>
          <section id="intent">

--- a/understanding/reading-level.html
+++ b/understanding/reading-level.html
@@ -11,7 +11,7 @@
       <nav>
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
-            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
             <li><a href="abbreviations.html">Previous <abbr title="Success Criterion">SC</abbr>: 略語</a></li>
             <li><a href="pronunciation.html">Next <abbr title="Success Criterion">SC</abbr>: 発音</a></li>
          </ul>

--- a/understanding/unusual-words.html
+++ b/understanding/unusual-words.html
@@ -11,7 +11,7 @@
       <nav>
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
-            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読みやすさ</a></li>
+            <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
             <li><a href="language-of-parts.html">Previous <abbr title="Success Criterion">SC</abbr>: 一部分の言語</a></li>
             <li><a href="abbreviations.html">Next <abbr title="Success Criterion">SC</abbr>: 略語</a></li>
          </ul>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

