### PR TITLE
guidelines/index.htmlの#dfn-user-agentを#dfn-user-agentsに統一

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2451,7 +2451,7 @@ details.respec-tests-details > li {
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html">Understanding Name, Role, Value</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#name-role-value">How to Meet Name, Role, Value</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>すべての<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> 及び<a href="#dfn-role" class="internalDFN" data-link-type="dfn">役割 (role)</a> は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" class="internalDFN" data-link-type="dfn">プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。
+   <p>すべての<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> 及び<a href="#dfn-role" class="internalDFN" data-link-type="dfn">役割 (role)</a> は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" class="internalDFN" data-link-type="dfn">プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。
    </p>
    
    <div class="note" id="issue-container-generatedID-27"><div role="heading" class="note-title marker" id="h-note-27" aria-level="5"><span>注記</span></div><p class="">この達成基準は、主に独自のユーザインタフェース コンポーネントを開発、又はスクリプトで実装するコンテンツ制作者に向けたものである。例えば、標準的な HTML のコントロールを仕様に沿って使用していれば、既にこの達成基準を満たしていることになる。
@@ -2653,7 +2653,7 @@ details.respec-tests-details > li {
                 <dt><dfn data-lt="accessibility-supported|accessibility support|accessibility supported" data-dfn-type="dfn" id="dfn-accessibility-supported">アクセシビリティ サポーテッド (accessibility supported)</dfn></dt>
 <dd>
    
-   <p>利用者の<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>と、ブラウザ及びその他の<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+   <p>利用者の<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>と、ブラウザ及びその他の<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
    
    <p>あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と 2.の両方が満たされていなければならない:
    </p>
@@ -2773,7 +2773,7 @@ details.respec-tests-details > li {
                 <dt>(この文書で用いられている) <dfn data-lt="assistive technologies|assistive technology" data-dfn-type="dfn" id="dfn-assistive-technologies">支援技術</dfn> (assistive technology (as used in this document))
 </dt>
 <dd>
-   <p><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>としてふるまうか、もしくは主流のユーザエージェントと共に用いられ、障害のある利用者が必要とする、主流のユーザエージェントが提供する以上の機能を提供するためのハードウェア及び／又はソフトウェア。</p>
+   <p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>としてふるまうか、もしくは主流のユーザエージェントと共に用いられ、障害のある利用者が必要とする、主流のユーザエージェントが提供する以上の機能を提供するためのハードウェア及び／又はソフトウェア。</p>
    
    <div class="note" id="issue-container-generatedID-48"><div role="heading" class="note-title marker" id="h-note-48" aria-level="3"><span>注記</span></div><p class="">支援技術が提供する機能としては、代替の提示 (例: 合成音声や拡大表示したコンテンツ)、代替入力手法 (例: 音声認識)、付加的なナビゲーション又は位置確認のメカニズム、及びコンテンツ変換 (例: テーブルをよりアクセシブルにするもの) などを挙げることができる。
    </p></div>
@@ -2918,7 +2918,7 @@ details.respec-tests-details > li {
    
    <ol>
       
-      <li><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>
+      <li><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>
       </li>
       
       <li><a href="#dfn-viewport" class="internalDFN" data-link-type="dfn">ビューポート</a>
@@ -3010,7 +3010,7 @@ details.respec-tests-details > li {
 </dt>
 <dd>
    
-   <p><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>によって利用者に伝達される情報及び感覚的な体験。コンテンツの<a href="#dfn-structure" class="internalDFN" data-link-type="dfn">構造</a>、<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>、及びインタラクションを定義するコードやマークアップを含む。
+   <p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>によって利用者に伝達される情報及び感覚的な体験。コンテンツの<a href="#dfn-structure" class="internalDFN" data-link-type="dfn">構造</a>、<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>、及びインタラクションを定義するコードやマークアップを含む。
    </p>
    
 </dd>
@@ -3388,7 +3388,7 @@ details.respec-tests-details > li {
    <p>結果を得るための<a href="#dfn-processes" class="internalDFN" data-link-type="dfn">プロセス</a>又は手法。
    </p>
    
-   <div class="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class="">メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>で提供されるものに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>することもある。
+   <div class="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class="">メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>で提供されるものに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>することもある。
    </p></div>
    
    <div class="note" id="issue-container-generatedID-106"><div role="heading" class="note-title marker" id="h-note-106" aria-level="3"><span>注記</span></div><p class="">メカニズムは、宣言する適合レベルのすべての達成基準を満たしている必要がある。</p></div>
@@ -3538,7 +3538,7 @@ details.respec-tests-details > li {
 </dt>
 <dd>
    
-   <p><a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む様々な<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。
+   <p><a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む様々な<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。
    </p>
    
    <div class="note" id="issue-container-generatedID-115"><div role="heading" class="note-title marker" id="h-note-115" aria-level="3"><span>注記</span></div><p class="">マークアップ言語で、一般に入手可能な支援技術が直接アクセスできる要素と属性から解釈される。
@@ -3879,7 +3879,7 @@ details.respec-tests-details > li {
 </dt>
 <dd>
    
-   <p><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>。</p>
+   <p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>。</p>
    
    <div class="note" id="issue-container-generatedID-130"><div role="heading" class="note-title marker" id="h-note-130" aria-level="3"><span>注記</span></div><p class="">このガイドラインで用いられている「ウェブ技術」及び (単独で用いられている) 「技術」という用語は、どちらもウェブコンテンツ技術を指す。
    </p></div>
@@ -4010,7 +4010,7 @@ details.respec-tests-details > li {
    
    <p>ユーザエージェントがコンテンツを提示するオブジェクト。</p>
    
-   <div class="note" id="issue-container-generatedID-139"><div role="heading" class="note-title marker" id="h-note-139" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>は、一つ以上のビューポートでコンテンツを提示する。ビューポートには、ウィンドウ、フレーム、スピーカー、拡大鏡ソフトなどがある。ビューポートは、他のビューポートを含んでいることがある (例えば、入れ子のフレーム)。プロンプト、メニュー、アラートのように、ユーザエージェントが作成するインタフェース コンポーネントは、ビューポートではない。
+   <div class="note" id="issue-container-generatedID-139"><div role="heading" class="note-title marker" id="h-note-139" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>は、一つ以上のビューポートでコンテンツを提示する。ビューポートには、ウィンドウ、フレーム、スピーカー、拡大鏡ソフトなどがある。ビューポートは、他のビューポートを含んでいることがある (例えば、入れ子のフレーム)。プロンプト、メニュー、アラートのように、ユーザエージェントが作成するインタフェース コンポーネントは、ビューポートではない。
    </p></div>
    
    <div class="note" id="issue-container-generatedID-140"><div role="heading" class="note-title marker" id="h-note-140" aria-level="3"><span>注記</span></div><p class="">この定義は、<a href="https://www.w3.org/TR/WAI-USERAGENT/glossary.html">User Agent Accessibility Guidelines 1.0 Glossary</a> [<cite><a class="bibref" href="#bib-UAAG10">UAAG10</a></cite>]をもとにしている。
@@ -4029,7 +4029,7 @@ details.respec-tests-details > li {
                 <dt><dfn data-lt="web page(s)|web pages|web page" data-dfn-type="dfn" id="dfn-web-page-s">ウェブページ (Web page)</dfn></dt>
 <dd>
    
-   <p>単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+   <p>単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
    
    <div class="note" id="issue-container-generatedID-141"><div role="heading" class="note-title marker" id="h-note-141" aria-level="3"><span>注記</span></div><p class="">どのような「その他のリソース」も主たるリソースと一緒にレンダリングされるであろうが、これらのリソースが同時にレンダリングされるとは限らない。
    </p></div>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2451,7 +2451,7 @@ details.respec-tests-details > li {
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html">Understanding Name, Role, Value</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#name-role-value">How to Meet Name, Role, Value</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>すべての<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> 及び<a href="#dfn-role" class="internalDFN" data-link-type="dfn">役割 (role)</a> は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" class="internalDFN" data-link-type="dfn">プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。
+   <p>すべての<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> 及び<a href="#dfn-role" class="internalDFN" data-link-type="dfn">役割 (role)</a> は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" class="internalDFN" data-link-type="dfn">プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。
    </p>
    
    <div class="note" id="issue-container-generatedID-27"><div role="heading" class="note-title marker" id="h-note-27" aria-level="5"><span>注記</span></div><p class="">この達成基準は、主に独自のユーザインタフェース コンポーネントを開発、又はスクリプトで実装するコンテンツ制作者に向けたものである。例えば、標準的な HTML のコントロールを仕様に沿って使用していれば、既にこの達成基準を満たしていることになる。
@@ -2653,7 +2653,7 @@ details.respec-tests-details > li {
                 <dt><dfn data-lt="accessibility-supported|accessibility support|accessibility supported" data-dfn-type="dfn" id="dfn-accessibility-supported">アクセシビリティ サポーテッド (accessibility supported)</dfn></dt>
 <dd>
    
-   <p>利用者の<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>と、ブラウザ及びその他の<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+   <p>利用者の<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>と、ブラウザ及びその他の<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
    
    <p>あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と 2.の両方が満たされていなければならない:
    </p>
@@ -2773,7 +2773,7 @@ details.respec-tests-details > li {
                 <dt>(この文書で用いられている) <dfn data-lt="assistive technologies|assistive technology" data-dfn-type="dfn" id="dfn-assistive-technologies">支援技術</dfn> (assistive technology (as used in this document))
 </dt>
 <dd>
-   <p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>としてふるまうか、もしくは主流のユーザエージェントと共に用いられ、障害のある利用者が必要とする、主流のユーザエージェントが提供する以上の機能を提供するためのハードウェア及び／又はソフトウェア。</p>
+   <p><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>としてふるまうか、もしくは主流のユーザエージェントと共に用いられ、障害のある利用者が必要とする、主流のユーザエージェントが提供する以上の機能を提供するためのハードウェア及び／又はソフトウェア。</p>
    
    <div class="note" id="issue-container-generatedID-48"><div role="heading" class="note-title marker" id="h-note-48" aria-level="3"><span>注記</span></div><p class="">支援技術が提供する機能としては、代替の提示 (例: 合成音声や拡大表示したコンテンツ)、代替入力手法 (例: 音声認識)、付加的なナビゲーション又は位置確認のメカニズム、及びコンテンツ変換 (例: テーブルをよりアクセシブルにするもの) などを挙げることができる。
    </p></div>
@@ -2918,7 +2918,7 @@ details.respec-tests-details > li {
    
    <ol>
       
-      <li><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>
+      <li><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>
       </li>
       
       <li><a href="#dfn-viewport" class="internalDFN" data-link-type="dfn">ビューポート</a>
@@ -3010,7 +3010,7 @@ details.respec-tests-details > li {
 </dt>
 <dd>
    
-   <p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>によって利用者に伝達される情報及び感覚的な体験。コンテンツの<a href="#dfn-structure" class="internalDFN" data-link-type="dfn">構造</a>、<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>、及びインタラクションを定義するコードやマークアップを含む。
+   <p><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>によって利用者に伝達される情報及び感覚的な体験。コンテンツの<a href="#dfn-structure" class="internalDFN" data-link-type="dfn">構造</a>、<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>、及びインタラクションを定義するコードやマークアップを含む。
    </p>
    
 </dd>
@@ -3388,7 +3388,7 @@ details.respec-tests-details > li {
    <p>結果を得るための<a href="#dfn-processes" class="internalDFN" data-link-type="dfn">プロセス</a>又は手法。
    </p>
    
-   <div class="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class="">メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>で提供されるものに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>することもある。
+   <div class="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class="">メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>で提供されるものに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>することもある。
    </p></div>
    
    <div class="note" id="issue-container-generatedID-106"><div role="heading" class="note-title marker" id="h-note-106" aria-level="3"><span>注記</span></div><p class="">メカニズムは、宣言する適合レベルのすべての達成基準を満たしている必要がある。</p></div>
@@ -3538,7 +3538,7 @@ details.respec-tests-details > li {
 </dt>
 <dd>
    
-   <p><a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む様々な<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。
+   <p><a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む様々な<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。
    </p>
    
    <div class="note" id="issue-container-generatedID-115"><div role="heading" class="note-title marker" id="h-note-115" aria-level="3"><span>注記</span></div><p class="">マークアップ言語で、一般に入手可能な支援技術が直接アクセスできる要素と属性から解釈される。
@@ -3879,7 +3879,7 @@ details.respec-tests-details > li {
 </dt>
 <dd>
    
-   <p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>。</p>
+   <p><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>。</p>
    
    <div class="note" id="issue-container-generatedID-130"><div role="heading" class="note-title marker" id="h-note-130" aria-level="3"><span>注記</span></div><p class="">このガイドラインで用いられている「ウェブ技術」及び (単独で用いられている) 「技術」という用語は、どちらもウェブコンテンツ技術を指す。
    </p></div>
@@ -4010,7 +4010,7 @@ details.respec-tests-details > li {
    
    <p>ユーザエージェントがコンテンツを提示するオブジェクト。</p>
    
-   <div class="note" id="issue-container-generatedID-139"><div role="heading" class="note-title marker" id="h-note-139" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>は、一つ以上のビューポートでコンテンツを提示する。ビューポートには、ウィンドウ、フレーム、スピーカー、拡大鏡ソフトなどがある。ビューポートは、他のビューポートを含んでいることがある (例えば、入れ子のフレーム)。プロンプト、メニュー、アラートのように、ユーザエージェントが作成するインタフェース コンポーネントは、ビューポートではない。
+   <div class="note" id="issue-container-generatedID-139"><div role="heading" class="note-title marker" id="h-note-139" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>は、一つ以上のビューポートでコンテンツを提示する。ビューポートには、ウィンドウ、フレーム、スピーカー、拡大鏡ソフトなどがある。ビューポートは、他のビューポートを含んでいることがある (例えば、入れ子のフレーム)。プロンプト、メニュー、アラートのように、ユーザエージェントが作成するインタフェース コンポーネントは、ビューポートではない。
    </p></div>
    
    <div class="note" id="issue-container-generatedID-140"><div role="heading" class="note-title marker" id="h-note-140" aria-level="3"><span>注記</span></div><p class="">この定義は、<a href="https://www.w3.org/TR/WAI-USERAGENT/glossary.html">User Agent Accessibility Guidelines 1.0 Glossary</a> [<cite><a class="bibref" href="#bib-UAAG10">UAAG10</a></cite>]をもとにしている。
@@ -4029,7 +4029,7 @@ details.respec-tests-details > li {
                 <dt><dfn data-lt="web page(s)|web pages|web page" data-dfn-type="dfn" id="dfn-web-page-s">ウェブページ (Web page)</dfn></dt>
 <dd>
    
-   <p>単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+   <p>単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="#dfn-user-agent" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
    
    <div class="note" id="issue-container-generatedID-141"><div role="heading" class="note-title marker" id="h-note-141" aria-level="3"><span>注記</span></div><p class="">どのような「その他のリソース」も主たるリソースと一緒にレンダリングされるであろうが、これらのリソースが同時にレンダリングされるとは限らない。
    </p></div>

--- a/understanding/abbreviations.html
+++ b/understanding/abbreviations.html
@@ -311,7 +311,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
 
                   </div>
                   

--- a/understanding/abbreviations.html
+++ b/understanding/abbreviations.html
@@ -311,7 +311,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
 
                   </div>
                   

--- a/understanding/abbreviations.html
+++ b/understanding/abbreviations.html
@@ -311,7 +311,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
 
                   </div>
                   

--- a/understanding/audio-control.html
+++ b/understanding/audio-control.html
@@ -117,7 +117,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent" target="terms">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents" target="terms">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
 
                   </div>
                   

--- a/understanding/audio-control.html
+++ b/understanding/audio-control.html
@@ -117,7 +117,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent" target="terms">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents" target="terms">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
 
                   </div>
                   

--- a/understanding/audio-control.html
+++ b/understanding/audio-control.html
@@ -117,7 +117,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents" target="terms">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent" target="terms">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
 
                   </div>
                   

--- a/understanding/bypass-blocks.html
+++ b/understanding/bypass-blocks.html
@@ -184,7 +184,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   
@@ -199,7 +199,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/bypass-blocks.html
+++ b/understanding/bypass-blocks.html
@@ -184,7 +184,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   
@@ -199,7 +199,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/bypass-blocks.html
+++ b/understanding/bypass-blocks.html
@@ -184,7 +184,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   
@@ -199,7 +199,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/change-on-request.html
+++ b/understanding/change-on-request.html
@@ -268,7 +268,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -301,7 +301,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/change-on-request.html
+++ b/understanding/change-on-request.html
@@ -268,7 +268,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -301,7 +301,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/change-on-request.html
+++ b/understanding/change-on-request.html
@@ -268,7 +268,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -301,7 +301,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/character-key-shortcuts.html
+++ b/understanding/character-key-shortcuts.html
@@ -154,7 +154,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/character-key-shortcuts.html
+++ b/understanding/character-key-shortcuts.html
@@ -154,7 +154,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/character-key-shortcuts.html
+++ b/understanding/character-key-shortcuts.html
@@ -154,7 +154,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -1074,7 +1074,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
                   
                   
                   <p xmlns="http://www.w3.org/1999/xhtml">あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と2.の両方が満たされていなければならない:</p>
@@ -1305,7 +1305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -1327,7 +1327,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -1074,7 +1074,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
                   
                   
                   <p xmlns="http://www.w3.org/1999/xhtml">あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と2.の両方が満たされていなければならない:</p>
@@ -1305,7 +1305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -1327,7 +1327,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -1074,7 +1074,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
                   
                   
                   <p xmlns="http://www.w3.org/1999/xhtml">あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と2.の両方が満たされていなければならない:</p>
@@ -1305,7 +1305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -1327,7 +1327,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/consistent-navigation.html
+++ b/understanding/consistent-navigation.html
@@ -181,7 +181,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/consistent-navigation.html
+++ b/understanding/consistent-navigation.html
@@ -181,7 +181,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/consistent-navigation.html
+++ b/understanding/consistent-navigation.html
@@ -181,7 +181,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/content-on-hover-or-focus.html
+++ b/understanding/content-on-hover-or-focus.html
@@ -267,7 +267,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/content-on-hover-or-focus.html
+++ b/understanding/content-on-hover-or-focus.html
@@ -267,7 +267,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/content-on-hover-or-focus.html
+++ b/understanding/content-on-hover-or-focus.html
@@ -267,7 +267,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/error-prevention-all.html
+++ b/understanding/error-prevention-all.html
@@ -82,7 +82,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/error-prevention-all.html
+++ b/understanding/error-prevention-all.html
@@ -82,7 +82,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/error-prevention-all.html
+++ b/understanding/error-prevention-all.html
@@ -82,7 +82,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/error-prevention-legal-financial-data.html
+++ b/understanding/error-prevention-legal-financial-data.html
@@ -210,7 +210,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/error-prevention-legal-financial-data.html
+++ b/understanding/error-prevention-legal-financial-data.html
@@ -210,7 +210,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/error-prevention-legal-financial-data.html
+++ b/understanding/error-prevention-legal-financial-data.html
@@ -210,7 +210,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/focus-order.html
+++ b/understanding/focus-order.html
@@ -200,7 +200,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/focus-order.html
+++ b/understanding/focus-order.html
@@ -200,7 +200,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/focus-order.html
+++ b/understanding/focus-order.html
@@ -200,7 +200,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/identify-input-purpose.html
+++ b/understanding/identify-input-purpose.html
@@ -111,7 +111,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/identify-input-purpose.html
+++ b/understanding/identify-input-purpose.html
@@ -111,7 +111,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/identify-input-purpose.html
+++ b/understanding/identify-input-purpose.html
@@ -111,7 +111,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/identify-purpose.html
+++ b/understanding/identify-purpose.html
@@ -128,7 +128,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/identify-purpose.html
+++ b/understanding/identify-purpose.html
@@ -128,7 +128,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/identify-purpose.html
+++ b/understanding/identify-purpose.html
@@ -128,7 +128,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/info-and-relationships.html
+++ b/understanding/info-and-relationships.html
@@ -379,7 +379,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/info-and-relationships.html
+++ b/understanding/info-and-relationships.html
@@ -379,7 +379,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/info-and-relationships.html
+++ b/understanding/info-and-relationships.html
@@ -379,7 +379,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-page.html
+++ b/understanding/language-of-page.html
@@ -152,7 +152,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -171,7 +171,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-page.html
+++ b/understanding/language-of-page.html
@@ -152,7 +152,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -171,7 +171,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-page.html
+++ b/understanding/language-of-page.html
@@ -152,7 +152,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -171,7 +171,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-parts.html
+++ b/understanding/language-of-parts.html
@@ -179,7 +179,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-parts.html
+++ b/understanding/language-of-parts.html
@@ -179,7 +179,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-parts.html
+++ b/understanding/language-of-parts.html
@@ -179,7 +179,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/link-purpose-link-only.html
+++ b/understanding/link-purpose-link-only.html
@@ -227,7 +227,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/link-purpose-link-only.html
+++ b/understanding/link-purpose-link-only.html
@@ -227,7 +227,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/link-purpose-link-only.html
+++ b/understanding/link-purpose-link-only.html
@@ -227,7 +227,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/meaningful-sequence.html
+++ b/understanding/meaningful-sequence.html
@@ -160,7 +160,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/meaningful-sequence.html
+++ b/understanding/meaningful-sequence.html
@@ -160,7 +160,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/meaningful-sequence.html
+++ b/understanding/meaningful-sequence.html
@@ -160,7 +160,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/motion-actuation.html
+++ b/understanding/motion-actuation.html
@@ -130,7 +130,7 @@
             <dd><definition xmlns="">
 
 
-                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
 
 
                   <p xmlns="http://www.w3.org/1999/xhtml">あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と2.の両方が満たされていなければならない:</p>

--- a/understanding/motion-actuation.html
+++ b/understanding/motion-actuation.html
@@ -130,7 +130,7 @@
             <dd><definition xmlns="">
 
 
-                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
 
 
                   <p xmlns="http://www.w3.org/1999/xhtml">あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と2.の両方が満たされていなければならない:</p>

--- a/understanding/motion-actuation.html
+++ b/understanding/motion-actuation.html
@@ -130,7 +130,7 @@
             <dd><definition xmlns="">
 
 
-                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
 
 
                   <p xmlns="http://www.w3.org/1999/xhtml">あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と2.の両方が満たされていなければならない:</p>

--- a/understanding/multiple-ways.html
+++ b/understanding/multiple-ways.html
@@ -185,7 +185,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/multiple-ways.html
+++ b/understanding/multiple-ways.html
@@ -185,7 +185,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/multiple-ways.html
+++ b/understanding/multiple-ways.html
@@ -185,7 +185,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -30,7 +30,7 @@
       </nav>
       <h1>達成基準 4.1.2: 名前 (name)・役割 (role) 及び値 (value) を理解する</h1>
       <blockquote class="scquote">
-         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#name-role-value" style="font-weight: bold;">4.1.2 名前 (name)・役割 (role) 及び値 (value) </a> (レベル A): すべての<a href="#dfn-user-interface-component" >ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" >名前 (name)</a> 及び<a href="#dfn-role" >役割 (role)</a> は、<a href="#dfn-programmatically-determined" >プログラムによる解釈</a>が可能である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" >プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technology" >支援技術</a>を含む<a href="#dfn-user-agents" >ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。</p>
+         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#name-role-value" style="font-weight: bold;">4.1.2 名前 (name)・役割 (role) 及び値 (value) </a> (レベル A): すべての<a href="#dfn-user-interface-component" >ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" >名前 (name)</a> 及び<a href="#dfn-role" >役割 (role)</a> は、<a href="#dfn-programmatically-determined" >プログラムによる解釈</a>が可能である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" >プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technology" >支援技術</a>を含む<a href="#dfn-user-agent" >ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。</p>
          <p class="note">この達成基準は、主に独自のユーザインタフェース コンポーネントを開発、又はスクリプトで実装するコンテンツ制作者に向けたものである。例えば、標準的な HTML のコントロールを仕様に沿って使用していれば、既にこの達成基準を満たしていることになる。</p>
       </blockquote>
       <main>
@@ -302,7 +302,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -372,7 +372,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -30,7 +30,7 @@
       </nav>
       <h1>達成基準 4.1.2: 名前 (name)・役割 (role) 及び値 (value) を理解する</h1>
       <blockquote class="scquote">
-         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#name-role-value" style="font-weight: bold;">4.1.2 名前 (name)・役割 (role) 及び値 (value) </a> (レベル A): すべての<a href="#dfn-user-interface-component" >ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" >名前 (name)</a> 及び<a href="#dfn-role" >役割 (role)</a> は、<a href="#dfn-programmatically-determined" >プログラムによる解釈</a>が可能である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" >プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technology" >支援技術</a>を含む<a href="#dfn-user-agent" >ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。</p>
+         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#name-role-value" style="font-weight: bold;">4.1.2 名前 (name)・役割 (role) 及び値 (value) </a> (レベル A): すべての<a href="#dfn-user-interface-component" >ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" >名前 (name)</a> 及び<a href="#dfn-role" >役割 (role)</a> は、<a href="#dfn-programmatically-determined" >プログラムによる解釈</a>が可能である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" >プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technology" >支援技術</a>を含む<a href="#dfn-user-agents" >ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。</p>
          <p class="note">この達成基準は、主に独自のユーザインタフェース コンポーネントを開発、又はスクリプトで実装するコンテンツ制作者に向けたものである。例えば、標準的な HTML のコントロールを仕様に沿って使用していれば、既にこの達成基準を満たしていることになる。</p>
       </blockquote>
       <main>
@@ -302,7 +302,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -372,7 +372,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -30,7 +30,7 @@
       </nav>
       <h1>達成基準 4.1.2: 名前 (name)・役割 (role) 及び値 (value) を理解する</h1>
       <blockquote class="scquote">
-         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#name-role-value" style="font-weight: bold;">4.1.2 名前 (name)・役割 (role) 及び値 (value) </a> (レベル A): すべての<a href="#dfn-user-interface-component" >ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" >名前 (name)</a> 及び<a href="#dfn-role" >役割 (role)</a> は、<a href="#dfn-programmatically-determined" >プログラムによる解釈</a>が可能である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" >プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technology" >支援技術</a>を含む<a href="#dfn-user-agent" >ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。</p>
+         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#name-role-value" style="font-weight: bold;">4.1.2 名前 (name)・役割 (role) 及び値 (value) </a> (レベル A): すべての<a href="#dfn-user-interface-component" >ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" >名前 (name)</a> 及び<a href="#dfn-role" >役割 (role)</a> は、<a href="#dfn-programmatically-determined" >プログラムによる解釈</a>が可能である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" >プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technology" >支援技術</a>を含む<a href="#dfn-user-agents" >ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。</p>
          <p class="note">この達成基準は、主に独自のユーザインタフェース コンポーネントを開発、又はスクリプトで実装するコンテンツ制作者に向けたものである。例えば、標準的な HTML のコントロールを仕様に沿って使用していれば、既にこの達成基準を満たしていることになる。</p>
       </blockquote>
       <main>

--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -302,7 +302,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -372,7 +372,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/non-text-content.html
+++ b/understanding/non-text-content.html
@@ -729,7 +729,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/non-text-content.html
+++ b/understanding/non-text-content.html
@@ -729,7 +729,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/non-text-content.html
+++ b/understanding/non-text-content.html
@@ -729,7 +729,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/on-focus.html
+++ b/understanding/on-focus.html
@@ -151,7 +151,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/on-focus.html
+++ b/understanding/on-focus.html
@@ -151,7 +151,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/on-focus.html
+++ b/understanding/on-focus.html
@@ -151,7 +151,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/on-input.html
+++ b/understanding/on-input.html
@@ -176,7 +176,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/on-input.html
+++ b/understanding/on-input.html
@@ -176,7 +176,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/on-input.html
+++ b/understanding/on-input.html
@@ -176,7 +176,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/page-titled.html
+++ b/understanding/page-titled.html
@@ -192,7 +192,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/page-titled.html
+++ b/understanding/page-titled.html
@@ -192,7 +192,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/page-titled.html
+++ b/understanding/page-titled.html
@@ -192,7 +192,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/pointer-cancellation.html
+++ b/understanding/pointer-cancellation.html
@@ -214,7 +214,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/pointer-cancellation.html
+++ b/understanding/pointer-cancellation.html
@@ -214,7 +214,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/pointer-cancellation.html
+++ b/understanding/pointer-cancellation.html
@@ -214,7 +214,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/pronunciation.html
+++ b/understanding/pronunciation.html
@@ -147,7 +147,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/pronunciation.html
+++ b/understanding/pronunciation.html
@@ -147,7 +147,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/pronunciation.html
+++ b/understanding/pronunciation.html
@@ -147,7 +147,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/resize-text.html
+++ b/understanding/resize-text.html
@@ -219,7 +219,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/resize-text.html
+++ b/understanding/resize-text.html
@@ -219,7 +219,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/resize-text.html
+++ b/understanding/resize-text.html
@@ -219,7 +219,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/status-messages.html
+++ b/understanding/status-messages.html
@@ -305,7 +305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -365,7 +365,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -394,7 +394,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/status-messages.html
+++ b/understanding/status-messages.html
@@ -305,7 +305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -365,7 +365,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -394,7 +394,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/status-messages.html
+++ b/understanding/status-messages.html
@@ -305,7 +305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -365,7 +365,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -394,7 +394,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/three-flashes-or-below-threshold.html
+++ b/understanding/three-flashes-or-below-threshold.html
@@ -215,7 +215,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/three-flashes-or-below-threshold.html
+++ b/understanding/three-flashes-or-below-threshold.html
@@ -215,7 +215,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/three-flashes-or-below-threshold.html
+++ b/understanding/three-flashes-or-below-threshold.html
@@ -215,7 +215,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/three-flashes.html
+++ b/understanding/three-flashes.html
@@ -128,7 +128,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/three-flashes.html
+++ b/understanding/three-flashes.html
@@ -128,7 +128,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/three-flashes.html
+++ b/understanding/three-flashes.html
@@ -128,7 +128,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/unusual-words.html
+++ b/understanding/unusual-words.html
@@ -323,7 +323,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/unusual-words.html
+++ b/understanding/unusual-words.html
@@ -323,7 +323,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/unusual-words.html
+++ b/understanding/unusual-words.html
@@ -323,7 +323,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/visual-presentation.html
+++ b/understanding/visual-presentation.html
@@ -332,7 +332,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/visual-presentation.html
+++ b/understanding/visual-presentation.html
@@ -332,7 +332,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/visual-presentation.html
+++ b/understanding/visual-presentation.html
@@ -332,7 +332,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/"#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
ほとんどのページのユーザーエージェントの文言のリンクが
うまく機能してないことに気づいて[guidelines/index.html](https://github.com/waic/wcag21/blob/master/guidelines/index.html#L2454)を次のように修正しました。🐻💦

`#dfn-user-agents` -> `#dfn-user-agent`

[WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)と [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認したところ`s`がない方が正しいようでした。