### PR TITLE
2. 操作可能の更新

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1672,6 +1672,8 @@ details.respec-tests-details > li {
 
             <section class="guideline" id="keyboard-accessible">
                 <h3 id="x2-1-keyboard-accessible"><span class="secno">ガイドライン 2.1 </span>キーボード操作可能<span class="permalink"><a href="#keyboard-accessible" aria-label="Permalink for 2.1 Keyboard Accessible" title="Permalink for 2.1 Keyboard Accessible"><span>§</span></a></span></h3>
+
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html">Understanding Keyboard Accessible</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard-accessible">How to Meet Keyboard Accessible</a></div>
                 <p>すべての機能をキーボードから利用できるようにすること。</p>
 
                 <section class="sc" id="keyboard">
@@ -1716,7 +1718,7 @@ details.respec-tests-details > li {
    
 </section>
               
-                <section class="sc new" id="character-key-shortcuts">
+                <section class="sc" id="character-key-shortcuts">
    					
    <h4 id="x2-1-4-character-key-shortcuts"><span class="secno">達成基準 2.1.4 </span>文字キーのショートカット<span class="permalink"><a href="#character-key-shortcuts" aria-label="Permalink for 2.1.4 Character Key Shortcuts" title="Permalink for 2.1.4 Character Key Shortcuts"><span>§</span></a></span></h4>
    					
@@ -1731,8 +1733,8 @@ details.respec-tests-details > li {
    <dt>解除</dt>
     <dd>ショートカットを解除する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる</dd>
       						
-   <dt>再割り当て</dt>
-     <dd>一つ以上の非印字文字 (例えば Ctrl や Alt など) を使用するようにショートカットを再割り当てするメカニズムが利用できる</dd>
+   <dt>再割当て</dt>
+     <dd>一つ以上のキーボードの非印字キー (例えば Ctrl、Alt) を含むようなショートカットを再割当てするメカニズムが利用できる</dd>
 
     <dt>フォーカス中にのみ有効化</dt>
     <dd><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>のキーボードショートカットは、そのコンポーネントがフォーカスをもっているときのみ有効になる。</dd>
@@ -1745,6 +1747,8 @@ details.respec-tests-details > li {
 
             <section class="guideline" id="enough-time">
                 <h3 id="x2-2-enough-time"><span class="secno">ガイドライン 2.2 </span>十分な時間<span class="permalink"><a href="#enough-time" aria-label="Permalink for 2.2 Enough Time" title="Permalink for 2.2 Enough Time"><span>§</span></a></span></h3>
+
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/enough-time.html">Understanding Enough Time</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#enough-time">How to Meet Enough Time</a></div>
                 <p>利用者がコンテンツを読み、使用するために十分な時間を提供すること。</p>
 
                 <section class="sc" id="timing-adjustable">
@@ -1894,7 +1898,7 @@ details.respec-tests-details > li {
    
 </section>
 
-                <section class="sc new" id="timeouts">
+                <section class="sc" id="timeouts">
    					
    <h4 id="x2-2-6-timeouts"><span class="secno">達成基準 2.2.6 </span>タイムアウト<span class="permalink"><a href="#timeouts" aria-label="Permalink for 2.2.6 Timeouts" title="Permalink for 2.2.6 Timeouts"><span>§</span></a></span></h4>
    					
@@ -1911,8 +1915,10 @@ details.respec-tests-details > li {
 
             </section>
 
-            <section class="guideline new" id="seizures-and-physical-reactions">
+            <section class="guideline" id="seizures-and-physical-reactions">
                 <h3 id="x2-3-seizures-and-physical-reactions"><span class="secno">ガイドライン 2.3 </span>発作と身体的反応<span class="permalink"><a href="#seizures-and-physical-reactions" aria-label="Permalink for 2.3 Seizures and Physical Reactions" title="Permalink for 2.3 Seizures and Physical Reactions"><span>§</span></a></span></h3>
+
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/seizures-and-physical-reactions.html">Understanding Seizures and Physical Reactions</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#seizures-and-physical-reactions">How to Meet Seizures and Physical Reactions</a></div>
                 <p>発作や身体的反応を引き起こすようなコンテンツを設計しないこと。</p>
 
                 <section class="sc" id="three-flashes-or-below-threshold">
@@ -1940,7 +1946,7 @@ details.respec-tests-details > li {
    
 </section>
                 
-                <section class="sc new" id="animation-from-interactions">
+                <section class="sc" id="animation-from-interactions">
    					
    <h4 id="x2-3-3-animation-from-interactions"><span class="secno">達成基準 2.3.3 </span>インタラクションによるアニメーション<span class="permalink"><a href="#animation-from-interactions" aria-label="Permalink for 2.3.3 Animation from Interactions" title="Permalink for 2.3.3 Animation from Interactions"><span>§</span></a></span></h4>
    					
@@ -1957,6 +1963,8 @@ details.respec-tests-details > li {
 
             <section class="guideline" id="navigable">
                 <h3 id="x2-4-navigable"><span class="secno">ガイドライン 2.4 </span>ナビゲーション可能<span class="permalink"><a href="#navigable" aria-label="Permalink for 2.4 Navigable" title="Permalink for 2.4 Navigable"><span>§</span></a></span></h3>
+
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/navigable.html">Understanding Navigable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#navigable">How to Meet Navigable</a></div>
                 <p>利用者がナビゲートしたり、コンテンツを探し出したり、現在位置を確認したりすることを手助けする手段を提供すること。</p>
 
                 <section class="sc" id="bypass-blocks">
@@ -2077,12 +2085,12 @@ details.respec-tests-details > li {
 
             </section>
 
-            <section class="guideline new" id="input-modalities">
+            <section class="guideline" id="input-modalities">
                 <h3 id="x2-5-input-modalities"><span class="secno">ガイドライン 2.5 </span>入力モダリティ<span class="permalink"><a href="#input-modalities" aria-label="Permalink for 2.5 Input Modalities" title="Permalink for 2.5 Input Modalities"><span>§</span></a></span></h3>
                 
                 <p>利用者がキーボード以外の様々な入力を通じて機能を操作しやすくすること。</p>
 
-                <section class="sc new" id="pointer-gestures">
+                <section class="sc" id="pointer-gestures">
    					
    <h4 id="x2-5-1-pointer-gestures"><span class="secno">達成基準 2.5.1 </span>ポインタのジェスチャ<span class="permalink"><a href="#pointer-gestures" aria-label="Permalink for 2.5.1 Pointer Gestures" title="Permalink for 2.5.1 Pointer Gestures"><span>§</span></a></span></h4>
    					
@@ -2097,7 +2105,7 @@ details.respec-tests-details > li {
 </section>
 
 
-                <section class="sc new" id="pointer-cancellation">
+                <section class="sc" id="pointer-cancellation">
    					
    <h4 id="x2-5-2-pointer-cancellation"><span class="secno">達成基準 2.5.2 </span>ポインタのキャンセル<span class="permalink"><a href="#pointer-cancellation" aria-label="Permalink for 2.5.2 Pointer Cancellation" title="Permalink for 2.5.2 Pointer Cancellation"><span>§</span></a></span></h4>
    					
@@ -2129,7 +2137,7 @@ details.respec-tests-details > li {
 </section>
 
 
-              	<section class="sc new" id="label-in-name">
+              	<section class="sc" id="label-in-name">
    <h4 id="x2-5-3-label-in-name"><span class="secno">達成基準 2.5.3 </span>ラベルを含む名前 (name)<span class="permalink"><a href="#label-in-name" aria-label="Permalink for 2.5.3 Label in Name" title="Permalink for 2.5.3 Label in Name"><span>§</span></a></span></h4>
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html">Understanding Label in Name</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#label-in-name">How to Meet Label in Name</a></div><p class="conformance-level">(レベル A)</p>
    
@@ -2141,7 +2149,7 @@ details.respec-tests-details > li {
 </section>
 
             	
-                <section class="sc new" id="motion-actuation">
+                <section class="sc" id="motion-actuation">
    					
    <h4 id="x2-5-4-motion-actuation"><span class="secno">達成基準 2.5.4 </span>動きによる起動<span class="permalink"><a href="#motion-actuation" aria-label="Permalink for 2.5.4 Motion Actuation" title="Permalink for 2.5.4 Motion Actuation"><span>§</span></a></span></h4>
   
@@ -2164,7 +2172,7 @@ details.respec-tests-details > li {
 </section>
 
 
-                <section class="sc new" id="target-size">
+                <section class="sc" id="target-size">
    					
    <h4 id="x2-5-5-target-size"><span class="secno">達成基準 2.5.5 </span>ターゲットのサイズ<span class="permalink"><a href="#target-size" aria-label="Permalink for 2.5.5 Target Size" title="Permalink for 2.5.5 Target Size"><span>§</span></a></span></h4>
    					
@@ -2187,7 +2195,7 @@ details.respec-tests-details > li {
 </section>
 
 
-                <section class="sc new" id="concurrent-input-mechanisms">
+                <section class="sc" id="concurrent-input-mechanisms">
    <h4 id="x2-5-6-concurrent-input-mechanisms"><span class="secno">達成基準 2.5.6 </span>入力メカニズムの共存<span class="permalink"><a href="#concurrent-input-mechanisms" aria-label="Permalink for 2.5.6 Concurrent Input Mechanisms" title="Permalink for 2.5.6 Concurrent Input Mechanisms"><span>§</span></a></span></h4>
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms.html">Understanding Concurrent Input Mechanisms</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#concurrent-input-mechanisms">How to Meet Concurrent Input Mechanisms</a></div><p class="conformance-level">(レベル AAA)</p>
   

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1734,7 +1734,7 @@ details.respec-tests-details > li {
     <dd>ショートカットを解除する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる</dd>
       						
    <dt>再割当て</dt>
-     <dd>一つ以上のキーボードの非印字キー (例えば Ctrl、Alt) を含むようなショートカットを再割当てするメカニズムが利用できる</dd>
+     <dd>一つ以上のキーボードの非印字キー (例えば Ctrl、Alt) を含むようにショートカットを再割当てするメカニズムが利用できる</dd>
 
     <dt>フォーカス中にのみ有効化</dt>
     <dd><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>のキーボードショートカットは、そのコンポーネントがフォーカスをもっているときのみ有効になる。</dd>


### PR DESCRIPTION
Close #1814

修正点は以下のとおりです

- 2.1.4の原文の追随
- `.new`の削除
- ガイドラインのUnderstandingへのリンク追加

公用文の書き方に従うと、「割り当て」は「割当て」になるのであわせて修正しています。
