### PR TITLE
文言の調整（入力メカニズム非依存→入力メカニズムの共存）：WCAG 2.1解説書 目次 & 2.5.6

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -715,7 +715,7 @@ details.respec-tests-details > li {
                     </li>
                     <li class="tocline">
                       <a href="#concurrent-input-mechanisms" class=
-                      "tocxref"><span class="secno">2.5.6</span> 入力メカニズム非依存</a>
+                      "tocxref"><span class="secno">2.5.6</span> 入力メカニズムの共存</a>
                     </li>
                   </ol>
                 </li>
@@ -1017,7 +1017,7 @@ details.respec-tests-details > li {
 						<li>2.5.3 <a href="#label-in-name">名前 (name) のラベル</a> (A)</li>
 						<li>2.5.4 <a href="#motion-actuation">動きによる起動</a> (A)</li>
 						<li>2.5.5 <a href="#target-size">ターゲットのサイズ</a> (AAA)</li>
-						<li>2.5.6 <a href="#concurrent-input-mechanisms">入力メカニズム非依存</a> (AAA)</li>
+						<li>2.5.6 <a href="#concurrent-input-mechanisms">入力メカニズムの共存</a> (AAA)</li>
 						<li>4.1.3 <a href="#status-messages">ステータスメッセージ</a> (AA)</li>
 					</ul>
 
@@ -2189,7 +2189,7 @@ details.respec-tests-details > li {
 
 
                 <section class="sc new" id="concurrent-input-mechanisms">
-   <h4 id="x2-5-6-concurrent-input-mechanisms"><span class="secno">達成基準 2.5.6 </span>入力メカニズム非依存<span class="permalink"><a href="#concurrent-input-mechanisms" aria-label="Permalink for 2.5.6 Concurrent Input Mechanisms" title="Permalink for 2.5.6 Concurrent Input Mechanisms"><span>§</span></a></span></h4>
+   <h4 id="x2-5-6-concurrent-input-mechanisms"><span class="secno">達成基準 2.5.6 </span>入力メカニズムの共存<span class="permalink"><a href="#concurrent-input-mechanisms" aria-label="Permalink for 2.5.6 Concurrent Input Mechanisms" title="Permalink for 2.5.6 Concurrent Input Mechanisms"><span>§</span></a></span></h4>
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms.html">Understanding Concurrent Input Mechanisms</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#concurrent-input-mechanisms">How to Meet Concurrent Input Mechanisms</a></div><p class="conformance-level">(レベル AAA)</p>
   
   <p>プラットフォームで提供されている入力モダリティの使用を、ウェブコンテンツが制限しない。ただし、その制限が<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合、コンテンツのセキュリティのために必要な場合、又は利用者による設定を尊重するうえで必要な場合は例外とする。</p><!--OddPage-->   					

--- a/techniques/failures/F98.html
+++ b/techniques/failures/F98.html
@@ -37,7 +37,7 @@
             <h2>適用 (対象)</h2>
             <p>インタラクティブなコントロール (リンク、フォーム入力、又は複雑なカスタムウィジェットなど) を含み、異なる入力モダリティの存在を検知することができるすべての技術。
             </p>
-            <p>この達成方法は、<span><a href="https://waic.jp/docs/WCAG21/Understanding/concurrent-input-mechanisms">達成基準 2.5.6: 入力メカニズム非依存</a> (失敗)</span> に関連する。
+            <p>この達成方法は、<span><a href="https://waic.jp/docs/WCAG21/Understanding/concurrent-input-mechanisms">達成基準 2.5.6: 入力メカニズムの共存</a> (失敗)</span> に関連する。
             </p>
          </section>
          <section id="description">

--- a/understanding/concurrent-input-mechanisms.html
+++ b/understanding/concurrent-input-mechanisms.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja">
    <head>
       <meta charset="UTF-8" />
-      <title>達成基準 2.5.6: 入力メカニズム非依存を理解する</title>
+      <title>達成基準 2.5.6: 入力メカニズムの共存を理解する</title>
       <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base" />
       <link rel="stylesheet" type="text/css" href="understanding.css" />
       <link rel="stylesheet" type="text/css" href="slicenav.css" />
@@ -27,9 +27,9 @@
             <li><a href="#key-terms">重要な用語</a></li>
          </ul>
       </nav>
-      <h1>達成基準 2.5.6: 入力メカニズム非依存を理解する</h1>
+      <h1>達成基準 2.5.6: 入力メカニズムの共存を理解する</h1>
       <blockquote class="scquote">
-         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#concurrent-input-mechanisms" style="font-weight: bold;">2.5.6 入力メカニズム非依存</a> (レベル AAA): プラットフォームで提供されている入力モダリティの使用を、ウェブコンテンツが制限しない。ただし、その制限が<a href="#dfn-essential" >必要不可欠</a>な場合、コンテンツのセキュリティのために必要な場合、又は利用者による設定を尊重するうえで必要な場合は例外とする。</p>
+         <p>達成基準 <a href="https://waic.jp/docs/WCAG21/#concurrent-input-mechanisms" style="font-weight: bold;">2.5.6 入力メカニズムの共存</a> (レベル AAA): プラットフォームで提供されている入力モダリティの使用を、ウェブコンテンツが制限しない。ただし、その制限が<a href="#dfn-essential" >必要不可欠</a>な場合、コンテンツのセキュリティのために必要な場合、又は利用者による設定を尊重するうえで必要な場合は例外とする。</p>
       </blockquote>
       <main>
          <section id="intent">

--- a/understanding/index.html
+++ b/understanding/index.html
@@ -237,7 +237,7 @@
                   <li class="tocline"><a href="label-in-name.html" class="tocxref"><span class="secno">2.5.3</span> 名前 (name) のラベル</a></li>
                   <li class="tocline"><a href="motion-actuation.html" class="tocxref"><span class="secno">2.5.4</span> 動きによる起動</a></li>
                   <li class="tocline"><a href="target-size.html" class="tocxref"><span class="secno">2.5.5</span> ターゲットのサイズ</a></li>
-                  <li class="tocline"><a href="concurrent-input-mechanisms.html" class="tocxref"><span class="secno">2.5.6</span> 入力メカニズム非依存</a></li>
+                  <li class="tocline"><a href="concurrent-input-mechanisms.html" class="tocxref"><span class="secno">2.5.6</span> 入力メカニズムの共存</a></li>
                </ol>
             </li>
          </ol>

--- a/understanding/input-modalities.html
+++ b/understanding/input-modalities.html
@@ -46,7 +46,7 @@
                <li><a href="label-in-name.html">2.5.3 名前 (name) のラベル</a></li>
                <li><a href="motion-actuation.html">2.5.4 動きによる起動</a></li>
                <li><a href="target-size.html">2.5.5 ターゲットのサイズ</a></li>
-               <li><a href="concurrent-input-mechanisms.html">2.5.6 入力メカニズム非依存</a></li>
+               <li><a href="concurrent-input-mechanisms.html">2.5.6 入力メカニズムの共存</a></li>
             </ul>
          </section>
       </main>

--- a/understanding/language-of-page.html
+++ b/understanding/language-of-page.html
@@ -12,7 +12,7 @@
          <ul id="navigation">
             <li><a href="." title="目次">目次</a></li>
             <li><a href="readable.html"><abbr title="Guideline">GL</abbr>: 読み取り可能</a></li>
-            <li><a href="concurrent-input-mechanisms.html">Previous <abbr title="Success Criterion">SC</abbr>: 入力メカニズム非依存</a></li>
+            <li><a href="concurrent-input-mechanisms.html">Previous <abbr title="Success Criterion">SC</abbr>: 入力メカニズムの共存</a></li>
             <li><a href="language-of-parts.html">Next <abbr title="Success Criterion">SC</abbr>: 一部分の言語</a></li>
          </ul>
       </nav>

--- a/understanding/target-size.html
+++ b/understanding/target-size.html
@@ -13,7 +13,7 @@
             <li><a href="." title="目次">目次</a></li>
             <li><a href="input-modalities.html"><abbr title="Guideline">GL</abbr>: 入力モダリティ</a></li>
             <li><a href="motion-actuation.html">Previous <abbr title="Success Criterion">SC</abbr>: 動きによる起動</a></li>
-            <li><a href="concurrent-input-mechanisms.html">Next <abbr title="Success Criterion">SC</abbr>: 入力メカニズム非依存</a></li>
+            <li><a href="concurrent-input-mechanisms.html">Next <abbr title="Success Criterion">SC</abbr>: 入力メカニズムの共存</a></li>
          </ul>
       </nav>
       <nav class="navtoc">


### PR DESCRIPTION
文言を編集しました。

■ 変更内容
入力メカニズム非依存
↓
入力メカニズムの共存

■ 対象ページ
\guidelines\index.html
\techniques\failures\F98.html
\understanding\input-modalities.html
\understanding\language-of-page.html
\understanding\target-size.html

# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

