### PR TITLE
F104解説をコメントに基づき修正

### DIFF
--- a/techniques/failures/F104.html
+++ b/techniques/failures/F104.html
@@ -51,7 +51,7 @@
             <ul>
                			  
                <li>
-                  囲む要素の oveflow プロパティを非表示に設定する
+                  囲んでいる要素の oveflow プロパティを hidden に設定する
                </li>
                			  
                <li>


### PR DESCRIPTION
Close #1589

F104の解説の修正です。
https://waic.jp/docs/WCAG21/Techniques/failures/F104

囲む要素の oveflow プロパティを非表示に設定する
↓
囲んでいる要素の oveflow プロパティを hidden に設定する

@caztcha レビューをお願いします。