### PR TITLE
用語集：拡張音声解説の注記の修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -3111,7 +3111,7 @@ details.respec-tests-details > li {
    <p><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>を一時停止することで追加の説明を付加するための時間を確保し、視聴覚提示に付加した音声解説。
    </p>
    
-   <div class="note" id="issue-container-generatedID-80"><div role="heading" class="note-title marker" id="h-note-80" aria-level="3"><span>注記</span></div><p class="">この達成方法は、追加の<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>がないと<a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。
+   <div class="note" id="issue-container-generatedID-80"><div role="heading" class="note-title marker" id="h-note-80" aria-level="3"><span>注記</span></div><p class="">この手法は、追加の<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>がないと<a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。
    </p></div>
    
 </dd>

--- a/understanding/audio-description-or-media-alternative-prerecorded.html
+++ b/understanding/audio-description-or-media-alternative-prerecorded.html
@@ -296,7 +296,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>この達成方法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。
+                     <p>この手法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/audio-description-prerecorded.html
+++ b/understanding/audio-description-prerecorded.html
@@ -233,7 +233,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>この達成方法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。
+                     <p>この手法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/captions-live.html
+++ b/understanding/captions-live.html
@@ -278,7 +278,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>この達成方法は、追加の<a href="#dfn-audio-description"音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。
+                     <p>この手法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/captions-prerecorded.html
+++ b/understanding/captions-prerecorded.html
@@ -390,7 +390,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>この達成方法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。
+                     <p>この手法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/extended-audio-description-prerecorded.html
+++ b/understanding/extended-audio-description-prerecorded.html
@@ -176,7 +176,7 @@
                   
                   
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note"><div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>この達成方法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。</p>
+                     <p>この手法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。</p>
                   </div>
                   
                   

--- a/understanding/media-alternative-prerecorded.html
+++ b/understanding/media-alternative-prerecorded.html
@@ -342,7 +342,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>この達成方法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。
+                     <p>この手法は、追加の<a href="#dfn-audio-description">音声解説</a>がないと<a href="#dfn-video">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。
                         </p>
                   </div>
                   </definition>


### PR DESCRIPTION
## 「達成方法」という訳

https://waic.jp/docs/WCAG21/#dfn-extended-audio-description

> 拡張音声解説 (extended audio description)
> 注記
> この達成方法は、追加の音声解説がないと映像の意味が損なわれてしまい、かつ会話やナレーションの合間が短すぎる場合だけに用いられる。

https://www.w3.org/TR/2018/REC-WCAG21-20180605/#dfn-extended-audio-description

> This technique is only used when the sense of the video would be lost without the additional audio description and the pauses between dialogue/narration are too short.

「達成方法」は誤訳ではないだろうか。なお、techniqueという語は、メカニズム (mechanism)にも出てくる（実質、この他にはない）。

https://www.w3.org/TR/2018/REC-WCAG21-20180605/#dfn-mechanism
> process or technique for achieving a result

https://waic.jp/docs/WCAG21/#dfn-mechanism
> 結果を得るためのプロセス又は手法。

これにあわせると「手法」が適当か。

## dialogue/narrationの訳

`/`（単独）をどう訳すのかについては「JIS原案作成のための手引【第21版】」では、
https://webdesk.jsa.or.jp/pdf/dev/md_5652.pdf#page=19

> or の代わりとして用いている斜線は，“又は”に，and の代わりとして用いている場合は“及び”又は中点“・”に置き換えるなど，意図する内容に対応させる。

とあるので、ここでは「又は」とするのはどうか。

これでよければ解説書に展開する。