### PR TITLE
一部の達成基準番号の閉じタグの位置を修正する

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1177,7 +1177,7 @@ details.respec-tests-details > li {
 
                 <section class="sc" id="captions-live">
    
-   <h4 id="x1-2-4-captions-live"><span class="secno">達成基準 </span>1.2.4 キャプション (ライブ)<span class="permalink"><a href="#captions-live" aria-label="Permalink for 1.2.4 Captions (Live)" title="Permalink for 1.2.4 Captions (Live)"><span>§</span></a></span></h4>
+   <h4 id="x1-2-4-captions-live"><span class="secno">達成基準 1.2.4 </span>キャプション (ライブ)<span class="permalink"><a href="#captions-live" aria-label="Permalink for 1.2.4 Captions (Live)" title="Permalink for 1.2.4 Captions (Live)"><span>§</span></a></span></h4>
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html">Understanding Captions (Live)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#captions-live">How to Meet Captions (Live)</a></div><p class="conformance-level">(レベル AA)</p>
    
@@ -1199,7 +1199,7 @@ details.respec-tests-details > li {
 
                 <section class="sc" id="sign-language-prerecorded">
    
-   <h4 id="x1-2-6-sign-language-prerecorded"><span class="secno">達成基準 </span>1.2.6 手話 (収録済)<span class="permalink"><a href="#sign-language-prerecorded" aria-label="Permalink for 1.2.6 Sign Language (Prerecorded)" title="Permalink for 1.2.6 Sign Language (Prerecorded)"><span>§</span></a></span></h4>
+   <h4 id="x1-2-6-sign-language-prerecorded"><span class="secno">達成基準 1.2.6 </span>手話 (収録済)<span class="permalink"><a href="#sign-language-prerecorded" aria-label="Permalink for 1.2.6 Sign Language (Prerecorded)" title="Permalink for 1.2.6 Sign Language (Prerecorded)"><span>§</span></a></span></h4>
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/sign-language-prerecorded.html">Understanding Sign Language (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#sign-language-prerecorded">How to Meet Sign Language (Prerecorded)</a></div><p class="conformance-level">(レベル AAA)</p>
    
@@ -1404,7 +1404,7 @@ details.respec-tests-details > li {
 
                 <section class="sc" id="resize-text">
    
-   <h4 id="x1-4-4-resize-text"><span class="secno">達成基準 </span>1.4.4 テキストのサイズ変更<span class="permalink"><a href="#resize-text" aria-label="Permalink for 1.4.4 Resize text" title="Permalink for 1.4.4 Resize text"><span>§</span></a></span></h4>
+   <h4 id="x1-4-4-resize-text"><span class="secno">達成基準 1.4.4 </span>テキストのサイズ変更<span class="permalink"><a href="#resize-text" aria-label="Permalink for 1.4.4 Resize text" title="Permalink for 1.4.4 Resize text"><span>§</span></a></span></h4>
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html">Understanding Resize text</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#resize-text">How to Meet Resize text</a></div><p class="conformance-level">(レベル AA)</p>
    
@@ -1534,7 +1534,7 @@ details.respec-tests-details > li {
 
                 <section class="sc" id="visual-presentation">
    
-   <h4 id="x1-4-8-visual-presentation"><span class="secno">達成基準 </span>1.4.8 視覚的提示<span class="permalink"><a href="#visual-presentation" aria-label="Permalink for 1.4.8 Visual Presentation" title="Permalink for 1.4.8 Visual Presentation"><span>§</span></a></span></h4>
+   <h4 id="x1-4-8-visual-presentation"><span class="secno">達成基準 1.4.8 </span>視覚的提示<span class="permalink"><a href="#visual-presentation" aria-label="Permalink for 1.4.8 Visual Presentation" title="Permalink for 1.4.8 Visual Presentation"><span>§</span></a></span></h4>
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html">Understanding Visual Presentation</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#visual-presentation">How to Meet Visual Presentation</a></div><p class="conformance-level">(レベル AAA)</p>
    
@@ -2379,7 +2379,7 @@ details.respec-tests-details > li {
 
                 <section class="sc" id="error-prevention-legal-financial-data">
    
-   <h4 id="x3-3-4-error-prevention-legal-financial-data"><span class="secno">達成基準 3.3.4 誤り防止 </span>(法的、金融、データ)<span class="permalink"><a href="#error-prevention-legal-financial-data" aria-label="Permalink for 3.3.4 Error Prevention (Legal, Financial, Data)" title="Permalink for 3.3.4 Error Prevention (Legal, Financial, Data)"><span>§</span></a></span></h4>
+   <h4 id="x3-3-4-error-prevention-legal-financial-data"><span class="secno">達成基準 3.3.4 </span>誤り防止 (法的、金融、データ)<span class="permalink"><a href="#error-prevention-legal-financial-data" aria-label="Permalink for 3.3.4 Error Prevention (Legal, Financial, Data)" title="Permalink for 3.3.4 Error Prevention (Legal, Financial, Data)"><span>§</span></a></span></h4>
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html">Understanding Error Prevention (Legal, Financial, Data)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-prevention-legal-financial-data">How to Meet Error Prevention (Legal, Financial, Data)</a></div><p class="conformance-level">(レベル AA)</p>
    


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [x] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [x] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [x] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント
達成基準番号の `<span class="sc">` が含む範囲が他と異なる箇所がいくつかあったので修正しました。見た目に影響はありませんが、プログラムによる一括処理しやすさのため事前に修正しておきたいです。