### PR TITLE
H34 衍字の修正

### DIFF
--- a/techniques/html/H34.html
+++ b/techniques/html/H34.html
@@ -45,7 +45,7 @@
          </section>
          <section id="description">
             <h2>解説</h2>
-            <p>この達成方法の目的は、HTML の双方向性アルゴリズムが望ましくない結果を生じるとき時に、それを無効にするために Unicode 制御文字の right-to-left mark と left-to-right mark を用いることである。たとえば、スペース又は句読点のようなニュートラルな文字が異なる方向性のテキストの間に置かれている時に必要となることがある。この達成方法で用いられているコンセプトは、W3C 文書の「<a href="https://www.w3.org/International/articles/inline-bidi-markup/">What you need to know about the bidi algorithm and inline markup</a>」に書かれている。
+            <p>この達成方法の目的は、HTML の双方向性アルゴリズムが望ましくない結果を生じるときに、それを無効にするために Unicode 制御文字の right-to-left mark と left-to-right mark を用いることである。たとえば、スペース又は句読点のようなニュートラルな文字が異なる方向性のテキストの間に置かれている時に必要となることがある。この達成方法で用いられているコンセプトは、W3C 文書の「<a href="https://www.w3.org/International/articles/inline-bidi-markup/">What you need to know about the bidi algorithm and inline markup</a>」に書かれている。
             </p>
             <div class="note">
                <div role="heading" class="note-title marker" aria-level="3">訳注</div>


### PR DESCRIPTION
> HTML の双方向性アルゴリズムが望ましくない結果を生じるとき時に

を、
> HTML の双方向性アルゴリズムが望ましくない結果を生じるときに

に修正しました。

「とき」「時」はどちらでもよいとのことだったので、「とき」を採用しました。
https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md#if-when%E3%81%AE%E8%A8%B3%E8%AA%9E%E5%80%99%E8%A3%9C%E5%A0%B4%E5%90%88%E3%81%A8%E3%81%8D%E6%99%82g33e

原文は
> The objective of this technique is to use Unicode right-to-left marks and left-to-right marks to override the HTML bidirectional algorithm when it produces undesirable results. 

https://www.w3.org/WAI/WCAG21/Techniques/html/H34

# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

