### PR TITLE
1.4 判別可能の更新

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1582,7 +1582,7 @@ details.respec-tests-details > li {
   
    <div class="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>注記</span></div><p class="">320 CSS ピクセルは、400% ズーム時の開始ビューポート幅である 1280 CSS ピクセル幅に相当する。横スクロールになるように設計されたウェブコンテンツ (例えば、縦書きのテキスト) の場合、256 CSS ピクセルは、400% ズーム時の開始ビューポート高さである 1024 CSS ピクセル高さに相当する。</p></div>
    
-   <div class="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>注記</span></div><p class="">2 次元のレイアウトを必要とするコンテンツの例としては、理解のために必要な画像 (地図、図解など)、映像、ゲーム、プレゼンテーション、データテーブル (個々のセルではない)、及びコンテンツを操作している間にツールバーを表示しておく必要のあるインタフェースが挙げられる。そのようなコンテンツの部分には、2 次元スクロールを提供することが許容される。</p></div>
+   <div class="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>注記</span></div><p class="">2 次元のレイアウトを必要とするコンテンツの例としては、理解のために必要な画像 (地図、図解など)、映像、ゲーム、プレゼンテーション、データテーブル (個々のセルではない)、及びコンテンツを操作している間にツールバーを表示しておく必要のあるインタフェースが挙げられる。コンテンツのそのような部分には、2 次元スクロールを提供することが許容される。</p></div>
    				
 </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1331,6 +1331,7 @@ details.respec-tests-details > li {
 
             <section class="guideline" id="distinguishable">
                 <h3 id="x1-4-distinguishable"><span class="secno">ガイドライン 1.4 </span>判別可能<span class="permalink"><a href="#distinguishable" aria-label="Permalink for 1.4 Distinguishable" title="Permalink for 1.4 Distinguishable"><span>§</span></a></span></h3>
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/distinguishable.html">Understanding Distinguishable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#distinguishable">How to Meet Distinguishable</a></div>
                 <p>コンテンツを、利用者にとって見やすく、聞きやすいものにすること。これには、前景と背景を区別することも含む。</p>
 
                 <section class="sc" id="use-of-color">
@@ -1564,7 +1565,7 @@ details.respec-tests-details > li {
    
 </section>
 
-                <section class="sc new" id="reflow">
+                <section class="sc" id="reflow">
    					
    <h4 id="x1-4-10-reflow"><span class="secno">達成基準 1.4.10 </span>リフロー<span class="permalink"><a href="#reflow" aria-label="Permalink for 1.4.10 Reflow" title="Permalink for 1.4.10 Reflow"><span>§</span></a></span></h4>
    					
@@ -1579,14 +1580,14 @@ details.respec-tests-details > li {
    </ul>
    <p>利用や意味の理解に 2 次元のレイアウトが必須である一部のコンテンツを除く。</p>
   
-   <div class="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>注記</span></div><p class="">320 CSS ピクセルは、1280 CSS ピクセル幅を 400% ズームで見た場合の最初の表示幅に相当する。横スクロールになるように設計されたウェブコンテンツ (例えば、縦書きのテキスト) では、256 CSS ピクセルは、高さ 1024px を 400％ ズームで見た場合の最初の表示の高さに相当する。</p></div>
+   <div class="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>注記</span></div><p class="">320 CSS ピクセルは、400% ズーム時の開始ビューポート幅である 1280 CSS ピクセル幅に相当する。横スクロールになるように設計されたウェブコンテンツ (例えば、縦書きのテキスト) の場合、256 CSS ピクセルは、400% ズーム時の開始ビューポート高さである 1024 CSS ピクセル高さに相当する。</p></div>
    
-   <div class="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>注記</span></div><p class="">2 次元のレイアウトを必要とするコンテンツの例としては、画像、マップ、図解、ビデオ、ゲーム、プレゼンテーション、データテーブル、及びコンテンツを操作している間にツールバーを表示しておく必要のあるインタフェースが挙げられる。</p></div>
+   <div class="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>注記</span></div><p class="">2 次元のレイアウトを必要とするコンテンツの例としては、理解のために必要な画像 (地図、図解など)、映像、ゲーム、プレゼンテーション、データテーブル (個々のセルではない)、及びコンテンツを操作している間にツールバーを表示しておく必要のあるインタフェースが挙げられる。そのようなコンテンツの部分には、2 次元スクロールを提供することが許容される。</p></div>
    				
 </section>
 
 
-                <section class="sc new" id="non-text-contrast">
+                <section class="sc" id="non-text-contrast">
    					
    <h4 id="x1-4-11-non-text-contrast"><span class="secno">達成基準 1.4.11 </span>非テキストのコントラスト<span class="permalink"><a href="#non-text-contrast" aria-label="Permalink for 1.4.11 Non-text Contrast" title="Permalink for 1.4.11 Non-text Contrast"><span>§</span></a></span></h4>
    					
@@ -1611,7 +1612,7 @@ details.respec-tests-details > li {
 </section>
 
 
-                 <section class="sc new" id="text-spacing">
+                 <section class="sc" id="text-spacing">
    					
    <h4 id="x1-4-12-text-spacing"><span class="secno">達成基準 1.4.12 </span>テキストの間隔<span class="permalink"><a href="#text-spacing" aria-label="Permalink for 1.4.12 Text Spacing" title="Permalink for 1.4.12 Text Spacing"><span>§</span></a></span></h4>
    					
@@ -1633,7 +1634,7 @@ details.respec-tests-details > li {
 </section>
 
 
-                    <section class="sc new" id="content-on-hover-or-focus">
+                    <section class="sc" id="content-on-hover-or-focus">
    					
    <h4 id="x1-4-13-content-on-hover-or-focus"><span class="secno">達成基準 1.4.13 </span>ホバー又はフォーカスで表示されるコンテンツ<span class="permalink"><a href="#content-on-hover-or-focus" aria-label="Permalink for 1.4.13 Content on Hover or Focus" title="Permalink for 1.4.13 Content on Hover or Focus"><span>§</span></a></span></h4>
    					

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1580,7 +1580,7 @@ details.respec-tests-details > li {
    </ul>
    <p>利用や意味の理解に 2 次元のレイアウトが必須である一部のコンテンツを除く。</p>
   
-   <div class="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>注記</span></div><p class="">320 CSS ピクセルは、400% ズーム時の開始ビューポート幅である 1280 CSS ピクセル幅に相当する。横スクロールになるように設計されたウェブコンテンツ (例えば、縦書きのテキスト) の場合、256 CSS ピクセルは、400% ズーム時の開始ビューポート高さである 1024 CSS ピクセル高さに相当する。</p></div>
+   <div class="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>注記</span></div><p class="">320 CSS ピクセルは、400% ズーム時の開始ビューポート幅 1280 CSS ピクセルに相当する。横スクロールになるように設計されたウェブコンテンツ (例えば、縦書きのテキスト) の場合、256 CSS ピクセルは、400% ズーム時の開始ビューポート高さ 1024 CSS ピクセルに相当する。</p></div>
    
    <div class="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>注記</span></div><p class="">2 次元のレイアウトを必要とするコンテンツの例としては、理解のために必要な画像 (地図、図解など)、映像、ゲーム、プレゼンテーション、データテーブル (個々のセルではない)、及びコンテンツを操作している間にツールバーを表示しておく必要のあるインタフェースが挙げられる。コンテンツのそのような部分には、2 次元スクロールを提供することが許容される。</p></div>
    				


### PR DESCRIPTION
Close #1813

主な修正点は次のとおり：

- 1.4.10リフローの訳注更新（原文変更による）
- 1.4 Understandingのリンク追加
- `.new`の削除

とくに1つ目の訳注について、

> 320 CSS pixels is equivalent to a starting viewport width of 1280 CSS pixels wide at 400% zoom. For web content which is designed to scroll horizontally (e.g., with vertical text), 256 CSS pixels is equivalent to a starting viewport height of 1024 CSS pixels at 400% zoom.

原文では大きな変更はないですが、viewportがビューポートとされてないのを見つけたので、ついでに全体を見直してみました。

2つ目の訳注については、原文での変更点を中心に更新しています。