### PR TITLE
用語集：映像しか含まないの修正

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -4000,7 +4000,7 @@ details.respec-tests-details > li {
                 <dt><dfn data-dfn-type="dfn" id="dfn-video-only">映像しか含まない (video-only)</dfn></dt>
 <dd>
    
-   <p><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>のみを含んだ、時間に依存する提示 (<a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>やインタラクションを含まない)。
+   <p><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>のみを含んだ (<a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>もインタラクションも含まない)、時間に依存する提示。
    </p>
    
 </dd>

--- a/understanding/audio-only-and-video-only-prerecorded.html
+++ b/understanding/audio-only-and-video-only-prerecorded.html
@@ -311,7 +311,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="#dfn-video">映像</a>のみを含んだ、時間に依存する提示 (<a href="#dfn-audio">音声</a>やインタラクションを含まない)。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="#dfn-video">映像</a>のみを含んだ (<a href="#dfn-audio">音声</a>もインタラクションも含まない)、時間に依存する提示。</p>
                   
                   
                </definition>

--- a/understanding/media-alternative-prerecorded.html
+++ b/understanding/media-alternative-prerecorded.html
@@ -515,7 +515,7 @@
             <dd><definition xmlns="">
                   
                   
-                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="#dfn-video">映像</a>のみを含んだ、時間に依存する提示 (<a href="#dfn-audio">音声</a>やインタラクションを含まない)。</p>
+                  <p xmlns="http://www.w3.org/1999/xhtml"><a href="#dfn-video">映像</a>のみを含んだ (<a href="#dfn-audio">音声</a>もインタラクションも含まない)、時間に依存する提示。</p>
                   
                   
                </definition>


### PR DESCRIPTION
Fix https://github.com/waic/wcag21/issues/1683

issueに基づき修正。（「のみ」のママとしています）

