### PR TITLE
堅牢のそれぞれの達成基準と適合を理解するページのユーザエージェントのリンクを修正

### DIFF
--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -1074,7 +1074,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">利用者の<a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>と、ブラウザ及びその他の<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
                   
                   
                   <p xmlns="http://www.w3.org/1999/xhtml">あるウェブコンテンツ技術 (あるいは、ある技術の機能) の使用方法がアクセシビリティ サポーテッドであると認められるためには、そのウェブコンテンツ技術 (あるいは、機能) について、次の 1.と2.の両方が満たされていなければならない:</p>
@@ -1305,7 +1305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism">メカニズム</a>。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -1327,7 +1327,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml">単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/name-role-value.html
+++ b/understanding/name-role-value.html
@@ -302,7 +302,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -372,7 +372,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>

--- a/understanding/status-messages.html
+++ b/understanding/status-messages.html
@@ -305,7 +305,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>として機能する、又は主流のユーザエージェントと一緒に機能するハードウェア及び／又はソフトウェアで、主流のユーザエージェントで提供されている機能以上の機能を、障害のある利用者の要求を満たすために提供するもの。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
@@ -365,7 +365,7 @@
                   <ol xmlns="http://www.w3.org/1999/xhtml">
                      
                      
-                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a></li>
+                     <li><a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a></li>
                      
                      
                      <li><a href="https://waic.jp/docs/WCAG21/#dfn-viewport">ビューポート</a></li>
@@ -394,7 +394,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="https://waic.jp/docs/WCAG21/#dfn-assistive-technology">支援技術</a>を含む様々な<a href="https://waic.jp/docs/WCAG21/#dfn-user-agents">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
ユーザエージェントのリンクが次のようになっていました

`<a href="https://waic.jp/docs/WCAG21/#dfn-user-agent">`

そのため、次のURLにうまくリンクできていなかったので修正しました。
https://waic.jp/docs/WCAG21/#dfn-user-agents 


## 影響範囲
達成基準 4.1.2: 名前 (name)・役割 (role) 及び値 (value) 
達成基準 4.1.3: ステータスメッセージ
適合を理解する