### PR TITLE
理解可能のそれぞれの達成基準のユーザエージェントのリンクを修正

### DIFF
--- a/understanding/abbreviations.html
+++ b/understanding/abbreviations.html
@@ -311,7 +311,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
 
                   </div>
                   

--- a/understanding/change-on-request.html
+++ b/understanding/change-on-request.html
@@ -268,7 +268,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -301,7 +301,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/consistent-navigation.html
+++ b/understanding/consistent-navigation.html
@@ -181,7 +181,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/error-prevention-all.html
+++ b/understanding/error-prevention-all.html
@@ -82,7 +82,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/error-prevention-legal-financial-data.html
+++ b/understanding/error-prevention-legal-financial-data.html
@@ -210,7 +210,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-page.html
+++ b/understanding/language-of-page.html
@@ -152,7 +152,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -171,7 +171,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/language-of-parts.html
+++ b/understanding/language-of-parts.html
@@ -179,7 +179,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/on-focus.html
+++ b/understanding/on-focus.html
@@ -151,7 +151,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/on-input.html
+++ b/understanding/on-input.html
@@ -176,7 +176,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>

--- a/understanding/pronunciation.html
+++ b/understanding/pronunciation.html
@@ -147,7 +147,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   

--- a/understanding/unusual-words.html
+++ b/understanding/unusual-words.html
@@ -323,7 +323,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
+                     <p>メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>で提供されるものに<a href="https://waic.jp/docs/WCAG21/#dfn-relied-upon">依存する</a>こともある。</p>
                   </div>
                   
                   


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
ユーザエージェントのリンクが次のようになっていました。

`<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">`

そのため、次のURLにうまくリンクできていなかったので修正しました。
https://waic.jp/docs/WCAG21/#dfn-user-agents 


## 影響範囲
達成基準 3.1.1: ページの言語
達成基準 3.1.2: 一部分の言語
達成基準 3.1.3: 一般的ではない用語
達成基準 3.1.4: 略語
達成基準 3.1.6: 発音
達成基準 3.2.1: フォーカス時
達成基準 3.2.2: 入力時
達成基準 3.2.3: 一貫したナビゲーション
達成基準 3.2.5: 要求による変化
達成基準 3.3.4: エラー回避 (法的、金融、データ) 
達成基準 3.3.6: エラー回避 (すべて) 