### PR TITLE
fix #1833 ARIA18のh1を修正

### DIFF
--- a/techniques/aria/ARIA18.html
+++ b/techniques/aria/ARIA18.html
@@ -27,7 +27,7 @@
             <li><a href="#tests">検証</a></li>
          </ul>
       </nav>
-      <h1>エラーを特定するために、ARIA role=alert 又はライブリージョン (Live Regions) を使用する</h1>
+      <h1>エラーを特定するために aria-alertdialog を使用する</h1>
       <section id="important-information">
          <h2>達成方法に関する重要な情報</h2>
          <p>この達成方法 (参考) の使用法と、この達成方法が WCAG 2.1 達成基準 (規定) とどのように関係するのかに関する重要な情報については、<a href="https://waic.jp/translations/WCAG21/Understanding/understanding-techniques">WCAG 達成基準の達成方法を理解する</a>を参照のこと。適用 (対象) のセクションは、その達成方法の範囲について説明しており、特定の技術に関する達成方法の存在は、その技術があらゆる状況で WCAG 2.1 を満たすコンテンツを作成するために使用できることを意味するものではない。


### PR DESCRIPTION
fix #1833 
ARIA18のタイトル (h1要素の内容) が誤ってARIA19のものになっていたのを修正しました。
