### PR TITLE
1知覚可能～ガイドライン1.3適応可能の更新

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1044,6 +1044,7 @@ details.respec-tests-details > li {
 
             <section class="guideline" id="text-alternatives">
                 <h3 id="x1-1-text-alternatives"><span class="secno">ガイドライン 1.1 </span>テキストによる代替<span class="permalink"><a href="#text-alternatives" aria-label="Permalink for 1.1 Text Alternatives" title="Permalink for 1.1 Text Alternatives"><span>§</span></a></span></h3>
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/text-alternatives.html">Understanding Text Alternatives</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#text-alternatives">How to Meet Text Alternatives</a></div>
                 <p>すべての非テキストコンテンツには、大活字、点字、音声、シンボル、平易な言葉などの利用者が必要とする形式に変換できるように、テキストによる代替を提供すること。</p>
                 <div class="note"><div role="heading" class="note-title marker" aria-level="4"><span>訳注</span></div><p>大活字とは、通常の出版物より大きな活字のことを指す。<a href="https://www.ndl.go.jp/jp/library/supportvisual/geppo201501/article05.html">障害者向け資料の紹介｜国立国会図書館―National Diet Library</a> も参照。</p></div>
                 <section class="sc" id="non-text-content">
@@ -1118,6 +1119,7 @@ details.respec-tests-details > li {
 
             <section class="guideline" id="time-based-media">
                 <h3 id="x1-2-time-based-media"><span class="secno">ガイドライン 1.2 </span>時間依存メディア<span class="permalink"><a href="#time-based-media" aria-label="Permalink for 1.2 Time-based Media" title="Permalink for 1.2 Time-based Media"><span>§</span></a></span></h3>
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/time-based-media.html">Understanding Time-based Media</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#time-based-media">How to Meet Time-based Media</a></div>
                 <p>時間依存メディアには代替コンテンツを提供すること。</p>
 
                 <section class="sc" id="audio-only-and-video-only-prerecorded">
@@ -1244,6 +1246,7 @@ details.respec-tests-details > li {
 
             <section class="guideline" id="adaptable">
                 <h3 id="x1-3-adaptable"><span class="secno">ガイドライン 1.3 </span>適応可能<span class="permalink"><a href="#adaptable" aria-label="Permalink for 1.3 Adaptable" title="Permalink for 1.3 Adaptable"><span>§</span></a></span></h3>
+                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/adaptable.html">Understanding Adaptable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#adaptable">How to Meet Adaptable</a></div>
                 <p>情報、及び構造を損なうことなく、様々な方法 (例えば、よりシンプルなレイアウト) で提供できるようにコンテンツを制作すること。</p>
 
                 <section class="sc" id="info-and-relationships">
@@ -1282,7 +1285,7 @@ details.respec-tests-details > li {
 </section>
 
 
-                <section class="sc new" id="orientation">
+                <section class="sc" id="orientation">
    					
    <h4 id="x1-3-4-orientation"><span class="secno">達成基準 1.3.4 </span>表示の向き<span class="permalink"><a href="#orientation" aria-label="Permalink for 1.3.4 Orientation" title="Permalink for 1.3.4 Orientation"><span>§</span></a></span></h4>
    					
@@ -1290,14 +1293,14 @@ details.respec-tests-details > li {
    					
    
    					
-  <p>コンテンツは、その表示及び操作を、縦向き (portrait) 又は横向き (landscape) などの単一の向きに制限しない。ただし、その表示の向きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合は例外とする。</p>
+  <p>コンテンツは、その表示及び操作を、縦向き (portrait) 又は横向き (landscape) のような単一の表示の向きに制限しない。ただし、特定の表示の向きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合は除く。</p>
    				
-   <div class="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="5"><span>注記</span></div><p class="">単一の表示の向きが必要不可欠な例としては、銀行の小切手、ピアノのアプリケーション、プロジェクタやテレビ向けのスライド、バイナリディスプレイ表示が適用されないバーチャルリアリティのコンテンツなどが挙げられる。</p></div>
+   <div class="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="5"><span>注記</span></div><p class="">特定の表示の向きが必要不可欠な例としては、銀行の小切手、ピアノのアプリケーション、プロジェクター又はテレビ向けのスライド、コンテンツが必ずしも横向き (landscape) 又は縦向き (portrait) の表示の向きに制限されないバーチャルリアリティのコンテンツが挙げられる。</p></div>
    					
 </section>
 
 
-                <section class="sc new" id="identify-input-purpose">
+                <section class="sc" id="identify-input-purpose">
 	
 	<h4 id="x1-3-5-identify-input-purpose"><span class="secno">達成基準 1.3.5 </span>入力目的の特定<span class="permalink"><a href="#identify-input-purpose" aria-label="Permalink for 1.3.5 Identify Input Purpose" title="Permalink for 1.3.5 Identify Input Purpose"><span>§</span></a></span></h4>
 	
@@ -1315,7 +1318,7 @@ details.respec-tests-details > li {
 </section>
 
               
-                <section class="sc new" id="identify-purpose">
+                <section class="sc" id="identify-purpose">
    					
    <h4 id="x1-3-6-identify-purpose"><span class="secno">達成基準 1.3.6 </span>目的の特定<span class="permalink"><a href="#identify-purpose" aria-label="Permalink for 1.3.6 Identify Purpose" title="Permalink for 1.3.6 Identify Purpose"><span>§</span></a></span></h4>
    					

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1293,9 +1293,9 @@ details.respec-tests-details > li {
    					
    
    					
-  <p>コンテンツは、その表示及び操作を、縦向き (portrait) 又は横向き (landscape) のような単一の表示の向きに制限しない。ただし、特定の表示の向きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合は除く。</p>
+  <p>コンテンツは、その表示及び操作を、縦向き (portrait) 又は横向き (landscape) のような単一のディスプレイの向きに制限しない。ただし、特定の表示装置の向きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合は除く。</p>
    				
-   <div class="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="5"><span>注記</span></div><p class="">特定の表示の向きが必要不可欠な例としては、銀行の小切手、ピアノのアプリケーション、プロジェクター又はテレビ向けのスライド、コンテンツが必ずしも横向き (landscape) 又は縦向き (portrait) の表示の向きに制限されないバーチャルリアリティのコンテンツが挙げられる。</p></div>
+   <div class="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="5"><span>注記</span></div><p class="">特定のディスプレイの向きが必要不可欠となり得る例としては、銀行の小切手、ピアノのアプリケーション、プロジェクターもしくはテレビ向けのスライド、又はコンテンツが必ずしも横向き (landscape) もしくは縦向き (portrait) のディスプレイの向きに制限されないバーチャルリアリティのコンテンツが挙げられる。</p></div>
    					
 </section>
 


### PR DESCRIPTION
Close #1812

主な修正点：

- Understandingへのリンク追加
- `.new`の削除
- 1.3.4表示の向きについて、原文の注記に伴う訳文の修正

達成基準：
> Content does not restrict its view and operation to a single display orientation, such as portrait or landscape, unless a specific display orientation is essential.

注記（2018）：
> Examples where a particular display orientation may be essential are a bank check, a piano application, slides for a projector or television, or virtual reality content where binary display orientation is not applicable.

注記（2023）：
> Examples where a particular display orientation may be essential are a bank check, a piano application, slides for a projector or television, or virtual reality content where content is not necessarily restricted to landscape or portrait display orientation.

注記（2023）でwhere以下が更新されたのに伴い、注記だけでなく達成基準も修正してみました。

- 注記のwhere以下では「コンテンツが必ずしも横向き (landscape) 又は縦向き (portrait) の表示の向きに制限されない」となっており、よって注記冒頭を「a particular display orientation」が「単一の表示の向き」とするよりかは辞書どおりの「特定の表示の向き」としたほうが適切ではないか
   - 達成基準で「view」が「表示」であるが、「a specific display orientation」 を「特定の表示の向き」というイディオムだと捉えれば「表示」がかぶっても問題ないと思われる。むしろ、「unless」以下と注記冒頭との連続性を考えると明確に訳すのが適当と思われる
- 達成基準の「such as」を「などの」とすると「又は」が使えなくなってしまう（JIS Z 8301:2019 H 3.2.4による）ので、「ような」としてみた
- 注記の「projector」を「プロジェクター」としてみた
  - [JIS原案作成のための手引【第 21 版】JIS Z 8301:2019 の主な改正点](https://webdesk.jsa.or.jp/pdf/dev/md_5652.pdf#page=115)によれば、長音を省く原則がなくなった。そのため、[外来語の表記　留意事項その2\(細則的な事項\)](https://www.bunka.go.jp/kokugo_nihongo/sisaku/joho/joho/kijun/naikaku/gairai/honbun06.html)に従った