### PR TITLE
用語集：音声解説の注記4の脱字

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2837,7 +2837,7 @@ details.respec-tests-details > li {
    <div class="note" id="issue-container-generatedID-54"><div role="heading" class="note-title marker" id="h-note-54" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>情報のすべてが既存の<a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>ですでに提供されている場合、補足の音声解説は不要である。
    </p></div>
    
-   <div class="note" id="issue-container-generatedID-55"><div role="heading" class="note-title marker" id="h-note-55" aria-level="3"><span>注記</span></div><p class="">video description" や "descriptive narration" とも呼ばれる。</p></div>
+   <div class="note" id="issue-container-generatedID-55"><div role="heading" class="note-title marker" id="h-note-55" aria-level="3"><span>注記</span></div><p class="">"video description" や "descriptive narration" とも呼ばれる。</p></div>
    <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>日本語では「音声ガイド」とも呼ばれる。</p></div>
    
 </dd>


### PR DESCRIPTION
https://waic.jp/docs/WCAG21/#dfn-audio-descriptions

> video description" や "descriptive narration" とも呼ばれる。

`"`が抜けている

