### PR TITLE
WCAG 2.1 (2023) 年版のHTMLへの流し込み

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -3180,7 +3180,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
          		
          
          		
-         <p>このセクションでは、WCAG 2.1 が <abbr title="World Wide Web Consortium">>W3C</abbr> 勧告として発行されてからの変更点を示す。これらの変更点は、<a href="https://www.w3.org/WAI/WCAG21/errata/">errata</a> としても記録されている。</p>
+         <p>このセクションでは、WCAG 2.1 が <abbr title="World Wide Web Consortium">W3C</abbr> 勧告として発行されてからの変更点を示す。これらの変更点は、<a href="https://www.w3.org/WAI/WCAG21/errata/">errata</a> としても記録されている。</p>
          
          <p>2018 年 6 月 5 日の <a href="https://www.w3.org/TR/2018/REC-WCAG21-20180605/"><abbr title="World Wide Web Consortium">W3C</abbr> 勧告</a>以降の変更点:</p>
          

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1,1325 +1,725 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja"><head><meta charset="UTF-8"><meta name="generator" content="ReSpec 21.0.1"><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><style>/* --- ISSUES/NOTES --- */
-div.issue-title, div.note-title , div.ednote-title, div.warning-title {
-    padding-right:  1em;
-    min-width: 7.5em;
-    color: #b9ab2d;
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja"><head>
+<meta charset="UTF-8">
+<meta name="generator" content="ReSpec 34.1.8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+span.example-title{text-transform:none}
+:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+div.illegal-example{color:red}
+div.illegal-example p{color:#000}
+:is(aside,div).example{border-left-width:.5em;border-left-style:solid;border-color:#e0cb52;background:#fcfaee}
+aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+.example pre{background-color:rgba(0,0,0,.03)}
+</style>
+<style>
+.issue-label{text-transform:initial}
+.warning>p:first-child{margin-top:0}
+.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+span.warning{padding:.1em .5em .15em}
+.issue.closed span.issue-number{text-decoration:line-through}
+.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
+.warning{border-color:#f11;border-width:.2em;border-style:solid;background:#fbe9e9}
+.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+li.task-list-item{list-style:none}
+input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;color:#000;box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;margin-top:.25em}
+.dfn-panel ul a[href]{color:#333}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+      
+      
+      
+      
+      
+<title>Web Content Accessibility Guidelines (WCAG) 2.1</title>
+      	
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
 }
-div.issue-title { color: #e05252; }
-div.note-title, div.ednote-title { color: #2b2; }
-div.warning-title { color: #f22; }
-div.issue-title span, div.note-title span, div.ednote-title span, div.warning-title span {
-    text-transform: uppercase;
+:is(h1,h2,h3,h4,h5,h6,a) abbr{border:none}
+dfn{font-weight:700}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
 }
-div.note, div.issue, div.ednote, div.warning {
-    margin-top: 1em;
-    margin-bottom: 1em;
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:normal}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+.toc a,.tof a{text-decoration:none}
+a .figno,a .secno{color:#000}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+table.simple{border-spacing:0;border-collapse:collapse;border-bottom:3px solid #005a9c}
+.simple th{background:#005a9c;color:#fff;padding:3px 5px;text-align:left}
+.simple th a{color:#fff;padding:3px 5px;text-align:left}
+.simple th[scope=row]{background:inherit;color:inherit;border-top:1px solid #ddd}
+.simple td{padding:3px 10px;border-top:1px solid #ddd}
+.simple tr:nth-child(even){background:#f0f6ff}
+.section dd>p:first-child{margin-top:0}
+.section dd>p:last-child{margin-bottom:0}
+.section dd{margin-bottom:1em}
+.section dl.attrs dd,.section dl.eldef dd{margin-bottom:0}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+aside.example .marker>a.self-link{color:inherit}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+:is(h2,h3)+a.self-link{top:-.2em}
+:is(h4,h5,h6)+a.self-link::before{color:#000}
+@media (max-width:767px){
+dd{margin-left:0}
 }
-.note > p:first-child, .ednote > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
-.issue, .note, .ednote, .warning {
-    padding: .5em;
-    border-left-width: .5em;
-    border-left-style: solid;
-}
-div.issue, div.note , div.ednote,  div.warning {
-    padding: 1em 1.2em 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
-}
-span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
-
-.issue {
-    border-color: #e05252;
-    background: #fbe9e9;
-}
-.note, .ednote {
-    border-color: #52e052;
-    background: #e9fbe9;
-}
-
-.warning {
-    border-color: #f11;
-    border-width: .2em;
-    border-style: solid;
-    background: #fbe9e9;
-}
-
-.warning-title:before{
-    content: "⚠"; /*U+26A0 WARNING SIGN*/
-    font-size: 3em;
-    float: left;
-    height: 100%;
-    padding-right: .3em;
-    vertical-align: top;
-    margin-top: -0.5em;
-}
-
-li.task-list-item {
-    list-style: none;
-}
-
-input.task-list-item-checkbox {
-    margin: 0 0.35em 0.25em -1.6em;
-    vertical-align: middle;
-}
-
-.issue a.respec-gh-label {
-  padding: 5px;
-  margin: 0 2px 0 2px;
-  font-size: 10px;
-  text-transform: none;
-  text-decoration: none;
-  font-weight: bold;
-  border-radius: 4px;
-  position: relative;
-  bottom: 2px;
-}
-
-.issue a.respec-label-dark {
-  color: #fff;
-  background-color: #000;
-}
-
-.issue a.respec-label-light {
-  color: #000;
-  background-color: #fff;
+@media print{
+.removeOnSave{display:none}
 }
 </style>
-<style>/* --- PERMALINKS --- */
-
-.permalink {
-  width: 1px;
-  height: 1px;
-  overflow: visible;
-  font-size: 10pt;
-  font-style: normal;
-  vertical-align: middle;
-  margin-left: 4px;
-  float: right;
-}
-
-.permalink a, .permalink a:link, .permalink a:visited, .permalink a:hover, .permalink a:focus, .permalink a:active {
-  background:transparent !important;
-  text-decoration:none;
-  font-weight: bold;
-  color:#666 !important;
-}
-
-.permalink abbr {
-  border:0;
-}
+      	
+      	
+      	
+      	
+      
+      
+<link rel="stylesheet" type="text/css" href="https://www.w3.org/TR/WCAG21/guidelines.css">
+      
+   
+<meta name="description" content="Web Content Accessibility Guidelines (WCAG) 2.1 は、ウェブコンテンツをよりアクセシブルにするための広範囲に及ぶ推奨事項を網羅している。このガイドラインに従うことで、全盲又はロービジョン、ろう又は難聴、運動制限、発話困難、光感受性発作及びこれらの組合せ、並びに学習障害及び認知限界への一部の適応を含んだ、様々な障害のある人に対して、コンテンツをアクセシブルにすることができる。しかし、これらの障害のある人に対するあらゆる利用者のニーズに対処するものではない。このガイドラインは、デスクトップ、ラップトップ、タブレット、及びモバイルデバイス上のウェブコンテンツのアクセシビリティを扱う。このガイドラインに従うことは、一般にウェブコンテンツが利用者にとってより使いやすいものにもなる。">
+<link rel="canonical" href="https://www.w3.org/TR/WCAG21/">
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#000}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#000;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 </style>
-        
-
-        <title>Web Content Accessibility Guidelines (WCAG) 2.1</title>
-    	
-    	
-    	
-    	
-    	
-        <link rel="stylesheet" type="text/css" href="https://www.w3.org/TR/WCAG21/guidelines.css">
-    <style id="respec-mainstyle">/*****************************************************************
- * ReSpec 3 CSS
- * Robin Berjon - http://berjon.com/
- *****************************************************************/
-
-/* Override code highlighter background */
-.hljs {
-  background: transparent !important;
-}
-
-/* --- INLINES --- */
-h1 abbr,
-h2 abbr,
-h3 abbr,
-h4 abbr,
-h5 abbr,
-h6 abbr,
-a abbr {
-  border: none;
-}
-
-dfn {
-  font-weight: bold;
-}
-
-a.internalDFN {
-  color: inherit;
-  border-bottom: 1px solid #99c;
-  text-decoration: none;
-}
-
-a.externalDFN {
-  color: inherit;
-  border-bottom: 1px dotted #ccc;
-  text-decoration: none;
-}
-
-a.bibref {
-  text-decoration: none;
-}
-
-cite .bibref {
-  font-style: normal;
-}
-
-code {
-  color: #c83500;
-}
-
-th code {
-  color: inherit;
-}
-
-/* --- TOC --- */
-
-.toc a,
-.tof a {
-  text-decoration: none;
-}
-
-a .secno,
-a .figno {
-  color: #000;
-}
-
-ul.tof,
-ol.tof {
-  list-style: none outside none;
-}
-
-.caption {
-  margin-top: 0.5em;
-  font-style: italic;
-}
-
-/* --- TABLE --- */
-
-table.simple {
-  border-spacing: 0;
-  border-collapse: collapse;
-  border-bottom: 3px solid #005a9c;
-}
-
-.simple th {
-  background: #005a9c;
-  color: #fff;
-  padding: 3px 5px;
-  text-align: left;
-}
-
-.simple th[scope="row"] {
-  background: inherit;
-  color: inherit;
-  border-top: 1px solid #ddd;
-}
-
-.simple td {
-  padding: 3px 10px;
-  border-top: 1px solid #ddd;
-}
-
-.simple tr:nth-child(even) {
-  background: #f0f6ff;
-}
-
-/* --- DL --- */
-
-.section dd > p:first-child {
-  margin-top: 0;
-}
-
-.section dd > p:last-child {
-  margin-bottom: 0;
-}
-
-.section dd {
-  margin-bottom: 1em;
-}
-
-.section dl.attrs dd,
-.section dl.eldef dd {
-  margin-bottom: 0;
-}
-
-#issue-summary > ul,
-.respec-dfn-list {
-  column-count: 2;
-}
-
-#issue-summary li,
-.respec-dfn-list li {
-  list-style: none;
-}
-
-details.respec-tests-details {
-  margin-left: 1em;
-  display: inline-block;
-  vertical-align: top;
-}
-
-details.respec-tests-details > * {
-  padding-right: 2em;
-}
-
-details.respec-tests-details[open] {
-  z-index: 999999;
-  position: absolute;
-  border: thin solid #cad3e2;
-  border-radius: .3em;
-  background-color: white;
-  padding-bottom: .5em;
-}
-
-details.respec-tests-details[open] > summary {
-  border-bottom: thin solid #cad3e2;
-  padding-left: 1em;
-  margin-bottom: 1em;
-  line-height: 2em;
-}
-
-details.respec-tests-details > ul {
-  width: 100%;
-  margin-top: -0.3em;
-}
-
-details.respec-tests-details > li {
-  padding-left: 1em;
-}
-
-@media print {
-  .removeOnSave {
-    display: none;
-  }
-}
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-REC"><link rel="canonical" href="https://www.w3.org/TR/WCAG21/"><meta name="description" content="Web Content Accessibility Guidelines (WCAG) 2.1 は、ウェブコンテンツをよりアクセシブルにするための広範囲に及ぶ推奨事項を網羅している。Following these guidelines will make content more accessible to a wider range of people with disabilities, including accommodations for blindness and low vision, deafness and hearing loss, limited movement, speech disabilities, photosensitivity, and combinations of these, and some accommodation for learning disabilities and cognitive limitations; but will not address every user need for people with these disabilities. These guidelines address accessibility of web content on desktops, laptops, tablets, and mobile devices. Following these guidelines will also often make Web content more usable to users in general."></head>
-    <body class="h-entry">
+<script id="initialUserConfig" type="application/json">{
+  "trace": true,
+  "useExperimentalStyles": true,
+  "doRDFa": "1.1",
+  "includePermalinks": true,
+  "permalinkEdge": true,
+  "permalinkHide": false,
+  "tocIntroductory": true,
+  "specStatus": "REC",
+  "diffTool": "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+  "shortName": "WCAG21",
+  "publishDate": "2023-09-21",
+  "copyrightStart": "2020",
+  "license": "document",
+  "previousPublishDate": "2018-06-05",
+  "previousMaturity": "REC",
+  "prevRecURI": "https://www.w3.org/TR/WCAG/",
+  "edDraftURI": "https://w3c.github.io/wcag/guidelines/22/",
+  "implementationReportURI": "https://www.w3.org/WAI/WCAG21/implementation-report/",
+  "group": "ag",
+  "github": "w3c/wcag",
+  "editors": [
+    {
+      "name": "Andrew Kirkpatrick",
+      "mailto": "akirkpat@adobe.com",
+      "company": "Adobe",
+      "companyURI": "http://www.adobe.com/",
+      "w3cid": 39770,
+      "url": "mailto:akirkpat@adobe.com"
+    },
+    {
+      "name": "Joshue O Connor",
+      "mailto": "josh@interaccess.ie",
+      "company": "Invited Expert, InterAccess",
+      "companyURI": "https://interaccess.org/",
+      "w3cid": 41218,
+      "url": "mailto:josh@interaccess.ie"
+    },
+    {
+      "name": "Alastair Campbell",
+      "mailto": "acampbell@nomensa.com",
+      "company": "Nomensa",
+      "companyURI": "https://www.nomensa.com/",
+      "w3cid": 44689,
+      "url": "mailto:acampbell@nomensa.com"
+    },
+    {
+      "name": "Michael Cooper",
+      "mailto": "cooper@w3.org",
+      "company": "W3C",
+      "companyURI": "https://www.w3.org",
+      "w3cid": 34017,
+      "url": "mailto:cooper@w3.org"
+    }
+  ],
+  "errata": "https://www.w3.org/WAI/WCAG21/errata/",
+  "wg": "Accessibility Guidelines Working Group",
+  "wgURI": "https://www.w3.org/WAI/GL/",
+  "wgPublicList": "public-agwg-comments",
+  "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/35422/status",
+  "maxTocLevel": 4,
+  "postProcess": [
+    null
+  ],
+  "localBiblio": {
+    "CAPTCHA": {
+      "href": "http://www.captcha.net/",
+      "publisher": "Carnegie Mellon University",
+      "title": "The CAPTCHA Project"
+    },
+    "GPII": {
+      "href": "https://gpii.net/",
+      "title": "Global Public Inclusive Infrastructure"
+    },
+    "HARDING-BINNIE": {
+      "authors": [
+        "Harding G. F. A.",
+        "Binnie, C.D."
+      ],
+      "date": "2002",
+      "title": "Independent Analysis of the ITC Photosensitive Epilepsy Calibration Test Tape"
+    },
+    "IEC-4WD": {
+      "date": "May 5, 1998",
+      "title": "IEC/4WD 61966-2-1: Colour Measurement and Management in Multimedia Systems and Equipment - Part 2.1: Default Colour Space - sRGB"
+    },
+    "ISO_9241-112": {
+      "uri": "https://www.iso.org/standard/64840.html",
+      "title": "Ergonomics of human-system interaction -- Part 112: Principles for the presentation of information",
+      "publisher": "International Standards Organization"
+    },
+    "ISO_9241-391": {
+      "isoNumber": "9241-391",
+      "href": "https://www.iso.org/standard/56350.html",
+      "title": "Ergonomics of human-system interaction—Part 391: Requirements, analysis and compliance test methods for the reduction of photosensitive seizures",
+      "publisher": "International Standards Organization",
+      "id": "iso_9241-391"
+    },
+    "UNESCO": {
+      "date": "1997",
+      "href": "http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm",
+      "title": "International Standard Classification of Education",
+      "id": "unesco"
+    }
+  },
+  "publishISODate": "2023-09-21T00:00:00.000Z",
+  "generatedSubtitle": "W3C Recommendation 21 September 2023"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-REC"></head>
+   
+   <body class="h-entry informative">
 <aside class="trnote">
 <p>この文書は、<a href="https://www.w3.org/TR/2023/REC-WCAG21-20230921/">2023 年 9 月 21 日付けの W3C 勧告 Web Content Accessibility Guidelines (WCAG) 2.1</a>を、<a href="https://waic.jp/committee/wg4/">ウェブアクセシビリティ基盤委員会 (WAIC) の翻訳ワーキンググループ</a>が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書は作業進行中です。また、あくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://docs.google.com/forms/d/e/1FAIpQLSdIpvogLx8kGIMewhQ6MzhG2pOCQZ50iIBViGg8pUrRJuslKg/viewform?entry.685195438=https%3A%2F%2Fwaic.jp%2ftranslations%2fWCAG21%2f" id="file-issue">翻訳に関するお問い合わせ (Google フォーム)</a>からご連絡ください。</p>
 <p>この翻訳文書の利用条件については、<a href="https://waic.jp/license-for-translated-documents/">WAICが提供する翻訳文書のライセンス</a>をご覧ください。</p>
 </aside>
-    <div class="head">
-  <a href="https://www.w3.org/" class="logo">
-      <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48">
-  </a>
-  <h1 id="title" class="title p-name">Web Content Accessibility Guidelines (WCAG) 2.1</h1>
-  
-  <h2 id="w3c-recommendation-05-june-2018"><abbr title="World Wide Web Consortium">W3C</abbr> Recommendation <time class="dt-published" datetime="2023-09-21">21 September 2023</time></h2>
-  <dl>
-    <dt>このバージョン:</dt><dd><a class="u-url" href="https://www.w3.org/TR/2023/REC-WCAG21-20230921/">https://www.w3.org/TR/2023/REC-WCAG21-20230921/</a></dd><dt>最新バージョン:</dt><dd><a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a></dd>
-    <dt>最新の編集者バージョン:</dt><dd><a href="https://w3c.github.io/wcag/guidelines/22/">https://w3c.github.io/wcag/guidelines/22/</a></dd>
-        <dt>履歴:</dt><dd>
-                    <a href="https://www.w3.org/standards/history/WCAG21/">https://www.w3.org/standards/history/WCAG21/</a>
-                  </dd><dd>
-                    <a href="https://github.com/w3c/wcag/commits/">Commit history</a>
-                  </dd>
-    <dt>実装報告書:</dt><dd><a href="https://www.w3.org/WAI/WCAG21/implementation-report/">https://www.w3.org/WAI/WCAG21/implementation-report/</a></dd>
-    
-    
-    <dt>前の勧告:</dt><dd><a href="https://www.w3.org/TR/WCAG20/">https://www.w3.org/TR/WCAG20/</a></dd>
-        <dt>編集者:</dt><dd class="editor p-author h-card vcard" data-editor-id="39770">
-    <a class="ed_mailto u-email email p-name" href="mailto:akirkpat@adobe.com">Andrew Kirkpatrick</a> (<span class="p-org org h-org">Adobe</span>)
-  </dd><dd class="editor p-author h-card vcard" data-editor-id="41218">
-    <a class="ed_mailto u-email email p-name" href="mailto:josh@interaccess.ie">Joshue O Connor</a> (<span class="p-org org h-org">Invited Expert, InterAccess</span>)
-  </dd><dd class="editor p-author h-card vcard" data-editor-id="44689">
-    <a class="ed_mailto u-email email p-name" href="mailto:acampbell@nomensa.com">Alastair Campbell</a> (<span class="p-org org h-org">Nomensa</span>)
-  </dd><dd class="editor p-author h-card vcard" data-editor-id="34017">
-    <a class="ed_mailto u-email email p-name" href="mailto:cooper@w3.org">Michael Cooper</a> (<span class="p-org org h-org">W3C</span>)
-  </dd>
+<div class="head"><p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a></p>
+    <h1 id="title" class="title">Web Content Accessibility Guidelines (WCAG) 2.1</h1> 
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#REC">W3C Recommendation</a> <time class="dt-published" datetime="2023-09-21">21 September 2023</time></p>
+    <details open="">
+      <summary>More details about this document</summary>
+      <dl>
+        <dt>このバージョン:</dt><dd><a class="u-url" href="https://www.w3.org/TR/2023/REC-WCAG21-20230921/">https://www.w3.org/TR/2023/REC-WCAG21-20230921/</a></dd>
+        <dt>最新バージョン:</dt><dd><a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a></dd>
+        <dt>最新の編集者バージョン: </dt><dd><a href="https://w3c.github.io/wcag/guidelines/22/">https://w3c.github.io/wcag/guidelines/22/</a></dd>
+        <dt>履歴: </dt><dd><a href="https://www.w3.org/standards/history/WCAG21/">https://www.w3.org/standards/history/WCAG21/</a></dd><dd><a href="https://github.com/w3c/wcag/commits/">Commit history</a></dd>
+        
+        <dt>実装報告書: </dt><dd><a href="https://www.w3.org/WAI/WCAG21/implementation-report/">https://www.w3.org/WAI/WCAG21/implementation-report/</a></dd>
         
         
-        <dt>フィードバック:</dt><dd>
-        <a href="https://github.com/w3c/wcag/">GitHub w3c/wcag</a>
-        (<a href="https://github.com/w3c/wcag/pulls/">pull requests</a>,
-        <a href="https://github.com/w3c/wcag/issues/new/choose">new issue</a>,
-        <a href="https://github.com/w3c/wcag/issues/">open issues</a>)
-      </dd><dd><a href="mailto:public-agwg-comments@w3.org?subject=%5BWCAG21%5D%20YOUR%20TOPIC%20HERE">public-agwg-comments@w3.org</a> <kbd>[WCAG21] <em>… メッセージトピック …</em></kbd>の件名にて (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-agwg-comments">archives</a>)</dd>
-        <dt>エラッタ:</dt><dd><a href="https://www.w3.org/WAI/WCAG21/errata/">Errata</a></dd>
+        <dt>前の勧告: </dt><dd><a href="https://www.w3.org/TR/WCAG20/">https://www.w3.org/TR/WCAG20/</a></dd>
+        <dt>編集者: </dt><dd class="editor p-author h-card vcard" data-editor-id="39770"><a class="ed_mailto u-email email p-name" href="mailto:akirkpat@adobe.com">Andrew Kirkpatrick</a> (<span class="p-org org h-org">Adobe</span>)</dd><dd class="editor p-author h-card vcard" data-editor-id="41218"><a class="ed_mailto u-email email p-name" href="mailto:josh@interaccess.ie">Joshue O Connor</a> (<span class="p-org org h-org">Invited Expert, InterAccess</span>)</dd><dd class="editor p-author h-card vcard" data-editor-id="44689"><a class="ed_mailto u-email email p-name" href="mailto:acampbell@nomensa.com">Alastair Campbell</a> (<span class="p-org org h-org">Nomensa</span>)</dd><dd class="editor p-author h-card vcard" data-editor-id="34017"><a class="ed_mailto u-email email p-name" href="mailto:cooper@w3.org">Michael Cooper</a> (<span class="p-org org h-org">W3C</span>)</dd>
+        
+        
+        <dt>フィードバック:</dt><dd><a href="https://github.com/w3c/wcag/">GitHub w3c/wcag</a> (<a href="https://github.com/w3c/wcag/pulls/">pull requests</a>, <a href="https://github.com/w3c/wcag/issues/new/choose">new issue</a>, <a href="https://github.com/w3c/wcag/issues/">open issues</a>)</dd><dd><a href="mailto:public-agwg-comments@w3.org?subject=%5BWCAG21%5D%20YOUR%20TOPIC%20HERE">public-agwg-comments@w3.org</a> <kbd>[WCAG21] <em>… メッセージトピック … </em>の件名にて</kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-agwg-comments">archives</a>)</dd>
+        <dt>エラッタ:</dt><dd><a href="https://www.w3.org/WAI/WCAG21/errata/">Errata exists</a>.</dd>
+        
+      </dl>
+    </details>
+    <p><a href="https://www.w3.org/Translations/?technology=WCAG21"><strong>translations</strong></a> も参照できる。</p>
     
-  </dl>
-    <p>
-          <a href="https://www.w3.org/Translations/?technology=WCAG21">
-            <strong>translations</strong></a> も参照できる。
-        </p>
-    
-    <p class="copyright">
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
-    ©
-    2020-2023
-    
-    <a href="https://www.w3.org/">World Wide Web Consortium</a>.
-    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-    <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents" title="W3C Document License">document use</a> rules apply.
-  </p>
+    <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2020-2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents" title="W3C Document License">document use</a> rules apply.</p>
     <hr title="Separator for header">
-</div><!--OddPage-->
-        <section id="abstract" class="introductory"><h2 id="abstract-0">概要</h2>
-            <p>Web Content Accessibility Guidelines (WCAG) 2.1 は、ウェブコンテンツをよりアクセシブルにするための広範囲に及ぶ推奨事項を網羅している。このガイドラインに従うことで、全盲又はロービジョン、ろう又は難聴、運動制限、発話困難、光感受性発作及びこれらの組合せ、並びに学習障害及び認知限界への一部の適応を含んだ、様々な障害のある人に対して、コンテンツをアクセシブルにすることができる。しかし、これらの障害のある人に対するあらゆる利用者のニーズに対処するものではない。このガイドラインは、デスクトップ、ラップトップ、タブレット、及びモバイルデバイス上のウェブコンテンツのアクセシビリティを扱う。このガイドラインに従うことは、一般にウェブコンテンツが利用者にとってより使いやすいものにもなる。</p>
-        	<p>WCAG 2.1 の達成基準は、技術に依存しない検証可能なものとして記述されている。特定の技術において達成基準を満たすためのガイドは、達成基準を理解するための一般的な情報とあわせて、別の文書群として提供している。イントロダクション並びに WCAG の達成方法及び教育資料については、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。</p>
-            <p>WCAG 2.1 は、2008 年 12 月に <abbr title="World Wide Web Consortium">W3C</abbr> 勧告として発行された、<a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0</a> [<cite><a class="bibref" href="#bib-wcag20">WCAG20</a></cite>] を拡張するものである。WCAG 2.1 に適合するコンテンツは、WCAG 2.0 にも適合する。ワーキンググループは、WCAG 2.0 への適合を要求する方針に対して、WCAG 2.1 が適合の代替手段を提供できることを意図している。WCAG 2.1 の発行は、WCAG 2.0 を廃止又は置き換えるものではない。WCAG 2.0 は <abbr title="World Wide Web Consortium">W3C</abbr> 勧告のままである一方で、<abbr title="World Wide Web Consortium">W3C</abbr> は、アクセシビリティの取組みについて将来の適用性を最大にするために WCAG 2.1 の使用を勧める。<abbr title="World Wide Web Consortium">W3C</abbr> はまた、ウェブアクセシビリティ指針を改良又は更新するときに、WCAG の最新版の使用を奨励する。</p><!--OddPage-->
-        </section>
-        <section id="sotd" class="introductory"><h2 id="status-of-this-document">この文書のステータス</h2><p>
-        <em>この節では、この文書の発行された時点でのステータスを説明する。現行の <abbr title="World Wide Web Consortium">W3C</abbr> の発行文書、及び、この技術レポートの最新版は、https://www.w3.org/TR/ にある <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> で参照可能である。</em>
-      </p>
-
-        <p>これは、<a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a> が作成した WCAG 2.1 の <a href="https://www.w3.org/2018/Process-20180201/#RecsW3C">Recommendation</a> である。これは <a href="https://www.w3.org/WAI/WCAG21/errata/">errata</a> を取り入れており、<a href="#changelog">変更点</a>で説明されている。ある時点で、追加の変更が <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">Edited or Amended Recommendation</a> へ取り入れられる可能性がある。</p>
-
-        <p>コメントするためには、<a href="https://github.com/w3c/wcag/issues/new"><abbr title="World Wide Web Consortium">W3C</abbr> WCAG GitHub リポジトリにイシューを提出していただきたい</a>。この文書で提案されている達成基準は、議論が続いているイシューを参照しているが、ワーキンググループは、パブリックコメントをコメントごとに一つの新しいイシューとして提出するよう要請する。GitHub アカウントを作成してイシューを提出することは自由である。GitHub でイシューの提出が実現できない場合、<a href="mailto:public-agwg-comments@w3.org?subject=WCAG%202.1%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>) へ電子メールを送付していただきたい。</p>
-
-        <p>この文書は <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines  Working Group</a> によって、<a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Recommendation track</a> を使用した勧告として公開された。
-        </p>
-
-        <p><abbr title="World Wide Web Consortium">W3C</abbr> は、この仕様を Web 標準として広く展開することを推奨する。</p>
-
-        <p><abbr title="World Wide Web Consortium">W3C</abbr> 勧告は、広範な合意形成を経て <abbr title="World Wide Web Consortium">W3C</abbr> とその会員によって承認された仕様であり、ワーキンググループのメンバーから実装に対する <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> が約束されている。
-        </p>
-
-        <p>この文書は <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">1 August 2017 <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a> の下で活動するグループによって作成された。<abbr title="World Wide Web Consortium">W3C</abbr> では、ワーキンググループの成果物に関係する <a rel="disclosure" href="https://www.w3.org/2004/01/pp-impl/35422/status">public list of any patent disclosures</a> を管理しており、そのページには特許開示にあたっての指示も含まれている。ある特許について現実に認識を有する者が、その特許に <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> が含まれていると判断した場合、<a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy の section 6</a> に従って、その情報を開示することが求められる。
-        </p>
-
-        <p>この文書は、<a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a> に従っている。
-        </p>
-
-        </section>
-        <nav id="toc">
-          <h2 class="introductory" id="table-of-contents">
-            目次
-          </h2>
-          <ol class="toc">
-            <li class="tocline">
-              <a href="#abstract" class="tocxref">概要</a>
-            </li>
-            <li class="tocline">
-              <a href="#sotd" class="tocxref">この文書のステータス</a>
-            </li>
-            <li class="tocline">
-              <a href="#intro" class="tocxref">イントロダクション</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#background-on-wcag-2" class="tocxref">WCAG 2 の背景</a>
-                </li>
-                <li class="tocline">
-                  <a href="#wcag-2-layers-of-guidance" class="tocxref">WCAG 2 ガイダンスのレイヤー</a>
-                </li>
-                <li class="tocline">
-                  <a href="#wcag-2-1-supporting-documents" class=
-                  "tocxref">WCAG 2.1 関連文書</a>
-                </li>
-                <li class="tocline">
-                  <a href="#requirements-for-wcag-2-1" class="tocxref">WCAG 2.1 の要件</a>
-                </li>
-                <li class="tocline">
-                  <a href="#comparison-with-wcag-2-0" class="tocxref">WCAG 2.0 との比較</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#new-features-in-wcag-2-1" class=
-                      "tocxref">WCAG 2.1 の新しい特徴</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#numbering-in-wcag-2-1" class="tocxref">WCAG 2.1 におけるナンバリング</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#conformance-to-wcag-2-1" class=
-                      "tocxref">WCAG 2.1 への適合</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#later-versions-of-accessibility-guidelines" class=
-                  "tocxref">アクセシビリティガイドラインの後続版</a>
-                </li>
-              </ol>
-            </li>
-            <li class="tocline">
-              <a href="#perceivable" class="tocxref"><span class="secno">1.</span> 知覚可能</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#text-alternatives" class="tocxref"><span class=
-                  "secno">1.1</span> テキストによる代替</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#non-text-content" class="tocxref"><span class=
-                      "secno">1.1.1</span> 非テキストコンテンツ</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#time-based-media" class="tocxref"><span class=
-                  "secno">1.2</span> 時間依存メディア</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#audio-only-and-video-only-prerecorded" class=
-                      "tocxref"><span class="secno">1.2.1</span> 音声のみ及び映像のみ (収録済)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#captions-prerecorded" class="tocxref"><span class=
-                      "secno">1.2.2</span> キャプション (収録済)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#audio-description-or-media-alternative-prerecorded"
-                      class="tocxref"><span class="secno">1.2.3</span> 音声解説、又はメディアに対する代替 (収録済)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#captions-live" class="tocxref"><span class=
-                      "secno">1.2.4</span> キャプション (ライブ)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#audio-description-prerecorded" class=
-                      "tocxref"><span class="secno">1.2.5</span> 音声解説 (収録済)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#sign-language-prerecorded" class=
-                      "tocxref"><span class="secno">1.2.6</span> 手話 (収録済)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#extended-audio-description-prerecorded" class=
-                      "tocxref"><span class="secno">1.2.7</span> 拡張音声解説 (収録済)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#media-alternative-prerecorded" class=
-                      "tocxref"><span class="secno">1.2.8</span> メディアに対する代替 (収録済)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#audio-only-live" class="tocxref"><span class=
-                      "secno">1.2.9</span> 音声のみ (ライブ)</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#adaptable" class="tocxref"><span class=
-                  "secno">1.3</span> 適応可能</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#info-and-relationships" class=
-                      "tocxref"><span class="secno">1.3.1</span> 情報及び関係性</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#meaningful-sequence" class="tocxref"><span class=
-                      "secno">1.3.2</span> 意味のあるシーケンス</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#sensory-characteristics" class=
-                      "tocxref"><span class="secno">1.3.3</span> 感覚的な特徴</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#orientation" class="tocxref"><span class=
-                      "secno">1.3.4</span> 表示の向き</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#identify-input-purpose" class=
-                      "tocxref"><span class="secno">1.3.5</span> 入力目的の特定</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#identify-purpose" class="tocxref"><span class=
-                      "secno">1.3.6</span> 目的の特定</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#distinguishable" class="tocxref"><span class=
-                  "secno">1.4</span> 判別可能</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#use-of-color" class="tocxref"><span class=
-                      "secno">1.4.1 </span>色の使用</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#audio-control" class="tocxref"><span class=
-                      "secno">1.4.2</span> 音声の制御</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#contrast-minimum" class="tocxref"><span class=
-                      "secno">1.4.3</span> コントラスト (最低限)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#resize-text" class="tocxref"><span class=
-                      "secno">1.4.4</span> テキストのサイズ変更</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#images-of-text" class="tocxref"><span class=
-                      "secno">1.4.5</span> 文字画像</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#contrast-enhanced" class="tocxref"><span class=
-                      "secno">1.4.6</span> コントラスト (高度)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#low-or-no-background-audio" class=
-                      "tocxref"><span class="secno">1.4.7</span> 小さな背景音、又は背景音なし</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#visual-presentation" class="tocxref"><span class=
-                      "secno">1.4.8</span> 視覚的提示</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#images-of-text-no-exception" class=
-                      "tocxref"><span class="secno">1.4.9</span> 文字画像 (例外なし)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#reflow" class="tocxref"><span class=
-                      "secno">1.4.10</span> リフロー</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#non-text-contrast" class="tocxref"><span class=
-                      "secno">1.4.11</span> 非テキストのコントラスト</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#text-spacing" class="tocxref"><span class=
-                      "secno">1.4.12</span> テキストの間隔</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#content-on-hover-or-focus" class=
-                      "tocxref"><span class="secno">1.4.13</span> ホバー又はフォーカスで表示されるコンテンツ</a>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li class="tocline">
-              <a href="#operable" class="tocxref"><span class="secno">2.</span> 操作可能</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#keyboard-accessible" class="tocxref"><span class=
-                  "secno">2.1</span> キーボード操作可能</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#keyboard" class="tocxref"><span class=
-                      "secno">2.1.1</span> キーボード</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#no-keyboard-trap" class="tocxref"><span class=
-                      "secno">2.1.2</span> キーボードトラップなし</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#keyboard-no-exception" class="tocxref"><span class=
-                      "secno">2.1.3</span> キーボード (例外なし)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#character-key-shortcuts" class=
-                      "tocxref"><span class="secno">2.1.4</span> 文字キーのショートカット</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#enough-time" class="tocxref"><span class=
-                  "secno">2.2</span> 十分な時間</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#timing-adjustable" class="tocxref"><span class=
-                      "secno">2.2.1</span> タイミング調整可能</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#pause-stop-hide" class="tocxref"><span class=
-                      "secno">2.2.2</span> 一時停止、停止、非表示</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#no-timing" class="tocxref"><span class=
-                      "secno">2.2.3</span> タイミング非依存</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#interruptions" class="tocxref"><span class=
-                      "secno">2.2.4</span> 割り込み</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#re-authenticating" class="tocxref"><span class=
-                      "secno">2.2.5</span> 再認証</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#timeouts" class="tocxref"><span class=
-                      "secno">2.2.6</span> タイムアウト</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#seizures-and-physical-reactions" class=
-                  "tocxref"><span class="secno">2.3</span> 発作と身体的反応</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#three-flashes-or-below-threshold" class=
-                      "tocxref"><span class="secno">2.3.1</span> 3 回の閃光、又は閾値以下</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#three-flashes" class="tocxref"><span class=
-                      "secno">2.3.2</span> 3 回の閃光</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#animation-from-interactions" class=
-                      "tocxref"><span class="secno">2.3.3</span> インタラクションによるアニメーション</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#navigable" class="tocxref"><span class=
-                  "secno">2.4</span> ナビゲーション可能</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#bypass-blocks" class="tocxref"><span class=
-                      "secno">2.4.1</span> ブロックスキップ</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#page-titled" class="tocxref"><span class=
-                      "secno">2.4.2</span> ページタイトル</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#focus-order" class="tocxref"><span class=
-                      "secno">2.4.3</span> フォーカス順序</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#link-purpose-in-context" class=
-                      "tocxref"><span class="secno">2.4.4</span> リンクの目的 (コンテキスト内)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#multiple-ways" class="tocxref"><span class=
-                      "secno">2.4.5</span> 複数の手段</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#headings-and-labels" class="tocxref"><span class=
-                      "secno">2.4.6</span> 見出し及びラベル</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#focus-visible" class="tocxref"><span class=
-                      "secno">2.4.7</span> フォーカスの可視化</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#location" class="tocxref"><span class=
-                      "secno">2.4.8</span> 現在位置</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#link-purpose-link-only" class=
-                      "tocxref"><span class="secno">2.4.9</span> リンクの目的 (リンクのみ)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#section-headings" class="tocxref"><span class=
-                      "secno">2.4.10</span> セクション見出し</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#input-modalities" class="tocxref"><span class=
-                  "secno">2.5</span> 入力モダリティ</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#pointer-gestures" class="tocxref"><span class=
-                      "secno">2.5.1</span> ポインタのジェスチャ</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#pointer-cancellation" class="tocxref"><span class=
-                      "secno">2.5.2</span> ポインタのキャンセル</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#label-in-name" class="tocxref"><span class=
-                      "secno">2.5.3</span> ラベルを含む名前 (name)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#motion-actuation" class="tocxref"><span class=
-                      "secno">2.5.4</span> 動きによる起動</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#target-size" class="tocxref"><span class=
-                      "secno">2.5.5</span> ターゲットのサイズ</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#concurrent-input-mechanisms" class=
-                      "tocxref"><span class="secno">2.5.6</span> 入力メカニズムの共存</a>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li class="tocline">
-              <a href="#understandable" class="tocxref"><span class=
-              "secno">3.</span> 理解可能</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#readable" class="tocxref"><span class=
-                  "secno">3.1</span> 読み取り可能</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#language-of-page" class="tocxref"><span class=
-                      "secno">3.1.1</span> ページの言語</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#language-of-parts" class="tocxref"><span class=
-                      "secno">3.1.2</span> 一部分の言語</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#unusual-words" class="tocxref"><span class=
-                      "secno">3.1.3</span> 一般的ではない用語</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#abbreviations" class="tocxref"><span class=
-                      "secno">3.1.4</span> 略語</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#reading-level" class="tocxref"><span class=
-                      "secno">3.1.5</span> 読解レベル</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#pronunciation" class="tocxref"><span class=
-                      "secno">3.1.6</span> 発音</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#predictable" class="tocxref"><span class=
-                  "secno">3.2</span> 予測可能</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#on-focus" class="tocxref"><span class=
-                      "secno">3.2.1</span> フォーカス時</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#on-input" class="tocxref"><span class=
-                      "secno">3.2.2</span> 入力時</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#consistent-navigation" class="tocxref"><span class=
-                      "secno">3.2.3</span> 一貫したナビゲーション</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#consistent-identification" class=
-                      "tocxref"><span class="secno">3.2.4</span> 一貫した識別性</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#change-on-request" class="tocxref"><span class=
-                      "secno">3.2.5</span> 要求による変化</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#input-assistance" class="tocxref"><span class=
-                  "secno">3.3</span> 入力支援</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#error-identification" class="tocxref"><span class=
-                      "secno">3.3.1</span> エラーの特定</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#labels-or-instructions" class=
-                      "tocxref"><span class="secno">3.3.2</span> ラベル又は説明</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#error-suggestion" class="tocxref"><span class=
-                      "secno">3.3.3</span> エラー修正の提案</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#error-prevention-legal-financial-data" class=
-                      "tocxref"><span class="secno">3.3.4</span> 誤り防止 (法的、金融、データ)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#help" class="tocxref"><span class=
-                      "secno">3.3.5</span> ヘルプ</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#error-prevention-all" class="tocxref"><span class=
-                      "secno">3.3.6</span> 誤り防止 (すべて)</a>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li class="tocline">
-              <a href="#robust" class="tocxref"><span class="secno">4.</span> 堅牢 (robust)</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#compatible" class="tocxref"><span class=
-                  "secno">4.1</span> 互換性</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#parsing" class="tocxref"><span class=
-                      "secno">4.1.1</span> 構文解析</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#name-role-value" class="tocxref"><span class=
-                      "secno">4.1.2</span> 名前 (name) ・役割 (role) ・値 (value)</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#status-messages" class="tocxref"><span class=
-                      "secno">4.1.3</span> ステータスメッセージ</a>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li class="tocline">
-              <a href="#conformance" class="tocxref"><span class="secno">5.</span> 適合</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#interpreting-normative-requirements" class=
-                  "tocxref"><span class="secno">5.1</span> 規定要件の解釈</a>
-                </li>
-                <li class="tocline">
-                  <a href="#conformance-reqs" class="tocxref"><span class=
-                  "secno">5.2</span> 適合要件</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#cc1" class="tocxref"><span class=
-                      "secno">5.2.1</span> 適合レベル</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#cc2" class="tocxref"><span class=
-                      "secno">5.2.2</span> ウェブページ全体</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#cc3" class="tocxref"><span class=
-                      "secno">5.2.3</span> プロセス全体</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#cc4" class="tocxref"><span class=
-                      "secno">5.2.4</span> 技術のアクセシビリティ サポーテッドな使用方法だけ</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#cc5" class="tocxref"><span class=
-                      "secno">5.2.5</span> 非干渉</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#conformance-claims" class="tocxref"><span class=
-                  "secno">5.3</span> 適合表明 (任意)</a>
-                  <ol class="toc">
-                    <li class="tocline">
-                      <a href="#conformance-required" class="tocxref"><span class=
-                      "secno">5.3.1</span> 適合表明の必須要素</a>
-                    </li>
-                    <li class="tocline">
-                      <a href="#conformance-optional" class="tocxref"><span class=
-                      "secno">5.3.2</span> 適合表明の任意要素</a>
-                    </li>
-                  </ol>
-                </li>
-                <li class="tocline">
-                  <a href="#conformance-partial" class="tocxref"><span class=
-                  "secno">5.4</span> 部分適合に関する記述 － 第三者によるコンテンツ</a>
-                </li>
-                <li class="tocline">
-                  <a href="#conformance-partial-lang" class="tocxref"><span class=
-                  "secno">5.5</span> 部分適合に関する記述 － 言語</a>
-                </li>
-              </ol>
-            </li>
-            <li class="tocline">
-              <a href="#glossary" class="tocxref"><span class="secno">6.</span> 用語集</a>
-            </li>
-            <li class="tocline">
-              <a href="#input-purposes" class="tocxref"><span class=
-              "secno">7.</span> ユーザインタフェース コンポーネントの入力目的</a>
-            </li>
-            <li class="tocline"><a class="tocxref" href="#changelog"><bdi class="secno">A. </bdi>変更点</a></li>
-            <li class="tocline">
-              <a href="#acknowledgments" class="tocxref"><span class=
-              "secno">B.</span>謝辞</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#ack_participants-active" class="tocxref"><span class=
-                  "secno">B.1</span> この文書の作成時にアクティブだった AG WG 参加者:</a>
-                </li>
-                <li class="tocline">
-                  <a href="#ack_participants-previous" class="tocxref"><span class=
-                  "secno">B.2</span> 以前に活動していた他の WCAG WG 参加者及び WCAG 2.0、WCAG 2.1、又は関連文書への他の貢献者</a>
-                </li>
-                <li class="tocline">
-                  <a href="#enabling-funders" class="tocxref"><span class=
-                  "secno">B.3 </span>有効な資金提供者</a>
-                </li>
-              </ol>
-            </li>
-            <li class="tocline">
-              <a href="#references" class="tocxref"><span class="secno">C.</span> 参考文献</a>
-              <ol class="toc">
-                <li class="tocline">
-                  <a href="#normative-references" class="tocxref"><span class=
-                  "secno">C.1</span> 引用文書</a>
-                </li>
-                <li class="tocline">
-                  <a href="#informative-references" class="tocxref"><span class=
-                  "secno">B.2</span> 参考文書</a>
-                </li>
-              </ol>
-            </li>
-          </ol><!--OddPage-->
-        </nav>
-        <section class="informative introductory" id="intro">
-			<h2 id="introduction">イントロダクション</h2><p><em>この節は規定ではない。</em></p>
-			<section id="background-on-wcag-2">
-				<h3 id="x0-1-background-on-wcag-2">WCAG 2 の背景<span class="permalink"><a href="#background-on-wcag-2" aria-label="Permalink for 0.1 Background on WCAG 2" title="Permalink for 0.1 Background on WCAG 2"><span>§</span></a></span></h3>
-				<p>Web Content Accessibility Guidelines (WCAG) 2.1 は、ウェブコンテンツを障害のある人にとってよりアクセシブルにする方法を定義している。アクセシビリティは、視覚、聴覚、身体、発話、認知、言語、学習、神経の障害を含む、広範な障害に関係している。このガイドラインは、広範囲に及ぶ事項を網羅しているが、障害のすべての種類、程度、組合せからくるニーズを満たすことはできない。また、このガイドラインは、加齢により能力が変化している高齢者にとってもウェブコンテンツをより使いやすくするものであるとともに、しばしば利用者全般のユーザビリティを向上させる。</p>
-				<p>WCAG 2.1 は、ウェブコンテンツのアクセシビリティに対して、様々な国の個人、組織、政府のニーズを満たすような共通の基準を提供することを目的として、<a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/"><abbr title="World Wide Web Consortium">W3C</abbr> process</a> に従って世界中の個人及び組織の協力のもと作成されている。WCAG 2.0 [<cite><a class="bibref" href="#bib-wcag20">WCAG20</a></cite>] は WCAG 1.0 [<cite><a class="bibref" href="#bib-wai-webcontent">WAI-WEBCONTENT</a></cite>] をベースに、 WCAG 2.1 は WCAG 2.0 [WCAG20] をベースに、順に作られており、現在及び将来の様々なウェブ技術に広く適用され、自動テストと人間による評価の組み合わせでテスト可能になるように設計されている。WCAG のイントロダクションとしては、<a href="http://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。</p>
-                
-				<p>認知、言語、及び学習障害に対処するための追加の達成基準を定義するにあたり、勧告策定期間の短さに加えて、勧告案のテスト可能性や実装可能性、国際的な観点からの検討について合意形成に至る際の課題など、重大な課題に向き合うこととなった。こうした領域については、WCAG の将来の版で検討が継続されることになる。コンテンツ制作者においては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/#supplement">学習障害、認知障害、ロービジョンなど障害のある人のインクルージョンを向上するための補足的なガイダンス</a>を参照することを推奨する。</p>
-
-				<p>ウェブアクセシビリティは、アクセシブルなコンテンツだけではなく、アクセシブルなウェブブラウザやその他のユーザエージェントにも依存している。そして、オーサリングツールもウェブアクセシビリティにおいて重要な役割を担っている。ウェブ開発やインタラクションを構成するこれらの要素が相互にどのように関係しているかの概要については、以下を参照:</p>
-				<ul>
-					<li><strong><a href="https://www.w3.org/WAI/fundamentals/components/">Essential Components of Web Accessibility</a></strong></li>
-					<li><strong><a href="https://www.w3.org/WAI/standards-guidelines/uaag/">User Agent Accessibility Guidelines (UAAG) Overview</a></strong></li>
-					<li><strong><a href="https://www.w3.org/WAI/standards-guidelines/atag/">Authoring Tool Accessibility Guidelines (ATAG) Overview</a></strong></li>
-				</ul>
-            <p>この文書で <q>WCAG 2</q> を表す場合、2 で始まる WCAG の全てのバージョンを表すことを意図している。
-            </p>
-			</section>
-			<section id="wcag-2-layers-of-guidance">
-				<h3 id="x0-2-wcag-2-layers-of-guidance">WCAG 2 ガイダンスのレイヤー<span class="permalink"><a href="#wcag-2-layers-of-guidance" aria-label="Permalink for 0.2 WCAG 2 Layers of Guidance" title="Permalink for 0.2 WCAG 2 Layers of Guidance"><span>§</span></a></span></h3>
-				<p>WCAG を用いる個人や組織は実に幅広く、ウェブデザイナーや開発者、政策立案者、調達担当者、教師、及び生徒などが含まれる。これらの人たちの様々なニーズに応えるために WCAG 2.0 では、<em>原則</em>、一般的な<em>ガイドライン</em>、検証可能な<em>達成基準</em>、<em>十分な達成方法</em>、<em>参考達成方法</em>、及び<em>よくある失敗例</em>を示した豊富な文書群を含む様々なレイヤーのガイダンスが、事例や参考リンク及びコードとともに提供されている。</p>
-				<ul>
-					<li>
-						<p><strong>原則</strong> - 最上位には、ウェブアクセシビリティの土台となる四つの原則がある: <em>知覚可能、操作可能、理解可能、及び堅牢 (robust)</em>。あわせて、<a href="https://www.w3.org/WAI/WCAG21/Understanding/intro#understanding-the-four-principles-of-accessibility">Understanding the Four Principles of Accessibility</a> も参照。</p>
-					</li>
-					<li>
-						<p><strong>ガイドライン</strong> - 原則の下にあるのがガイドラインである。13 のガイドラインは、様々な障害のある利用者に対してコンテンツをよりアクセシブルにするためにコンテンツ制作者が取り組むべき基本的な目標を提供している。これらのガイドラインは検証可能ではないが、コンテンツ制作者が達成基準を理解し、より適した達成方法を用いることができるように、全体的な枠組みや全般的な目的を提供するものである。</p>
-					</li>
-					<li>
-						<p><strong>達成基準</strong> - 各ガイドラインには、検証可能な達成基準が設けられており、デザイン仕様検討、調達、基準策定、及び契約上の合意などにあたりその要件や適合試験が必要となる際に WCAG 2.1 を用いることが可能である。様々な利用者層や状況からくるニーズを満たすために、三つの適合レベルが定義されている: A (最低レベル)、AA、AAA (最高レベル)。WCAG のレベルに関する補足情報は、<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#levels">Understanding Levels of Conformance</a> を参照。</p>
-					</li>
-					<li>
-						<p><strong>十分な達成方法及び参考達成方法</strong> - WCAG 2.1 文書自体にある<em>ガイドライン</em>及び<em>達成基準</em>それぞれに対して、ワーキンググループは<em>達成方法</em>についても広範囲にわたって文書化している。達成方法は参考情報であり、二つのカテゴリに分類される: 達成基準を満たすのに<em>十分な</em>達成方法と<em>参考達成方法</em>である。参考達成方法は、個々の達成基準の要件を上回るもので、これらの達成方法を用いることで、コンテンツ制作者はガイドラインに対してより良い対処をすることができる。参考達成方法の中には、検証可能な達成基準によってカバーされていないアクセシビリティの問題に対処するものもある。よくある失敗例がある場合は、それも文書化されている。<a href="https://www.w3.org/WAI/WCAG21/Understanding/understanding-techniques">Sufficient and Advisory Techniques in Understanding WCAG 2.1</a> も参照。</p>
-					</li>
-				</ul>
-				<p>このガイダンスのレイヤー (原則、ガイドライン、達成基準、十分な達成方法及び参考達成方法) はすべて、コンテンツをよりアクセシブルにする方法に関するガイダンスを提供するために連携している。コンテンツ制作者は可能な範囲で最も広い利用者のニーズに最大限対処できるように、参考達成方法を含めたすべてのレイヤーを確認して適用することが推奨される。</p>
-				<p>注意すべきなのは、最高レベル (AAA) で適合しているコンテンツでさえも、すべての種類、程度あるいは組合せの障害のある個人、特に、認知、言語及び学習の面において、アクセシブルではないということである。コンテンツ制作者は、参考達成方法を含むすべての達成方法を考慮するとともに、ウェブコンテンツが可能な限りアクセシブルであることを確実にするためにも、こうした人たちに対して、現状における最善の対応策に関するアドバイスを追い求めることが推奨される。<a href="https://www.w3.org/WAI/WCAG21/Understanding/understanding-metadata">メタデータ</a>は、彼らのニーズに最適なコンテンツを探し出す際に、利用者を支援できる可能性がある。</p>
-			</section>
-			<section id="wcag-2-1-supporting-documents">
-				<h3 id="x0-3-wcag-2-1-supporting-documents">WCAG 2.1 関連文書<span class="permalink"><a href="#wcag-2-1-supporting-documents" aria-label="Permalink for 0.3 WCAG 2.1 Supporting Documents" title="Permalink for 0.3 WCAG 2.1 Supporting Documents"><span>§</span></a></span></h3>
-				<p>WCAG 2.1 の文書は、安定した参照可能な技術標準を必要とする人たちのニーズを満たすように作成されている。関連文書と呼ばれるその他の文書は、WCAG 2.1 文書に基づいて、WCAG が新しい技術にどのように適用されるかを説明するために更新できるようにすることを含め、その他の重要な役割を果たすものである。関連文書には以下に挙げるものがある: </p>
-				<ol class="enumar">
-					<li>
-						<p><strong><a href="https://www.w3.org/WAI/WCAG21/quickref/">How to Meet WCAG 2.1</a></strong> - WCAG 2.1 のカスタマイズ可能なクイックリファレンス。コンテンツ制作者がウェブコンテンツを制作したり評価したりする際に用いるガイドライン、達成基準、達成方法のすべてが含まれる。これには WCAG 2.0 および WCAG 2.1 のコンテンツが含まれており、関連するコンテンツにコンテンツ制作者がフォーカスできるよう、様々な方法でフィルタリングできるようになっている。</p>
-					</li>
-					<li>
-						<p><strong><a href="https://www.w3.org/WAI/WCAG21/Understanding/">Understanding WCAG 2.1</a></strong> - WCAG 2.1 を理解して実践するための解説書。重要なトピックスとあわせて、WCAG 2.1 の各ガイドライン及び達成基準を「理解する」ための簡潔な文書がある。</p>
-					</li>
-					<li>
-						<p><strong><a href="https://www.w3.org/WAI/WCAG21/Techniques/">Techniques for WCAG 2.1</a></strong> - 達成方法集及びよくある失敗例集。個々に別々の文書になっており、解説、事例、コード例、テストが含まれる。</p>
-					</li>
-					<li>
-						<p><strong><a href="https://www.w3.org/WAI/standards-guidelines/wcag/docs/">The WCAG Documents</a></strong> - 技術文書群がどのように関係していてリンクされているのかを示した図と解説。</p>
-					</li>
-				</ol>
-				<p>WCAG 2.0 に関する教育資料を含む関連資料の説明は、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。例えば、ウェブアクセシビリティのビジネスにおける効果、ウェブサイトのアクセシビリティを改善するための実施計画作成、及びアクセシビリティ方針といったトピックに関する補足資料は、<a href="https://www.w3.org/WAI/Resources/Overview">WAI Resources</a> に挙げられている。</p>
-			</section>
-        	<section id="requirements-for-wcag-2-1">
-        		<h3 id="x0-4-requirements-for-wcag-2-1">WCAG 2.1 の要件<span class="permalink"><a href="#requirements-for-wcag-2-1" aria-label="Permalink for 0.4 Requirements for WCAG 2.1" title="Permalink for 0.4 Requirements for WCAG 2.1"><span>§</span></a></span></h3>
-                <p>WCAG 2.1 は、WCAG 2.0 の要件を継承する一連の <a href="https://w3c.github.io/wcag21/requirements/">WCAG 2.1 の要件</a>を満たしている。要件は、ガイドラインの全体的なフレームワークを構成し、後方互換性を確保している。ワーキンググループはまた、達成基準のスタイルや品質が WCAG 2.0 のものと類似することを確保するために、達成基準に対し、あまり形式的ではない一連の受け入れ基準を採用した。これらの要件は、WCAG 2.1に含めることができるものを制限している。この制限は、WCAG 2 のドットリリースの性質を保持するために重要である。</p>
-        	</section>
-    		<section id="comparison-with-wcag-2-0">
-                <h3 id="x0-5-comparison-with-wcag-2-0">WCAG 2.0 との比較<span class="permalink"><a href="#comparison-with-wcag-2-0" aria-label="Permalink for 0.5 Comparison with WCAG 2.0" title="Permalink for 0.5 Comparison with WCAG 2.0"><span>§</span></a></span></h3>
-                <p>WCAG 2.1 は、認知または学習障害のある利用者、ロービジョンの利用者、モバイルデバイス上の障害のある利用者、という三つの主要なグループためのアクセシビリティのガイダンスを改善することを目的に開始された。これらのニーズを満たすために多くの方法が提案され評価され、ワーキンググループによって洗練された。WCAG 2.0 から引き継がれた構造上の要件、提案の明確さ及び影響、並びに進行計画が、この版に含まれる最終的な一式の達成基準につながった。ワーキンググループは、WCAG 2.1 がこれらすべての領域におけるウェブコンテンツのアクセシビリティのガイダンスを段階的に進歩させると考えているが、このガイドラインではすべての利用者のニーズが満たされているわけではないことを強調している。</p>
-
-				<p>WCAG 2.1 は WCAG 2.0 をベースに構築され、WCAG 2.0 と後方互換性があるため、WCAG 2.1 に適合しているウェブページはすなわち WCAG 2.0 にも適合していることにもなる。WCAG 2.0 への適合を方針によって要求されているコンテンツ制作者は、WCAG 2.0 への適合を維持したままコンテンツを WCAG 2.1 に適合できるようアップデートすることができる。両方のガイドラインに従うコンテンツ制作者は、以下に挙げる差異に注意すべきである。</p>
-				<section id="new-features-in-wcag-2-1">
-					<h4 id="x0-5-1-new-features-in-wcag-2-1">WCAG 2.1 の新しい特徴<span class="permalink"><a href="#new-features-in-wcag-2-1" aria-label="Permalink for 0.5.1 New Features in WCAG 2.1" title="Permalink for 0.5.1 New Features in WCAG 2.1"><span>§</span></a></span></h4>
-					<p>WCAG 2.1 は WCAG 2.0 に新しい達成基準やそれらを補助する定義、追加分をまとめるガイドライン、適合の節へのいくつかの追加によって拡張されている。この付加的なアプローチは、WCAG 2.1 に適合するサイトが WCAG 2.0 にも適合することを明確にするのに役立ち、それによって WCAG 2.0 固有の適合義務を満たす。アクセシビリティガイドライン ワーキンググループは新しい適合目標として、例え公的義務が WCAG 2.0 に言及するものであっても、将来のポリシーの変更を鑑みアクセシビリティをより向上させるために、サイトが WCAG 2.1 を採用することを推奨する。</p>
-					<p>以下が WCAG 2.1 の新しい達成基準である:</p>
-					<ul>
-						<li>1.3.4 <a href="#orientation">表示の向き</a> (AA)</li>
-						<li>1.3.5 <a href="#identify-input-purpose">入力目的の特定</a> (AA)</li>
-						<li>1.3.6 <a href="#identify-purpose">目的の特定</a> (AAA)</li>
-						<li>1.4.10 <a href="#reflow">リフロー</a> (AA)</li>
-						<li>1.4.11 <a href="#non-text-contrast">非テキストのコントラスト</a> (AA)</li>
-						<li>1.4.12 <a href="#text-spacing">テキストの間隔</a> (AA)</li>
-						<li>1.4.13 <a href="#content-on-hover-or-focus">ホバー又はフォーカスで表示されるコンテンツ</a> (AA)</li>
-						<li>2.1.4 <a href="#character-key-shortcuts">文字キーのショートカット</a> (A)</li>
-						<li>2.2.6 <a href="#timeouts">タイムアウト</a> (AAA)</li>
-						<li>2.3.3 <a href="#animation-from-interactions">インタラクションによるアニメーション</a> (AAA)</li>
-						<li>2.5.1 <a href="#pointer-gestures">ポインタのジェスチャ</a> (A)</li>
-						<li>2.5.2 <a href="#pointer-cancellation">ポインタのキャンセル</a> (A)</li>
-						<li>2.5.3 <a href="#label-in-name">ラベルを含む名前 (name)</a> (A)</li>
-						<li>2.5.4 <a href="#motion-actuation">動きによる起動</a> (A)</li>
-						<li>2.5.5 <a href="#target-size">ターゲットのサイズ</a> (AAA)</li>
-						<li>2.5.6 <a href="#concurrent-input-mechanisms">入力メカニズムの共存</a> (AAA)</li>
-						<li>4.1.3 <a href="#status-messages">ステータスメッセージ</a> (AA)</li>
-					</ul>
-
-					<p>新しい達成基準は、用語集に追加された新しい用語を参照していることがあり、それらもまた達成基準の規定要件の一部を構成することがある。</p>
-					<p>適合の節では、<a href="#cc2">ページ全体</a>にページのバリエーションについて 3 番目の注記が追加され、<a href="#conformance-optional">適合表明の任意要素</a>に機械的に読み取れるメタデータのオプションが追加されている。</p>
-
-				</section>
-				<section id="numbering-in-wcag-2-1">
-					<h4 id="x0-5-2-numbering-in-wcag-2-1">WCAG 2.1 におけるナンバリング<span class="permalink"><a href="#numbering-in-wcag-2-1" aria-label="Permalink for 0.5.2 Numbering in WCAG 2.1" title="Permalink for 0.5.2 Numbering in WCAG 2.1"><span>§</span></a></span></h4>
-					<p>WCAG 2.0 に対する後方互換性が重要となる開発者の混乱を招くことを避けるため、WCAG 2.1 における新しい達成基準はガイドライン内の一連の達成基準の末尾に追加されている。これにより、ガイドラインの既存の達成基準の間に新しい達成基準を挿入することによって生じるであろう、WCAG 2.0 からある達成基準のセクション番号の変更の必要性が、回避される。しかしながらこのことは、各ガイドライン内の達成基準がもはや適合レベルごとにグループ分けされていないことを意味する。各ガイドライン内での達成基準の順番は、適合レベルに関する情報を暗示するものではなく、各達成基準自身の適合レベル表示 (A / AA / AAA) のみが適合レベルを示す。<a href="https://www.w3.org/WAI/WCAG21/quickref/">WCAG 2.1 クイックリファレンス</a>は、他の多数のフィルターや並べ替え方法と共に、適合レベルごとにグループ化された達成基準を見る方法を提供する。</p>
-				</section>
-				<section id="conformance-to-wcag-2-1">
-					<h4 id="x0-5-3-conformance-to-wcag-2-1">WCAG 2.1 への適合<span class="permalink"><a href="#conformance-to-wcag-2-1" aria-label="Permalink for 0.5.3 Conformance to WCAG 2.1" title="Permalink for 0.5.3 Conformance to WCAG 2.1"><span>§</span></a></span></h4>
-					<p>WCAG 2.1 は WCAG 2.0 と同様の適合モデルをいくつかの追加と共に用いており、<a href="#conformance">適合</a>の節に記載されている。WCAG 2.1 に適合するサイトは WCAG 2.0 にも適合することを意図している。つまり、それらのサイトは WCAG 2.0 が参照する全ての方針の要求を満たしつつ、現在のウェブの利用者のニーズもより多く満たすことができる。</p>
-				</section>
-			</section>
-        	<section id="later-versions-of-accessibility-guidelines">
-        		<h3 id="x0-6-later-versions-of-accessibility-guidelines">アクセシビリティガイドラインの後続版<span class="permalink"><a href="#later-versions-of-accessibility-guidelines" aria-label="Permalink for 0.6 Later Versions of Accessibility Guidelines" title="Permalink for 0.6 Later Versions of Accessibility Guidelines"><span>§</span></a></span></h3>
-        		<p>WCAG 2.1 と並行して、アクセシビリティガイドライン ワーキンググループは、アクセシビリティガイドラインの別の主要版を開発している。この作業の結果は、現実的な WCAG 2 のドットリリースのためと言うより、ウェブアクセシビリティガイダンスのより大幅な再構築になると期待されている。この作業は、コンテンツ制作、ユーザエージェントのサポート、及びオーサリングツールのサポートの役割を含む、最も効果的かつ柔軟な結果を生むために、研究に焦点を合わせた、ユーザ中心設計の方法論に従う。これは長年にわたる努力であるため、WCAG 2.0 の公開からのウェブ上の変化を反映するための最新のウェブアクセシビリティガイダンスを提供するための暫定措置として WCAG 2.1 が必要とされる。ワーキンググループは、主要版が完成するまでの間、同様に短いタイムラインで追加のサポートを提供するために、WCAG 2.2 及びそれに続く暫定版を開発するかもしれない。</p><!--OddPage-->
-        	</section>
-        </section>
-        <section class="principle" id="perceivable">
-            <h2 id="x1-perceivable"><span class="secno">1. </span> 知覚可能 <span class="permalink"><a href="#perceivable" aria-label="Permalink for 1.  Perceivable " title="Permalink for 1.  Perceivable "><span>§</span></a></span></h2>
-            <p>情報及びユーザインタフェース コンポーネントは、利用者が知覚できる方法で利用者に提示可能でなければならない。</p>
-
-            <section class="guideline" id="text-alternatives">
-                <h3 id="x1-1-text-alternatives"><span class="secno">ガイドライン 1.1 </span>テキストによる代替<span class="permalink"><a href="#text-alternatives" aria-label="Permalink for 1.1 Text Alternatives" title="Permalink for 1.1 Text Alternatives"><span>§</span></a></span></h3>
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/text-alternatives.html">Understanding Text Alternatives</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#text-alternatives">How to Meet Text Alternatives</a></div>
-                <p>すべての非テキストコンテンツには、大活字、点字、音声、シンボル、平易な言葉などの利用者が必要とする形式に変換できるように、テキストによる代替を提供すること。</p>
-                <div class="note"><div role="heading" class="note-title marker" aria-level="4"><span>訳注</span></div><p>大活字とは、通常の出版物より大きな活字のことを指す。<a href="https://www.ndl.go.jp/jp/library/supportvisual/geppo201501/article05.html">障害者向け資料の紹介｜国立国会図書館―National Diet Library</a> も参照。</p></div>
-                <section class="sc" id="non-text-content">
+  </div>
+      
+      <section id="abstract" class="introductory"><h2>概要</h2>
+         
+         <p>Web Content Accessibility Guidelines (WCAG) 2.1 は、ウェブコンテンツをよりアクセシブルにするための広範囲に及ぶ推奨事項を網羅している。このガイドラインに従うことで、全盲又はロービジョン、ろう又は難聴、運動制限、発話困難、光感受性発作及びこれらの組合せ、並びに学習障害及び認知限界への一部の適応を含んだ、様々な障害のある人に対して、コンテンツをアクセシブルにすることができる。しかし、これらの障害のある人に対するあらゆる利用者のニーズに対処するものではない。このガイドラインは、デスクトップ、ラップトップ、タブレット、及びモバイルデバイス上のウェブコンテンツのアクセシビリティを扱う。このガイドラインに従うことは、一般にウェブコンテンツが利用者にとってより使いやすいものにもなる。</p>
+         	
+         <p>WCAG 2.1 の達成基準は、技術に依存しない検証可能なものとして記述されている。特定の技術において達成基準を満たすためのガイドは、達成基準を理解するための一般的な情報とあわせて、別の文書群として提供している。イントロダクション並びに WCAG の達成方法及び教育資料については、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。</p>
+         
+         <p>WCAG 2.1 は、2008 年 12 月に <abbr title="World Wide Web Consortium">W3C</abbr> 勧告として発行された、<a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-wcag20" title="Web Content Accessibility Guidelines (WCAG) 2.0">WCAG20</a></cite>] を拡張するものである。WCAG 2.1 に適合するコンテンツは、WCAG 2.0 にも適合する。ワーキンググループは、WCAG 2.0 への適合を要求する方針に対して、WCAG 2.1 が適合の代替手段を提供できることを意図している。WCAG 2.1 の発行は、WCAG 2.0 を廃止又は置き換えるものではない。WCAG 2.0 は <abbr title="World Wide Web Consortium">W3C</abbr> 勧告のままである一方で、 <abbr title="World Wide Web Consortium">W3C</abbr> は、アクセシビリティの取組みについて将来の適用性を最大にするために WCAG 2.1 の使用を勧める。<abbr title="World Wide Web Consortium">W3C</abbr> はまた、ウェブアクセシビリティ指針を改良又は更新するときに、WCAG の最新版の使用を奨励する。</p>
+         
+      </section>
+      
+      <section id="sotd" class="introductory"><h2>この文書のステータス</h2><p><em>この節では、この文書の発行された時点でのステータスを説明する。現行の <abbr title="World Wide Web Consortium">W3C</abbr> の発行文書、及び、この技術レポートの最新版は、https://www.w3.org/TR/ にある <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> で参照可能である。</em></p>
+         
+         <p>これは、<a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a> が作成した WCAG 2.1 の <a href="https://www.w3.org/2018/Process-20180201/#RecsW3C">Recommendation</a> である。これは <a href="https://www.w3.org/WAI/WCAG21/errata/">errata</a> を取り入れており、<a href="#changelog">変更点</a>で説明されている。ある時点で、追加の変更が <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">Edited or Amended Recommendation</a> へ取り入れられる可能性がある。</p>
+         
+         <p>コメントするためには、 <a href="https://github.com/w3c/wcag/issues/new"><abbr title="World Wide Web Consortium">W3C</abbr> WCAG GitHub リポジトリにイシューを提出していただきたい</a>。この文書で提案されている達成基準は、議論が続いているイシューを参照しているが、ワーキンググループは、パブリックコメントをコメントごとに一つの新しいイシューとして提出するよう要請する。GitHub アカウントを作成してイシューを提出することは自由である。GitHub でイシューの提出が実現できない場合、<a href="mailto:public-agwg-comments@w3.org?subject=WCAG%202.1%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>) へ電子メールを送付していただきたい。</p>
+         
+      <p>この文書は <a href="https://www.w3.org/groups/wg/ag">Accessibility Guidelines Working Group</a> によって、<a href="https://www.w3.org/2023/Process-20230612/#recs-and-notes">Recommendation track</a> を使用した勧告として公開された。</p><p><abbr title="World Wide Web Consortium">W3C</abbr> は、この仕様を Web 標準として広く展開することを推奨する。</p><p><abbr title="World Wide Web Consortium">W3C</abbr> 勧告は、広範な合意形成を経て <abbr title="World Wide Web Consortium">W3C</abbr> とその会員によって承認された仕様であり、ワーキンググループのメンバーから実装に対する <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Requirements">royalty-free licensing</a> が約束されている。</p><p>この文書は <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/">1 August 2017 <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a> の下で活動するグループによって作成された。<abbr title="World Wide Web Consortium">W3C</abbr> では、ワーキンググループの成果物に関係する<a rel="disclosure" href="https://www.w3.org/groups/wg/ag/ipr"> public list of any patent disclosures</a> を管理しており、そのページには特許開示にあたっての指示も含まれている。ある特許について現実に認識を有する者が、その特許に <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#def-essential">Essential Claim(s)</a> が含まれていると判断した場合、 <a href="https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-Disclosure"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy の section 6</a> に従って、その情報を開示することが求められる。</p><p>この文書は、 <a id="w3c_process_revision" href="https://www.w3.org/2023/Process-20230612/">12 June 2023 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a> に従っている。</p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">目次</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">概要</a></li><li class="tocline"><a class="tocxref" href="#sotd">この文書のステータス</a></li><li class="tocline"><a class="tocxref" href="#intro">イントロダクション</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#background-on-wcag-2">WCAG 2 の背景</a></li><li class="tocline"><a class="tocxref" href="#wcag-2-layers-of-guidance">WCAG 2 ガイダンスのレイヤー</a></li><li class="tocline"><a class="tocxref" href="#wcag-2-1-supporting-documents">WCAG 2.1 関連文書</a></li><li class="tocline"><a class="tocxref" href="#requirements-for-wcag-2-1">WCAG 2.1 の要件</a></li><li class="tocline"><a class="tocxref" href="#comparison-with-wcag-2-0">WCAG 2.0 との比較</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#new-features-in-wcag-2-1">WCAG 2.1 の新しい特徴</a></li><li class="tocline"><a class="tocxref" href="#numbering-in-wcag-2-1">WCAG 2.1 におけるナンバリング</a></li><li class="tocline"><a class="tocxref" href="#conformance-to-wcag-2-1">WCAG 2.1 への適合</a></li></ol></li><li class="tocline"><a class="tocxref" href="#later-versions-of-accessibility-guidelines">アクセシビリティガイドラインの後続版</a></li></ol></li><li class="tocline"><a class="tocxref" href="#perceivable"><bdi class="secno">1. </bdi>知覚可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#text-alternatives"><bdi class="secno">1.1 </bdi>テキストによる代替</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#non-text-content"><bdi class="secno">1.1.1 </bdi>非テキストコンテンツ</a></li></ol></li><li class="tocline"><a class="tocxref" href="#time-based-media"><bdi class="secno">1.2 </bdi>時間依存メディア</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#audio-only-and-video-only-prerecorded"><bdi class="secno">1.2.1 </bdi>音声のみ及び映像のみ (収録済)</a></li><li class="tocline"><a class="tocxref" href="#captions-prerecorded"><bdi class="secno">1.2.2 </bdi>キャプション (収録済)</a></li><li class="tocline"><a class="tocxref" href="#audio-description-or-media-alternative-prerecorded"><bdi class="secno">1.2.3 </bdi>音声解説、又はメディアに対する代替 (収録済)</a></li><li class="tocline"><a class="tocxref" href="#captions-live"><bdi class="secno">1.2.4 </bdi>キャプション (ライブ)</a></li><li class="tocline"><a class="tocxref" href="#audio-description-prerecorded"><bdi class="secno">1.2.5 </bdi>音声解説 (収録済)</a></li><li class="tocline"><a class="tocxref" href="#sign-language-prerecorded"><bdi class="secno">1.2.6 </bdi>手話 (収録済)</a></li><li class="tocline"><a class="tocxref" href="#extended-audio-description-prerecorded"><bdi class="secno">1.2.7 </bdi>拡張音声解説 (収録済)</a></li><li class="tocline"><a class="tocxref" href="#media-alternative-prerecorded"><bdi class="secno">1.2.8 </bdi>メディアに対する代替 (収録済)</a></li><li class="tocline"><a class="tocxref" href="#audio-only-live"><bdi class="secno">1.2.9 </bdi>音声のみ (ライブ)</a></li></ol></li><li class="tocline"><a class="tocxref" href="#adaptable"><bdi class="secno">1.3 </bdi>適応可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#info-and-relationships"><bdi class="secno">1.3.1 </bdi>情報及び関係性</a></li><li class="tocline"><a class="tocxref" href="#meaningful-sequence"><bdi class="secno">1.3.2 </bdi>意味のあるシーケンス</a></li><li class="tocline"><a class="tocxref" href="#sensory-characteristics"><bdi class="secno">1.3.3 </bdi>感覚的な特徴</a></li><li class="tocline"><a class="tocxref" href="#orientation"><bdi class="secno">1.3.4 </bdi>表示の向き</a></li><li class="tocline"><a class="tocxref" href="#identify-input-purpose"><bdi class="secno">1.3.5 </bdi>入力目的の特定</a></li><li class="tocline"><a class="tocxref" href="#identify-purpose"><bdi class="secno">1.3.6 </bdi>目的の特定</a></li></ol></li><li class="tocline"><a class="tocxref" href="#distinguishable"><bdi class="secno">1.4 </bdi>判別可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#use-of-color"><bdi class="secno">1.4.1 </bdi>色の使用</a></li><li class="tocline"><a class="tocxref" href="#audio-control"><bdi class="secno">1.4.2 </bdi>音声の制御</a></li><li class="tocline"><a class="tocxref" href="#contrast-minimum"><bdi class="secno">1.4.3 </bdi>コントラスト (最低限)</a></li><li class="tocline"><a class="tocxref" href="#resize-text"><bdi class="secno">1.4.4 </bdi>テキストのサイズ変更</a></li><li class="tocline"><a class="tocxref" href="#images-of-text"><bdi class="secno">1.4.5 </bdi>文字画像</a></li><li class="tocline"><a class="tocxref" href="#contrast-enhanced"><bdi class="secno">1.4.6 </bdi>コントラスト (高度)</a></li><li class="tocline"><a class="tocxref" href="#low-or-no-background-audio"><bdi class="secno">1.4.7 </bdi>小さな背景音、又は背景音なし</a></li><li class="tocline"><a class="tocxref" href="#visual-presentation"><bdi class="secno">1.4.8 </bdi>視覚的提示</a></li><li class="tocline"><a class="tocxref" href="#images-of-text-no-exception"><bdi class="secno">1.4.9 </bdi>文字画像 (例外なし)</a></li><li class="tocline"><a class="tocxref" href="#reflow"><bdi class="secno">1.4.10 </bdi>リフロー</a></li><li class="tocline"><a class="tocxref" href="#non-text-contrast"><bdi class="secno">1.4.11 </bdi>非テキストのコントラスト</a></li><li class="tocline"><a class="tocxref" href="#text-spacing"><bdi class="secno">1.4.12 </bdi>テキストの間隔</a></li><li class="tocline"><a class="tocxref" href="#content-on-hover-or-focus"><bdi class="secno">1.4.13 </bdi>ホバー又はフォーカスで表示されるコンテンツ</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#operable"><bdi class="secno">2. </bdi>操作可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#keyboard-accessible"><bdi class="secno">2.1 </bdi>キーボード操作可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#keyboard"><bdi class="secno">2.1.1 </bdi>キーボード</a></li><li class="tocline"><a class="tocxref" href="#no-keyboard-trap"><bdi class="secno">2.1.2 </bdi>キーボードトラップなし</a></li><li class="tocline"><a class="tocxref" href="#keyboard-no-exception"><bdi class="secno">2.1.3 </bdi>キーボード (例外なし)</a></li><li class="tocline"><a class="tocxref" href="#character-key-shortcuts"><bdi class="secno">2.1.4 </bdi>文字キーのショートカット</a></li></ol></li><li class="tocline"><a class="tocxref" href="#enough-time"><bdi class="secno">2.2 </bdi>十分な時間</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#timing-adjustable"><bdi class="secno">2.2.1 </bdi>タイミング調整可能</a></li><li class="tocline"><a class="tocxref" href="#pause-stop-hide"><bdi class="secno">2.2.2 </bdi>一時停止、停止、非表示</a></li><li class="tocline"><a class="tocxref" href="#no-timing"><bdi class="secno">2.2.3 </bdi>タイミング非依存</a></li><li class="tocline"><a class="tocxref" href="#interruptions"><bdi class="secno">2.2.4 </bdi>割り込み</a></li><li class="tocline"><a class="tocxref" href="#re-authenticating"><bdi class="secno">2.2.5 </bdi>再認証</a></li><li class="tocline"><a class="tocxref" href="#timeouts"><bdi class="secno">2.2.6 </bdi>タイムアウト</a></li></ol></li><li class="tocline"><a class="tocxref" href="#seizures-and-physical-reactions"><bdi class="secno">2.3 </bdi>発作と身体的反応</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#three-flashes-or-below-threshold"><bdi class="secno">2.3.1 </bdi>3 回の閃光、又は閾値以下</a></li><li class="tocline"><a class="tocxref" href="#three-flashes"><bdi class="secno">2.3.2 </bdi>3 回の閃光</a></li><li class="tocline"><a class="tocxref" href="#animation-from-interactions"><bdi class="secno">2.3.3 </bdi>インタラクションによるアニメーション</a></li></ol></li><li class="tocline"><a class="tocxref" href="#navigable"><bdi class="secno">2.4 </bdi>ナビゲーション可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#bypass-blocks"><bdi class="secno">2.4.1 </bdi>ブロックスキップ</a></li><li class="tocline"><a class="tocxref" href="#page-titled"><bdi class="secno">2.4.2 </bdi>ページタイトル</a></li><li class="tocline"><a class="tocxref" href="#focus-order"><bdi class="secno">2.4.3 </bdi>フォーカス順序</a></li><li class="tocline"><a class="tocxref" href="#link-purpose-in-context"><bdi class="secno">2.4.4 </bdi>リンクの目的 (コンテキスト内)</a></li><li class="tocline"><a class="tocxref" href="#multiple-ways"><bdi class="secno">2.4.5 </bdi>複数の手段</a></li><li class="tocline"><a class="tocxref" href="#headings-and-labels"><bdi class="secno">2.4.6 </bdi>見出し及びラベル</a></li><li class="tocline"><a class="tocxref" href="#focus-visible"><bdi class="secno">2.4.7 </bdi>フォーカスの可視化</a></li><li class="tocline"><a class="tocxref" href="#location"><bdi class="secno">2.4.8 </bdi>現在位置</a></li><li class="tocline"><a class="tocxref" href="#link-purpose-link-only"><bdi class="secno">2.4.9 </bdi>リンクの目的 (リンクのみ)</a></li><li class="tocline"><a class="tocxref" href="#section-headings"><bdi class="secno">2.4.10 </bdi>セクション見出し</a></li></ol></li><li class="tocline"><a class="tocxref" href="#input-modalities"><bdi class="secno">2.5 </bdi>入力モダリティ</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#pointer-gestures"><bdi class="secno">2.5.1 </bdi>ポインタのジェスチャ</a></li><li class="tocline"><a class="tocxref" href="#pointer-cancellation"><bdi class="secno">2.5.2 </bdi>ポインタのキャンセル</a></li><li class="tocline"><a class="tocxref" href="#label-in-name"><bdi class="secno">2.5.3 </bdi>ラベルを含む名前 (name)</a></li><li class="tocline"><a class="tocxref" href="#motion-actuation"><bdi class="secno">2.5.4 </bdi>動きによる起動</a></li><li class="tocline"><a class="tocxref" href="#target-size"><bdi class="secno">2.5.5 </bdi>ターゲットのサイズ</a></li><li class="tocline"><a class="tocxref" href="#concurrent-input-mechanisms"><bdi class="secno">2.5.6 </bdi>入力メカニズムの共存</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#understandable"><bdi class="secno">3. </bdi> 理解可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#readable"><bdi class="secno">3.1 </bdi>読み取り可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#language-of-page"><bdi class="secno">3.1.1 </bdi>ページの言語</a></li><li class="tocline"><a class="tocxref" href="#language-of-parts"><bdi class="secno">3.1.2 </bdi>一部分の言語</a></li><li class="tocline"><a class="tocxref" href="#unusual-words"><bdi class="secno">3.1.3 </bdi>一般的ではない用語</a></li><li class="tocline"><a class="tocxref" href="#abbreviations"><bdi class="secno">3.1.4 </bdi>略語</a></li><li class="tocline"><a class="tocxref" href="#reading-level"><bdi class="secno">3.1.5 </bdi>読解レベル</a></li><li class="tocline"><a class="tocxref" href="#pronunciation"><bdi class="secno">3.1.6 </bdi>発音</a></li></ol></li><li class="tocline"><a class="tocxref" href="#predictable"><bdi class="secno">3.2 </bdi>予測可能</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#on-focus"><bdi class="secno">3.2.1 </bdi>フォーカス時</a></li><li class="tocline"><a class="tocxref" href="#on-input"><bdi class="secno">3.2.2 </bdi>入力時</a></li><li class="tocline"><a class="tocxref" href="#consistent-navigation"><bdi class="secno">3.2.3 </bdi>一貫したナビゲーション</a></li><li class="tocline"><a class="tocxref" href="#consistent-identification"><bdi class="secno">3.2.4 </bdi>一貫した識別性</a></li><li class="tocline"><a class="tocxref" href="#change-on-request"><bdi class="secno">3.2.5 </bdi>要求による変化</a></li></ol></li><li class="tocline"><a class="tocxref" href="#input-assistance"><bdi class="secno">3.3 </bdi>入力支援</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#error-identification"><bdi class="secno">3.3.1 </bdi>エラーの特定</a></li><li class="tocline"><a class="tocxref" href="#labels-or-instructions"><bdi class="secno">3.3.2 </bdi>ラベル又は説明</a></li><li class="tocline"><a class="tocxref" href="#error-suggestion"><bdi class="secno">3.3.3 </bdi>エラー修正の提案</a></li><li class="tocline"><a class="tocxref" href="#error-prevention-legal-financial-data"><bdi class="secno">3.3.4 </bdi>誤り防止 (法的、金融、データ)</a></li><li class="tocline"><a class="tocxref" href="#help"><bdi class="secno">3.3.5 </bdi>ヘルプ</a></li><li class="tocline"><a class="tocxref" href="#error-prevention-all"><bdi class="secno">3.3.6 </bdi>誤り防止 (すべて)</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#robust"><bdi class="secno">4. </bdi>堅牢 (robust)</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#compatible"><bdi class="secno">4.1 </bdi>互換性</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#parsing"><bdi class="secno">4.1.1 </bdi>構文解析</a></li><li class="tocline"><a class="tocxref" href="#name-role-value"><bdi class="secno">4.1.2 </bdi>名前 (name)・役割 (role)・値 (value)</a></li><li class="tocline"><a class="tocxref" href="#status-messages"><bdi class="secno">4.1.3 </bdi>ステータスメッセージ</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">5. </bdi>適合</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#interpreting-normative-requirements"><bdi class="secno">5.1 </bdi>規定要件の解釈</a></li><li class="tocline"><a class="tocxref" href="#conformance-reqs"><bdi class="secno">5.2 </bdi>適合要件</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#cc1"><bdi class="secno">5.2.1 </bdi>適合レベル</a></li><li class="tocline"><a class="tocxref" href="#cc2"><bdi class="secno">5.2.2 </bdi>ウェブページ全体</a></li><li class="tocline"><a class="tocxref" href="#cc3"><bdi class="secno">5.2.3 </bdi>プロセス全体</a></li><li class="tocline"><a class="tocxref" href="#cc4"><bdi class="secno">5.2.4 </bdi>技術のアクセシビリティ サポーテッドな使用方法だけ</a></li><li class="tocline"><a class="tocxref" href="#cc5"><bdi class="secno">5.2.5 </bdi>非干渉</a></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance-claims"><bdi class="secno">5.3 </bdi>適合表明 (任意)</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance-required"><bdi class="secno">5.3.1 </bdi>適合表明の必須要素</a></li><li class="tocline"><a class="tocxref" href="#conformance-optional"><bdi class="secno">5.3.2 </bdi>適合表明の任意要素</a></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance-partial"><bdi class="secno">5.4 </bdi>部分適合に関する記述 － 第三者によるコンテンツ</a></li><li class="tocline"><a class="tocxref" href="#conformance-partial-lang"><bdi class="secno">5.5 </bdi>部分適合に関する記述 － 言語</a></li></ol></li><li class="tocline"><a class="tocxref" href="#glossary"><bdi class="secno">6. </bdi>用語集</a></li><li class="tocline"><a class="tocxref" href="#input-purposes"><bdi class="secno">7. </bdi>ユーザインタフェース コンポーネントの入力目的</a></li><li class="tocline"><a class="tocxref" href="#changelog"><bdi class="secno">A. </bdi>変更点</a></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B. </bdi>謝辞</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#ack_participants-active"><bdi class="secno">B.1 </bdi>この文書の作成時にアクティブだった AG WG 参加者:</a></li><li class="tocline"><a class="tocxref" href="#ack_participants-previous"><bdi class="secno">B.2 </bdi>以前に活動していた他の WCAG WG 参加者及び WCAG 2.0、WCAG 2.1、又は関連文書への他の貢献者</a></li><li class="tocline"><a class="tocxref" href="#enabling-funders"><bdi class="secno">B.3 </bdi>有効な資金提供者</a></li></ol></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">C. </bdi>参考文献</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.1 </bdi>参考文書</a></li></ol></li></ol></nav>
+      
+      <section class="informative introductory" id="intro"><div class="header-wrapper"><h2 id="introduction">イントロダクション</h2><a class="self-link" href="#intro" aria-label="Permalink for this Section"></a></div><p><em>この節は規定ではない。</em></p>
+         			
+         
+         			
+         <section id="background-on-wcag-2"><div class="header-wrapper"><h3 id="background-on-wcag-2-0">WCAG 2 の背景</h3><a class="self-link" href="#background-on-wcag-2" aria-label="Permalink for this Section"></a></div>
+            				
+            
+            				
+            <p>Web Content Accessibility Guidelines (WCAG) 2.1 は、ウェブコンテンツを障害のある人にとってよりアクセシブルにする方法を定義している。アクセシビリティは、視覚、聴覚、身体、発話、認知、言語、学習、神経の障害を含む、広範な障害に関係している。このガイドラインは、広範囲に及ぶ事項を網羅しているが、障害のすべての種類、程度、組合せからくるニーズを満たすことはできない。また、このガイドラインは、加齢により能力が変化している高齢者にとってもウェブコンテンツをより使いやすくするものであるとともに、しばしば利用者全般のユーザビリティを向上させる。</p>
+            				
+            <p>WCAG 2.1 は、ウェブコンテンツのアクセシビリティに対して、様々な国の個人、組織、政府のニーズを満たすような共通の基準を提供することを目的として、 <a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/"><abbr title="World Wide Web Consortium">W3C</abbr> process</a> に従って世界中の個人及び組織の協力のもと作成されている。WCAG 2.0 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wcag20" title="Web Content Accessibility Guidelines (WCAG) 2.0">WCAG20</a></cite>] は WCAG 1.0 [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-webcontent" title="Web Content Accessibility Guidelines 1.0">WAI-WEBCONTENT</a></cite>] をベースに、 WCAG 2.1 は WCAG 2.0 をベースに、順に作られており、現在及び将来の様々なウェブ技術に広く適用され、自動テストと人間による評価の組み合わせでテスト可能になるように設計されている。WCAG のイントロダクションとしては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。</p>
+            
+            				
+            <p>認知、言語、及び学習障害に対処するための追加の達成基準を定義するにあたり、勧告策定期間の短さに加えて、勧告案のテスト可能性や実装可能性、国際的な観点からの検討について合意形成に至る際の課題など、重大な課題に向き合うこととなった。こうした領域については、WCAG の将来の版で検討が継続されることになる。コンテンツ制作者においては、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/#supplement">学習障害、認知障害、ロービジョンなど障害のある人のインクルージョンを向上するための補足的なガイダンス</a>を参照することを推奨する。</p>
+            
+            				
+            <p>ウェブアクセシビリティは、アクセシブルなコンテンツだけではなく、アクセシブルなウェブブラウザやその他のユーザエージェントにも依存している。そして、オーサリングツールもウェブアクセシビリティにおいて重要な役割を担っている。ウェブ開発やインタラクションを構成するこれらの要素が相互にどのように関係しているかの概要については、以下を参照:</p>
+            				
+            <ul>
+               					
+               <li><strong><a href="https://www.w3.org/WAI/fundamentals/components/">Essential Components of Web Accessibility</a></strong></li>
+               					
+               <li><strong><a href="https://www.w3.org/WAI/standards-guidelines/uaag/">User Agent Accessibility Guidelines (UAAG) Overview</a></strong></li>
+               					
+               <li><strong><a href="https://www.w3.org/WAI/standards-guidelines/atag/">Authoring Tool Accessibility Guidelines (ATAG) Overview</a></strong></li>
+               
+            </ul>
+            
+            <p>この文書で <q>WCAG 2</q> を表す場合、2 で始まる WCAG の全てのバージョンを表すことを意図している。</p>
+            			
+         </section>
+         			
+         <section id="wcag-2-layers-of-guidance"><div class="header-wrapper"><h3 id="wcag-2-layers-of-guidance-0">WCAG 2 ガイダンスのレイヤー</h3><a class="self-link" href="#wcag-2-layers-of-guidance" aria-label="Permalink for this Section"></a></div>
+            				
+            
+            				
+            <p>WCAG を用いる個人や組織は実に幅広く、ウェブデザイナーや開発者、政策立案者、調達担当者、教師、及び生徒などが含まれる。これらの人たちの様々なニーズに応えるために WCAG 2.0 では、 <em>原則</em>、一般的な <em>ガイドライン</em> 、検証可能な<em>達成基準</em> 、<em>十分な達成方法</em>、<em>参考達成方法</em>、及び<em>よくある失敗例</em>を示した豊富な文書群を含む様々なレイヤーのガイダンスが、事例や参考リンク及びコードとともに提供されている。</p>
+            				
+            <ul>
+               					
+               <li><p><strong>原則</strong> - 最上位には、ウェブアクセシビリティの土台となる四つの原則がある: <em>知覚可能、操作可能、理解可能、及び堅牢 (robust)</em> 。あわせて、<a href="https://www.w3.org/WAI/WCAG21/Understanding/intro#understanding-the-four-principles-of-accessibility">Understanding the Four Principles of Accessibility</a> も参照。</p>
+                  					
+               </li>
+               					
+               <li><p><strong>ガイドライン</strong> - 原則の下にあるのがガイドラインである。13 のガイドラインは、様々な障害のある利用者に対してコンテンツをよりアクセシブルにするためにコンテンツ制作者が取り組むべき基本的な目標を提供している。これらのガイドラインは検証可能ではないが、コンテンツ制作者が達成基準を理解し、より適した達成方法を用いることができるように、全体的な枠組みや全般的な目的を提供するものである。</p>
+                  					
+               </li>
+               					
+               <li><p><strong>達成基準</strong> - 各ガイドラインには、検証可能な達成基準が設けられており、デザイン仕様検討、調達、基準策定、及び契約上の合意などにあたりその要件や適合試験が必要となる際に WCAG 2.1 を用いることが可能である。様々な利用者層や状況からくるニーズを満たすために、三つの適合レベルが定義されている: A (最低レベル)、AA、AAA (最高レベル)。WCAG のレベルに関する補足情報は、<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#levels">Understanding Levels of Conformance</a> を参照。</p>
+                  					
+               </li>
+               					
+               <li><p><strong>十分な達成方法及び参考達成方法</strong> - WCAG 2.1 文書自体にある<em>ガイドライン </em>及び<em>達成基準</em>それぞれに対して、ワーキンググループは<em>達成方法</em>についても広範囲にわたって文書化している。達成方法は参考情報であり、二つのカテゴリに分類される: 達成基準を満たすのに<em>十分な</em>達成方法と<em>参考達成方法</em>である。参考達成方法は、個々の達成基準の要件を上回るもので、これらの達成方法を用いることで、コンテンツ制作者はガイドラインに対してより良い対処をすることができる。参考達成方法の中には、検証可能な達成基準によってカバーされていないアクセシビリティの問題に対処するものもある。よくある失敗例がある場合は、それも文書化されている。<a href="https://www.w3.org/WAI/WCAG21/Understanding/understanding-techniques">Sufficient and Advisory Techniques in Understanding WCAG 2.1</a> も参照。</p>
+                  					
+               </li>
+               				
+            </ul>
+            				
+            <p>このガイダンスのレイヤー (原則、ガイドライン、達成基準、十分な達成方法及び参考達成方法) はすべて、コンテンツをよりアクセシブルにする方法に関するガイダンスを提供するために連携している。コンテンツ制作者は可能な範囲で最も広い利用者のニーズに最大限対処できるように、参考達成方法を含めたすべてのレイヤーを確認して適用することが推奨される。</p>
+            				
+            <p>注意すべきなのは、最高レベル (AAA) で適合しているコンテンツでさえも、すべての種類、程度あるいは組合せの障害のある個人、特に、認知、言語及び学習の面において、アクセシブルではないということである。コンテンツ制作者は、参考達成方法を含むすべての達成方法を考慮するとともに、ウェブコンテンツが可能な限りアクセシブルであることを確実にするためにも、こうした人たちに対して、現状における最善の対応策に関するアドバイスを追い求めることが推奨される。<a href="https://www.w3.org/WAI/WCAG21/Understanding/understanding-metadata">メタデータ</a>は、彼らのニーズに最適なコンテンツを探し出す際に、利用者を支援できる可能性がある。</p>
+            			
+         </section>
+         			
+         <section id="wcag-2-1-supporting-documents"><div class="header-wrapper"><h3 id="wcag-2-1-supporting-documents-0">WCAG 2.1 関連文書</h3><a class="self-link" href="#wcag-2-1-supporting-documents" aria-label="Permalink for this Section"></a></div>
+            				
+            
+            				
+            <p>WCAG 2.1 の文書は、安定した参照可能な技術標準を必要とする人たちのニーズを満たすように作成されている。関連文書と呼ばれるその他の文書は、WCAG 2.1 文書に基づいて、WCAG が新しい技術にどのように適用されるかを説明するために更新できるようにすることを含め、その他の重要な役割を果たすものである。関連文書には以下に挙げるものがある:</p>
+            				
+            <ol class="enumar">
+               					
+               <li><p><strong><a href="https://www.w3.org/WAI/WCAG21/quickref/">How to Meet WCAG 2.1</a></strong> - WCAG 2.1 のカスタマイズ可能なクイックリファレンス。コンテンツ制作者がウェブコンテンツを制作したり評価したりする際に用いるガイドライン、達成基準、達成方法のすべてが含まれる。これには WCAG 2.0 および WCAG 2.1 のコンテンツが含まれており、関連するコンテンツにコンテンツ制作者がフォーカスできるよう、様々な方法でフィルタリングできるようになっている。</p>
+                  					
+               </li>
+               					
+               <li><p><strong><a href="https://www.w3.org/WAI/WCAG21/Understanding/">Understanding WCAG 2.1</a></strong> - WCAG 2.1 を理解して実践するための解説書。重要なトピックスとあわせて、WCAG 2.1 の各ガイドライン及び達成基準を「理解する」ための簡潔な文書がある。</p>
+                  					
+               </li>
+               					
+               <li><p><strong><a href="https://www.w3.org/WAI/WCAG21/Techniques/">Techniques for WCAG 2.1</a></strong> - 達成方法集及びよくある失敗例集。個々に別々の文書になっており、解説、事例、コード例、テストが含まれる。</p>
+                  					
+               </li>
+               					
+               <li><p><strong><a href="https://www.w3.org/WAI/standards-guidelines/wcag/docs/">The WCAG Documents</a></strong> - 技術文書群がどのように関係していてリンクされているのかを示した図と解説。</p>
+                  					
+               </li>
+               				
+            </ol>
+            				
+            <p>WCAG 2.1 に関する教育資料を含む関連資料の説明は、<a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> を参照。例えば、ウェブアクセシビリティのビジネスにおける効果、ウェブサイトのアクセシビリティを改善するための実施計画作成、及びアクセシビリティ方針といったトピックに関する補足資料は、<a href="https://www.w3.org/WAI/Resources/Overview">WAI Resources</a> に挙げられている。</p>
+            			
+         </section>
+         	
+         <section id="requirements-for-wcag-2-1"><div class="header-wrapper"><h3 id="requirements-for-wcag-2-1-0">WCAG 2.1 の要件</h3><a class="self-link" href="#requirements-for-wcag-2-1" aria-label="Permalink for this Section"></a></div>
+            		
+            
+            
+            <p>WCAG 2.1 は、WCAG 2.0 の要件を継承する一連の <a href="https://w3c.github.io/wcag21/requirements/">WCAG 2.1 の要件</a>を満たしている。要件は、ガイドラインの全体的なフレームワークを構成し、後方互換性を確保している。ワーキンググループはまた、達成基準のスタイルや品質が WCAG 2.0 のものと類似することを確保するために、達成基準に対し、あまり形式的ではない一連の受け入れ基準を採用した。これらの要件は、WCAG 2.1に含めることができるものを制限している。この制限は、WCAG 2 のドットリリースの性質を保持するために重要である。</p>
+            	
+         </section>
+         		
+         <section id="comparison-with-wcag-2-0"><div class="header-wrapper"><h3 id="comparison-with-wcag-2-0-0">WCAG 2.0 との比較</h3><a class="self-link" href="#comparison-with-wcag-2-0" aria-label="Permalink for this Section"></a></div>
+            
+            
+            
+            <p>WCAG 2.1 は、認知または学習障害のある利用者、ロービジョンの利用者、モバイルデバイス上の障害のある利用者、という三つの主要なグループためのアクセシビリティのガイダンスを改善することを目的に開始された。これらのニーズを満たすために多くの方法が提案され評価され、ワーキンググループによって洗練された。WCAG 2.0 から引き継がれた構造上の要件、提案の明確さ及び影響、並びに進行計画が、この版に含まれる最終的な一式の達成基準につながった。ワーキンググループは、WCAG 2.1 がこれらすべての領域におけるウェブコンテンツのアクセシビリティのガイダンスを段階的に進歩させると考えているが、このガイドラインではすべての利用者のニーズが満たされているわけではないことを強調している。</p>
+            
+            				
+            <p>WCAG 2.1 は WCAG 2.0 をベースに構築され、WCAG 2.0 と後方互換性があるため、WCAG 2.1 に適合しているウェブページはすなわち WCAG 2.0 にも適合していることにもなる。WCAG 2.0 への適合を方針によって要求されているコンテンツ制作者は、WCAG 2.0 への適合を維持したままコンテンツを WCAG 2.1 に適合できるようアップデートすることができる。両方のガイドラインに従うコンテンツ制作者は、以下に挙げる差異に注意すべきである。</p>
+            				
+            <section id="new-features-in-wcag-2-1"><div class="header-wrapper"><h4 id="new-features-in-wcag-2-1-0">WCAG 2.1 の新しい特徴</h4><a class="self-link" href="#new-features-in-wcag-2-1" aria-label="Permalink for this Section"></a></div>
+               					
+               
+               					
+               <p>WCAG 2.1 は WCAG 2.0 に新しい達成基準やそれらを補助する定義、追加分をまとめるガイドライン、適合の節へのいくつかの追加によって拡張されている。この付加的なアプローチは、WCAG 2.1 に適合するサイトが WCAG 2.0 にも適合することを明確にするのに役立ち、それによって WCAG 2.0 固有の適合義務を満たす。アクセシビリティガイドライン ワーキンググループは新しい適合目標として、例え公的義務が WCAG 2.0 に言及するものであっても、将来のポリシーの変更を鑑みアクセシビリティをより向上させるために、サイトが WCAG 2.1 を採用することを推奨する。</p>
+               					
+               <p>以下が WCAG 2.1 の新しい達成基準である:</p>
+               					
+               <ul>
+                  						
+                  <li>1.3.4 <a href="#orientation">表示の向き</a> (AA)</li>
+                  						
+                  <li>1.3.5 <a href="#identify-input-purpose">入力目的の特定</a> (AA)</li>
+                  						
+                  <li>1.3.6 <a href="#identify-purpose">目的の特定</a> (AAA)</li>
+                  						
+                  <li>1.4.10 <a href="#reflow">リフロー</a> (AA)</li>
+                  						
+                  <li>1.4.11 <a href="#non-text-contrast">非テキストのコントラスト</a> (AA)</li>
+                  						
+                  <li>1.4.12 <a href="#text-spacing">テキストの間隔</a> (AA)</li>
+                  						
+                  <li>1.4.13 <a href="#content-on-hover-or-focus">ホバー又はフォーカスで表示されるコンテンツ</a> (AA)</li>
+                  						
+                  <li>2.1.4 <a href="#character-key-shortcuts">文字キーのショートカット</a> (A)</li>
+                  						
+                  <li>2.2.6 <a href="#timeouts">タイムアウト</a> (AAA)</li>
+                  						
+                  <li>2.3.3 <a href="#animation-from-interactions">インタラクションによるアニメーション</a> (AAA)</li>
+                  						
+                  <li>2.5.1 <a href="#pointer-gestures">ポインタのジェスチャ</a> (A)</li>
+                  						
+                  <li>2.5.2 <a href="#pointer-cancellation">ポインタのキャンセル</a> (A)</li>
+                  						
+                  <li>2.5.3 <a href="#label-in-name">ラベルを含む名前 (name)</a> (A)</li>
+                  						
+                  <li>2.5.4 <a href="#motion-actuation">動きによる起動</a> (A)</li>
+                  						
+                  <li>2.5.5 <a href="#target-size">ターゲットのサイズ</a> (AAA)</li>
+                  						
+                  <li>2.5.6 <a href="#concurrent-input-mechanisms">入力メカニズムの共存</a> (AAA)</li>
+                  						
+                  <li>4.1.3 <a href="#status-messages">ステータスメッセージ</a> (AA)</li>
+                  					
+               </ul>
+               					
+               <p>新しい達成基準は、用語集に追加された新しい用語を参照していることがあり、それらもまた達成基準の規定要件の一部を構成することがある。</p>
+               					
+               <p>適合の節では、<a href="#cc2">ページ全体</a>にページのバリエーションについて 3 番目の注記が追加され、<a href="#conformance-optional">適合表明の任意要素</a>に機械的に読み取れるメタデータのオプションが追加されている。</p>
+               				
+            </section>
+            				
+            <section id="numbering-in-wcag-2-1"><div class="header-wrapper"><h4 id="numbering-in-wcag-2-1-0">WCAG 2.1 におけるナンバリング</h4><a class="self-link" href="#numbering-in-wcag-2-1" aria-label="Permalink for this Section"></a></div>
+               					
+               
+               					
+               <p>WCAG 2.0 に対する後方互換性が重要となる開発者の混乱を招くことを避けるため、WCAG 2.1 における新しい達成基準はガイドライン内の一連の達成基準の末尾に追加されている。これにより、ガイドラインの既存の達成基準の間に新しい達成基準を挿入することによって生じるであろう、WCAG 2.0 からある達成基準のセクション番号の変更の必要性が、回避される。しかしながらこのことは、各ガイドライン内の達成基準がもはや適合レベルごとにグループ分けされていないことを意味する。各ガイドライン内での達成基準の順番は、適合レベルに関する情報を暗示するものではなく、各達成基準自身の適合レベル表示 (A / AA / AAA) のみが適合レベルを示す。<a href="https://www.w3.org/WAI/WCAG21/quickref/">WCAG 2.1 クイックリファレンス</a>は、他の多数のフィルターや並べ替え方法と共に、適合レベルごとにグループ化された達成基準を見る方法を提供する。</p>
+               				
+            </section>
+            				
+            <section id="conformance-to-wcag-2-1"><div class="header-wrapper"><h4 id="conformance-to-wcag-2-1-0">WCAG 2.1 への適合</h4><a class="self-link" href="#conformance-to-wcag-2-1" aria-label="Permalink for this Section"></a></div>
+               					
+               
+               					
+               <p>WCAG 2.1 は WCAG 2.0 と同様の適合モデルをいくつかの追加と共に用いており、<a href="#conformance">適合</a>の節に記載されている。WCAG 2.1 に適合するサイトは WCAG 2.0 にも適合することを意図している。つまり、それらのサイトは WCAG 2.0 が参照する全ての方針の要求を満たしつつ、現在のウェブの利用者のニーズもより多く満たすことができる。</p>
+               				
+            </section>
+            			
+         </section>
+         	
+         <section id="later-versions-of-accessibility-guidelines"><div class="header-wrapper"><h3 id="later-versions-of-accessibility-guidelines-0">アクセシビリティガイドラインの後続版</h3><a class="self-link" href="#later-versions-of-accessibility-guidelines" aria-label="Permalink for this Section"></a></div>
+            		
+            
+            		
+            <p>WCAG 2.1 と並行して、アクセシビリティガイドライン ワーキンググループは、アクセシビリティガイドラインの別の主要版を開発している。この作業の結果は、現実的な WCAG 2 のドットリリースのためと言うより、ウェブアクセシビリティガイダンスのより大幅な再構築になると期待されている。この作業は、コンテンツ制作、ユーザエージェントのサポート、及びオーサリングツールのサポートの役割を含む、最も効果的かつ柔軟な結果を生むために、研究に焦点を合わせた、ユーザ中心設計の方法論に従う。これは長年にわたる努力であるため、WCAG 2.0 の公開からのウェブ上の変化を反映するための最新のウェブアクセシビリティガイダンスを提供するための暫定措置として WCAG 2.1 が必要とされる。ワーキンググループは、主要版が完成するまでの間、同様に短いタイムラインで追加のサポートを提供するために、WCAG 2.2 及びそれに続く暫定版を開発するかもしれない。</p>
+            	
+         </section>
+         
+      </section>
+      
+      <section class="principle" id="perceivable"><div class="header-wrapper"><h2 id="x1-perceivable"><bdi class="secno">1. </bdi> 知覚可能</h2><a class="self-link" href="#perceivable" aria-label="Permalink for Section 1."></a></div>
+         
+         
+         
+         <p>情報及びユーザインタフェース コンポーネントは、利用者が知覚できる方法で利用者に提示可能でなければならない。</p>
+         
+         
+         <section class="guideline" id="text-alternatives"><div class="header-wrapper"><h3 id="x1-1-text-alternatives"><bdi class="secno">ガイドライン 1.1</bdi> テキストによる代替</h3><a class="self-link" href="#text-alternatives" aria-label="Permalink for Section 1.1"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/text-alternatives.html">Understanding Text Alternatives</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#text-alternatives">How to Meet Text Alternatives</a></div><p>すべての非テキストコンテンツには、大活字、点字、音声、シンボル、平易な言葉などの利用者が必要とする形式に変換できるように、テキストによる代替を提供すること。</p>
+            <div class="note"><div role="heading" class="note-title marker" aria-level="4"><span>訳注</span></div><p>大活字とは、通常の出版物より大きな活字のことを指す。<a href="https://www.ndl.go.jp/jp/library/supportvisual/geppo201501/article05.html">障害者向け資料の紹介｜国立国会図書館―National Diet Library</a> も参照。</p></div>
+            <section class="guideline" id="non-text-content"><div class="header-wrapper"><h4 id="x1-1-1-non-text-content"><bdi class="secno">達成基準 1.1.1</bdi> 非テキストコンテンツ</h4><a class="self-link" href="#non-text-content" aria-label="Permalink for Section 1.1.1"></a></div>
    
-   <h4 id="x1-1-1-non-text-content"><span class="secno">達成基準 1.1.1 </span>非テキストコンテンツ<span class="permalink"><a href="#non-text-content" aria-label="Permalink for 1.1.1 Non-text Content" title="Permalink for 1.1.1 Non-text Content"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html">Understanding Non-text Content</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#non-text-content">How to Meet Non-text Content</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>利用者に提示されるすべての<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn">非テキストコンテンツ</a>には、同等の目的を果たす<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn">テキストによる代替</a>が提供されている。ただし、次の場合は除く:
-   </p>
+   <p>利用者に提示されるすべての<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-non-text-content-1" title="プログラムによる解釈が可能な文字の並びではないコンテンツ、又は文字の並びが自然言語においても何をも表現していないコンテンツ。">非テキストコンテンツ</a>には、同等の目的を果たす<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-alternative-1" title="非テキストコンテンツとプログラムで関連付けられるテキスト。又は非テキストコンテンツとプログラムで関連付けられるテキストから参照されるテキスト。プログラムで関連付けられたテキストとは、その場所を、非テキストコンテンツからプログラムによる解釈が可能なテキストである。">テキストによる代替</a>が提供されている。ただし、次の場合は除く:</p>
    
    <dl>
       
       <dt>コントロール、入力</dt>
       
-      <dd>
-         
-         <p>非テキストコンテンツが、コントロール又は利用者の入力を受け付けるものであるとき、その目的を説明する<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> を提供している。(コントロール及び利用者の入力を受け入れるコンテンツに関するその他の要件は、<a href="#name-role-value">Success Criterion 4.1.2</a> を参照。)
-         </p>
+      <dd><p>非テキストコンテンツが、コントロール又は利用者の入力を受け付けるものであるとき、その目的を説明する<a href="#dfn-name" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-name-1" title="ソフトウェアが、ウェブコンテンツのコンポーネントを利用者に識別させることができるテキスト。">名前 (name)</a> を提供している。(コントロール及び利用者の入力を受け入れるコンテンツに関するその他の要件は、<a href="#name-role-value">Success Criterion 4.1.2</a> を参照。) </p>
          
       </dd>
       
       <dt>時間依存メディア</dt>
       
-      <dd>
-         
-         <p>非テキストコンテンツが、時間に依存したメディアであるとき、テキストによる代替は、少なくとも、その非テキストコンテンツを識別できる説明を提供している。(メディアに関するその他の要件は、<a href="#time-based-media">ガイドライン 1.2</a> を参照。)
-         </p>
+      <dd><p>非テキストコンテンツが、時間に依存したメディアであるとき、テキストによる代替は、少なくとも、その非テキストコンテンツを識別できる説明を提供している。(メディアに関するその他の要件は、<a href="#time-based-media">ガイドライン 1.2</a> を参照。) </p>
          
       </dd>
       
       <dt>テスト</dt>
       
-      <dd>
-         
-         <p>非テキストコンテンツが、<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>で提示されると無効になるテスト又は演習のとき、テキストによる代替は、少なくともその非テキストコンテンツを識別できる説明を提供している。
-         </p>
+      <dd><p>非テキストコンテンツが、<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-1" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>で提示されると無効になるテスト又は演習のとき、テキストによる代替は、少なくともその非テキストコンテンツを識別できる説明を提供している。</p>
          
       </dd>
       
       <dt>感覚的</dt>
       
-      <dd>
-         
-         <p>非テキストコンテンツが、<a href="#dfn-specific-sensory-experience" class="internalDFN" data-link-type="dfn">特定の感覚的体験</a>を創り出すことを主に意図しているとき、テキストによる代替は、少なくともその非テキストコンテンツを識別できる説明を提供している。
-         </p>
+      <dd><p>非テキストコンテンツが、<a href="#dfn-specific-sensory-experience" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-specific-sensory-experience-1" title="純粋な装飾ではなく、かつ、重要な情報を伝える、又は機能を果たすことを主としない、感覚的な体験。">特定の感覚的体験</a>を創り出すことを主に意図しているとき、テキストによる代替は、少なくともその非テキストコンテンツを識別できる説明を提供している。</p>
          
       </dd>
       
-      <dt><a href="#dfn-captcha" class="internalDFN" data-link-type="dfn">CAPTCHA</a></dt>
+      <dt><a href="#dfn-captcha" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-captcha-1" title="コンピュータと人間とを判別する完全自動化されたチューリングテスト (Completely Automated Public Turing test to tell Computers and Humans Apart) の頭文字語。">CAPTCHA</a></dt>
       
-      <dd>
-         
-         <p>非テキストコンテンツが、コンピュータではなく人間がコンテンツにアクセスしていることを確認する目的で用いられているとき、テキストによる代替は、その非テキストコンテンツの目的を特定し、説明している。なおかつ、他の感覚による知覚に対応して出力する CAPTCHA の代替形式を提供することで、様々な障害に対応している。
-         </p>
+      <dd><p>非テキストコンテンツが、コンピュータではなく人間がコンテンツにアクセスしていることを確認する目的で用いられているとき、テキストによる代替は、その非テキストコンテンツの目的を特定し、説明している。なおかつ、他の感覚による知覚に対応して出力する CAPTCHA の代替形式を提供することで、様々な障害に対応している。</p>
          
       </dd>
       
       <dt>装飾、整形、非表示</dt>
       
-      <dd>
-         
-         <p>非テキストコンテンツが、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn">純粋な装飾</a>である、見た目の整形のためだけに用いられている、又は利用者に提供されるものではないとき、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>が無視できるように実装されている。
-         </p>
+      <dd><p>非テキストコンテンツが、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-pure-decoration-1" title="見栄えのためだけのもので、情報は提供せず、機能性も備えていないもの。">純粋な装飾</a>である、見た目の整形のためだけに用いられている、又は利用者に提供されるものではないとき、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-1" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>が無視できるように実装されている。</p>
          
       </dd>
       
    </dl>
    
 </section>
-            </section>
-
-            <section class="guideline" id="time-based-media">
-                <h3 id="x1-2-time-based-media"><span class="secno">ガイドライン 1.2 </span>時間依存メディア<span class="permalink"><a href="#time-based-media" aria-label="Permalink for 1.2 Time-based Media" title="Permalink for 1.2 Time-based Media"><span>§</span></a></span></h3>
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/time-based-media.html">Understanding Time-based Media</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#time-based-media">How to Meet Time-based Media</a></div>
-                <p>時間依存メディアには代替コンテンツを提供すること。</p>
-
-                <section class="sc" id="audio-only-and-video-only-prerecorded">
+            
+         </section>
+         
+         
+         <section class="guideline" id="time-based-media"><div class="header-wrapper"><h3 id="x1-2-time-based-media"><bdi class="secno">ガイドライン 1.2</bdi> 時間依存メディア</h3><a class="self-link" href="#time-based-media" aria-label="Permalink for Section 1.2"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/time-based-media.html">Understanding Time-based Media</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#time-based-media">How to Meet Time-based Media</a></div><p>時間依存メディアには代替コンテンツを提供すること。</p>
+            
+            <section class="guideline" id="audio-only-and-video-only-prerecorded"><div class="header-wrapper"><h4 id="x1-2-1-audio-only-and-video-only-prerecorded"><bdi class="secno">達成基準 1.2.1</bdi> 音声のみ及び映像のみ (収録済)</h4><a class="self-link" href="#audio-only-and-video-only-prerecorded" aria-label="Permalink for Section 1.2.1"></a></div>
    
-   <h4 id="x1-2-1-audio-only-and-video-only-prerecorded"><span class="secno">達成基準 1.2.1 </span>音声のみ及び映像のみ (収録済)<span class="permalink"><a href="#audio-only-and-video-only-prerecorded" aria-label="Permalink for 1.2.1 Audio-only and Video-only (Prerecorded)" title="Permalink for 1.2.1 Audio-only and Video-only (Prerecorded)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html">Understanding Audio-only and Video-only (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-only-and-video-only-prerecorded">How to Meet Audio-only and Video-only (Prerecorded)</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済の</a><a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn">音声しか</a>含まないメディア及び収録済の<a href="#dfn-video-only" class="internalDFN" data-link-type="dfn">映像しか</a>含まないメディアは、次の事項を満たしている。ただし、その音声又は映像がメディアによるテキストの代替であって、<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn">メディアによる代替</a>であることが明確にラベル付けされている場合は除く:
-   </p>
+   <p><a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-1" title="ライブではない情報。">収録済の</a><a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-only-1" title="a time-based presentation that contains only audio (no video and no interaction)">音声しか</a>含まないメディア及び収録済の<a href="#dfn-video-only" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-only-1" title="映像のみを含んだ (音声もインタラクションも含まない)、時間に依存する提示。">映像しか</a>含まないメディアは、次の事項を満たしている。ただし、その音声又は映像がメディアによるテキストの代替であって、<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-media-alternative-for-text-1" title="テキストで (直接又はテキストによる代替によって) 既に提示されている情報以上のものを提示していないメディア。">メディアによる代替</a>であることが明確にラベル付けされている場合は除く:</p>
    
    <dl>
       
       <dt>収録済の音声しか含まない</dt>
       
-      <dd>
-         
-         <p><a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn">時間依存メディアに対する代替</a>コンテンツによって、収録済の音声しか含まないコンテンツと同等の情報を提供している。
-         </p>
+      <dd><p><a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-alternative-for-time-based-media-1" title="時間依存の視覚的及び聴覚的情報を正しい順序で説明したテキストを含み、あらゆる時間依存のインタラクションによる結果を得る手段を提供している文書。">時間依存メディアに対する代替</a>コンテンツによって、収録済の音声しか含まないコンテンツと同等の情報を提供している。</p>
          
       </dd>
       
       <dt>収録済の映像しか含まない</dt>
       
-      <dd>
-         
-         <p>時間依存メディアに対する代替コンテンツ又は音声トラックによって、収録済の映像しか含まないコンテンツと同等の情報を提供している。
-         </p>
+      <dd><p>時間依存メディアに対する代替コンテンツ又は音声トラックによって、収録済の映像しか含まないコンテンツと同等の情報を提供している。</p>
          
       </dd>
       
    </dl>
    
 </section>
-
-                <section class="sc" id="captions-prerecorded">
+            
+            <section class="guideline" id="captions-prerecorded"><div class="header-wrapper"><h4 id="x1-2-2-captions-prerecorded"><bdi class="secno">達成基準 1.2.2</bdi> キャプション (収録済)</h4><a class="self-link" href="#captions-prerecorded" aria-label="Permalink for Section 1.2.2"></a></div>
    
-   <h4 id="x1-2-2-captions-prerecorded"><span class="secno">達成基準 1.2.2 </span>キャプション (収録済)<span class="permalink"><a href="#captions-prerecorded" aria-label="Permalink for 1.2.2 Captions (Prerecorded)" title="Permalink for 1.2.2 Captions (Prerecorded)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html">Understanding Captions (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#captions-prerecorded">How to Meet Captions (Prerecorded)</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済の</a><a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>コンテンツに対して、<a href="#dfn-captions" class="internalDFN" data-link-type="dfn">キャプション</a>が提供されている。ただし、その同期したメディアが<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn">メディアによるテキストの代替</a>であって、メディアによる代替であることが明確にラベル付けされている場合は除く。
-   </p>
+   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-1" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-2" title="ライブではない情報。">収録済の</a><a href="#dfn-audio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-1" title="音の再生技術。">音声</a>コンテンツに対して、<a href="#dfn-captions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-captions-1" title="そのメディアのコンテンツを理解するのに必要な、会話及び会話でない音声情報に対する、同期した視覚、及び／又はテキストによる代替。">キャプション</a>が提供されている。ただし、その同期したメディアが<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-media-alternative-for-text-2" title="テキストで (直接又はテキストによる代替によって) 既に提示されている情報以上のものを提示していないメディア。">メディアによるテキストの代替</a>であって、メディアによる代替であることが明確にラベル付けされている場合は除く。</p>
    
 </section>
-
-                <section class="sc" id="audio-description-or-media-alternative-prerecorded">
+            
+            <section class="guideline" id="audio-description-or-media-alternative-prerecorded"><div class="header-wrapper"><h4 id="x1-2-3-audio-description-or-media-alternative-prerecorded"><bdi class="secno">達成基準 1.2.3</bdi> 音声解説、又はメディアに対する代替 (収録済)</h4><a class="self-link" href="#audio-description-or-media-alternative-prerecorded" aria-label="Permalink for Section 1.2.3"></a></div>
    
-   <h4 id="x1-2-3-audio-description-or-media-alternative-prerecorded"><span class="secno">達成基準 1.2.3 </span>音声解説、又はメディアに対する代替 (収録済)<span class="permalink"><a href="#audio-description-or-media-alternative-prerecorded" aria-label="Permalink for 1.2.3 Audio Description or Media Alternative (Prerecorded)" title="Permalink for 1.2.3 Audio Description or Media Alternative (Prerecorded)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded.html">Understanding Audio Description or Media Alternative (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-description-or-media-alternative-prerecorded">How to Meet Audio Description or Media Alternative (Prerecorded)</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>に含まれている<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済の</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>コンテンツに対して、<a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn">時間依存メディアに対する代替</a>コンテンツ又は<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>が提供されている。ただし、その同期したメディアが<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn">メディアによるテキストの代替</a>であって、メディアによる代替であることが明確にラベル付けされている場合は除く。
-   </p>
+   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-2" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれている<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-3" title="ライブではない情報。">収録済の</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-1" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>コンテンツに対して、<a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-alternative-for-time-based-media-2" title="時間依存の視覚的及び聴覚的情報を正しい順序で説明したテキストを含み、あらゆる時間依存のインタラクションによる結果を得る手段を提供している文書。">時間依存メディアに対する代替</a>コンテンツ又は<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-descriptions-1" title="主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。">音声解説</a>が提供されている。ただし、その同期したメディアが<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-media-alternative-for-text-3" title="テキストで (直接又はテキストによる代替によって) 既に提示されている情報以上のものを提示していないメディア。">メディアによるテキストの代替</a>であって、メディアによる代替であることが明確にラベル付けされている場合は除く。</p>
    
 </section>
-
-                <section class="sc" id="captions-live">
+            
+            <section class="guideline" id="captions-live"><div class="header-wrapper"><h4 id="x1-2-4-captions-live"><bdi class="secno">達成基準 1.2.4</bdi> キャプション (ライブ)</h4><a class="self-link" href="#captions-live" aria-label="Permalink for Section 1.2.4"></a></div>
    
-   <h4 id="x1-2-4-captions-live"><span class="secno">達成基準 1.2.4 </span>キャプション (ライブ)<span class="permalink"><a href="#captions-live" aria-label="Permalink for 1.2.4 Captions (Live)" title="Permalink for 1.2.4 Captions (Live)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html">Understanding Captions (Live)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#captions-live">How to Meet Captions (Live)</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>に含まれているすべての<a href="#dfn-live" class="internalDFN" data-link-type="dfn">ライブ</a>の<a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>コンテンツに対して<a href="#dfn-captions" class="internalDFN" data-link-type="dfn">キャプション</a>が提供されている。
-   </p>
+   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-3" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれているすべての<a href="#dfn-live" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-live-1" title="現実の出来事から取り込まれ、放送遅延以上の遅延なく受け手に送信される情報。">ライブ</a>の<a href="#dfn-audio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-2" title="音の再生技術。">音声</a>コンテンツに対して<a href="#dfn-captions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-captions-2" title="そのメディアのコンテンツを理解するのに必要な、会話及び会話でない音声情報に対する、同期した視覚、及び／又はテキストによる代替。">キャプション</a>が提供されている。</p>
    
 </section>
-
-                <section class="sc" id="audio-description-prerecorded">
+            
+            <section class="guideline" id="audio-description-prerecorded"><div class="header-wrapper"><h4 id="x1-2-5-audio-description-prerecorded"><bdi class="secno">達成基準 1.2.5</bdi> 音声解説 (収録済)</h4><a class="self-link" href="#audio-description-prerecorded" aria-label="Permalink for Section 1.2.5"></a></div>
    
-   <h4 id="x1-2-5-audio-description-prerecorded"><span class="secno">達成基準 1.2.5 </span>音声解説 (収録済)<span class="permalink"><a href="#audio-description-prerecorded" aria-label="Permalink for 1.2.5 Audio Description (Prerecorded)" title="Permalink for 1.2.5 Audio Description (Prerecorded)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded.html">Understanding Audio Description (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-description-prerecorded">How to Meet Audio Description (Prerecorded)</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済の</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>コンテンツに対して、<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>が提供されている。
-   </p>
+   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-4" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-4" title="ライブではない情報。">収録済の</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-2" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>コンテンツに対して、<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-descriptions-2" title="主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。">音声解説</a>が提供されている。</p>
    
 </section>
-
-                <section class="sc" id="sign-language-prerecorded">
+            
+            <section class="guideline" id="sign-language-prerecorded"><div class="header-wrapper"><h4 id="x1-2-6-sign-language-prerecorded"><bdi class="secno">達成基準 1.2.6</bdi> 手話 (収録済)</h4><a class="self-link" href="#sign-language-prerecorded" aria-label="Permalink for Section 1.2.6"></a></div>
    
-   <h4 id="x1-2-6-sign-language-prerecorded"><span class="secno">達成基準 1.2.6 </span>手話 (収録済)<span class="permalink"><a href="#sign-language-prerecorded" aria-label="Permalink for 1.2.6 Sign Language (Prerecorded)" title="Permalink for 1.2.6 Sign Language (Prerecorded)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/sign-language-prerecorded.html">Understanding Sign Language (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#sign-language-prerecorded">How to Meet Sign Language (Prerecorded)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済の</a><a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>コンテンツに対して、<a href="#dfn-sign-language-interpretation" class="internalDFN" data-link-type="dfn">手話通訳</a>が提供されている。
-   </p>
+   <p><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-5" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-5" title="ライブではない情報。">収録済の</a><a href="#dfn-audio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-3" title="音の再生技術。">音声</a>コンテンツに対して、<a href="#dfn-sign-language-interpretation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-sign-language-interpretation-1" title="ある言語、通常は話されている言語を、手話に訳すこと。">手話通訳</a>が提供されている。</p>
    
 </section>
-
-                <section class="sc" id="extended-audio-description-prerecorded">
+            
+            <section class="guideline" id="extended-audio-description-prerecorded"><div class="header-wrapper"><h4 id="x1-2-7-extended-audio-description-prerecorded"><bdi class="secno">達成基準 1.2.7</bdi> 拡張音声解説 (収録済)</h4><a class="self-link" href="#extended-audio-description-prerecorded" aria-label="Permalink for Section 1.2.7"></a></div>
    
-   <h4 id="x1-2-7-extended-audio-description-prerecorded"><span class="secno">達成基準 1.2.7 </span>拡張音声解説 (収録済)<span class="permalink"><a href="#extended-audio-description-prerecorded" aria-label="Permalink for 1.2.7 Extended Audio Description (Prerecorded)" title="Permalink for 1.2.7 Extended Audio Description (Prerecorded)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/extended-audio-description-prerecorded.html">Understanding Extended Audio Description (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#extended-audio-description-prerecorded">How to Meet Extended Audio Description (Prerecorded)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>前景音の合間が、<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>で映像の意味を伝達するのに不十分な場合、<a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済の</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>コンテンツに対して、<a href="#dfn-extended-audio-description" class="internalDFN" data-link-type="dfn">拡張音声解説</a>が提供されている。
-   </p>
+   <p>前景音の合間が、<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-descriptions-3" title="主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。">音声解説</a>で映像の意味を伝達するのに不十分な場合、<a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-6" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>に含まれているすべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-6" title="ライブではない情報。">収録済の</a><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-3" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>コンテンツに対して、<a href="#dfn-extended-audio-description" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-audio-description-1" title="映像を一時停止することで追加の説明を付加するための時間を確保し、視聴覚提示に付加した音声解説。">拡張音声解説</a>が提供されている。</p>
    
 </section>
-
-                <section class="sc" id="media-alternative-prerecorded">
+            
+            <section class="guideline" id="media-alternative-prerecorded"><div class="header-wrapper"><h4 id="x1-2-8-media-alternative-prerecorded"><bdi class="secno">達成基準 1.2.8</bdi> メディアに対する代替 (収録済) </h4><a class="self-link" href="#media-alternative-prerecorded" aria-label="Permalink for Section 1.2.8"></a></div>
    
-   <h4 id="x1-2-8-media-alternative-prerecorded"><span class="secno">達成基準 1.2.8 </span>メディアに対する代替 (収録済)<span class="permalink"><a href="#media-alternative-prerecorded" aria-label="Permalink for 1.2.8 Media Alternative (Prerecorded)" title="Permalink for 1.2.8 Media Alternative (Prerecorded)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/media-alternative-prerecorded.html">Understanding Media Alternative (Prerecorded)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#media-alternative-prerecorded">How to Meet Media Alternative (Prerecorded)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>すべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済の</a><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>及びすべての収録済の<a href="#dfn-video-only" class="internalDFN" data-link-type="dfn">映像しか含まない</a>メディアに対して、<a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn">時間依存メディアに対する代替</a>コンテンツが提供されている。
-   </p>
+   <p>すべての<a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-7" title="ライブではない情報。">収録済の</a><a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-7" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>及びすべての収録済の<a href="#dfn-video-only" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-only-2" title="映像のみを含んだ (音声もインタラクションも含まない)、時間に依存する提示。">映像しか含まない</a>メディアに対して、<a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-alternative-for-time-based-media-3" title="時間依存の視覚的及び聴覚的情報を正しい順序で説明したテキストを含み、あらゆる時間依存のインタラクションによる結果を得る手段を提供している文書。">時間依存メディアに対する代替</a>コンテンツが提供されている。</p>
    
 </section>
-
-                <section class="sc" id="audio-only-live">
+            
+            <section class="guideline" id="audio-only-live"><div class="header-wrapper"><h4 id="x1-2-9-audio-only-live"><bdi class="secno">達成基準 1.2.9</bdi> 音声のみ (ライブ)</h4><a class="self-link" href="#audio-only-live" aria-label="Permalink for Section 1.2.9"></a></div>
    
-   <h4 id="x1-2-9-audio-only-live"><span class="secno">達成基準 1.2.9 </span>音声のみ (ライブ)<span class="permalink"><a href="#audio-only-live" aria-label="Permalink for 1.2.9 Audio-only (Live)" title="Permalink for 1.2.9 Audio-only (Live)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-only-live.html">Understanding Audio-only (Live)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-only-live">How to Meet Audio-only (Live)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-live" class="internalDFN" data-link-type="dfn">ライブ</a>の<a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn">音声しか含まない</a>コンテンツに対して、それと同等の情報を提示する、<a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn">時間依存メディアの代替</a>コンテンツが提供されている。
-   </p>
+   <p><a href="#dfn-live" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-live-2" title="現実の出来事から取り込まれ、放送遅延以上の遅延なく受け手に送信される情報。">ライブ</a>の<a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-only-2" title="a time-based presentation that contains only audio (no video and no interaction)">音声しか含まない</a>コンテンツに対して、それと同等の情報を提示する、<a href="#dfn-alternative-for-time-based-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-alternative-for-time-based-media-4" title="時間依存の視覚的及び聴覚的情報を正しい順序で説明したテキストを含み、あらゆる時間依存のインタラクションによる結果を得る手段を提供している文書。">時間依存メディアの代替</a>コンテンツが提供されている。</p>
    
 </section>
-            </section>
-
-            <section class="guideline" id="adaptable">
-                <h3 id="x1-3-adaptable"><span class="secno">ガイドライン 1.3 </span>適応可能<span class="permalink"><a href="#adaptable" aria-label="Permalink for 1.3 Adaptable" title="Permalink for 1.3 Adaptable"><span>§</span></a></span></h3>
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/adaptable.html">Understanding Adaptable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#adaptable">How to Meet Adaptable</a></div>
-                <p>情報、及び構造を損なうことなく、様々な方法 (例えば、よりシンプルなレイアウト) で提供できるようにコンテンツを制作すること。</p>
-
-                <section class="sc" id="info-and-relationships">
+            
+         </section>
+         
+         
+         <section class="guideline" id="adaptable"><div class="header-wrapper"><h3 id="x1-3-adaptable"><bdi class="secno">ガイドライン 1.3</bdi> 適応可能</h3><a class="self-link" href="#adaptable" aria-label="Permalink for Section 1.3"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/adaptable.html">Understanding Adaptable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#adaptable">How to Meet Adaptable</a></div><p>情報、及び構造を損なうことなく、様々な方法 (例えば、よりシンプルなレイアウト) で提供できるようにコンテンツを制作すること。</p>
+            
+            <section class="guideline" id="info-and-relationships"><div class="header-wrapper"><h4 id="x1-3-1-info-and-relationships"><bdi class="secno">達成基準 1.3.1</bdi> 情報及び関係性</h4><a class="self-link" href="#info-and-relationships" aria-label="Permalink for Section 1.3.1"></a></div>
    
-   <h4 id="x1-3-1-info-and-relationships"><span class="secno">達成基準 1.3.1 </span>情報及び関係性<span class="permalink"><a href="#info-and-relationships" aria-label="Permalink for 1.3.1 Info and Relationships" title="Permalink for 1.3.1 Info and Relationships"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html">Understanding Info and Relationships</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships">How to Meet Info and Relationships</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>何らかの形で<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>されている情報、<a href="#dfn-structure" class="internalDFN" data-link-type="dfn">構造</a>、及び<a href="#dfn-relationships" class="internalDFN" data-link-type="dfn">関係性</a>は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である、又はテキストで提供されている。
-   </p>
+   <p>何らかの形で<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-presentation-1" title="rendering of the content in a form to be perceived by users">提示</a>されている情報、<a href="#dfn-structure" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-structure-1" title="ウェブページの各部を相互の関係性によりまとめる方法論。一連のウェブページをまとめる方法論。">構造</a>、及び<a href="#dfn-relationships" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relationships-1" title="コンテンツの異なる部分間における意味のあるつながり。">関係性</a>は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-1" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である、又はテキストで提供されている。</p>
    
 </section>
-
-                <section class="sc" id="meaningful-sequence">
+            
+            <section class="guideline" id="meaningful-sequence"><div class="header-wrapper"><h4 id="x1-3-2-meaningful-sequence"><bdi class="secno">達成基準 1.3.2</bdi> 意味のあるシーケンス</h4><a class="self-link" href="#meaningful-sequence" aria-label="Permalink for Section 1.3.2"></a></div>
    
-   <h4 id="x1-3-2-meaningful-sequence"><span class="secno">達成基準 1.3.2 </span>意味のあるシーケンス<span class="permalink"><a href="#meaningful-sequence" aria-label="Permalink for 1.3.2 Meaningful Sequence" title="Permalink for 1.3.2 Meaningful Sequence"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence.html">Understanding Meaningful Sequence</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#meaningful-sequence">How to Meet Meaningful Sequence</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>コンテンツが提示されている順序が意味に影響を及ぼす場合には、<a href="#dfn-correct-reading-sequence" class="internalDFN" data-link-type="dfn">正しく読むシーケンス</a>は<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。
-   </p>
+   <p>コンテンツが提示されている順序が意味に影響を及ぼす場合には、<a href="#dfn-correct-reading-sequence" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-correct-reading-sequence-1" title="コンテンツの意味を変更せずに、単語及び段落が提示されるシーケンス。">正しく読むシーケンス</a>は<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-2" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である。</p>
    
 </section>
-
-                <section class="sc" id="sensory-characteristics">
+            
+            <section class="guideline" id="sensory-characteristics"><div class="header-wrapper"><h4 id="x1-3-3-sensory-characteristics"><bdi class="secno">達成基準 1.3.3</bdi> 感覚的な特徴</h4><a class="self-link" href="#sensory-characteristics" aria-label="Permalink for Section 1.3.3"></a></div>
    
-   <h4 id="x1-3-3-sensory-characteristics"><span class="secno">達成基準 1.3.3 </span>感覚的な特徴<span class="permalink"><a href="#sensory-characteristics" aria-label="Permalink for 1.3.3 Sensory Characteristics" title="Permalink for 1.3.3 Sensory Characteristics"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics.html">Understanding Sensory Characteristics</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#sensory-characteristics">How to Meet Sensory Characteristics</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>コンテンツを理解し操作するための説明は、形、色、大きさ、視覚的な位置、方向、又は音のような、構成要素が持つ感覚的な特徴だけに依存していない。
-   </p>
+   <p>コンテンツを理解し操作するための説明は、形、色、大きさ、視覚的な位置、方向、又は音のような、構成要素が持つ感覚的な特徴だけに依存していない。</p>
   
-  <div class="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="5"><span>注記</span></div><p class="">色に関する要件は、<a href="#distinguishable">ガイドライン 1.4</a> を参照。</p></div>
+  <div class="note" role="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="5"><span>注記</span></div><p class="">色に関する要件は、<a href="#distinguishable">ガイドライン 1.4</a> を参照。</p></div>
    
 </section>
 
-
-                <section class="sc" id="orientation">
+            
+            <section class="guideline" id="orientation"><div class="header-wrapper"><h4 id="x1-3-4-orientation"><bdi class="secno">達成基準 1.3.4</bdi> 表示の向き</h4><a class="self-link" href="#orientation" aria-label="Permalink for Section 1.3.4"></a></div>
    					
-   <h4 id="x1-3-4-orientation"><span class="secno">達成基準 1.3.4 </span>表示の向き<span class="permalink"><a href="#orientation" aria-label="Permalink for 1.3.4 Orientation" title="Permalink for 1.3.4 Orientation"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/orientation.html">Understanding Orientation</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#orientation">How to Meet Orientation</a></div><p class="conformance-level">(レベル AA)</p>
    					
-   
-   					
-  <p>コンテンツは、その表示及び操作を、縦向き (portrait) 又は横向き (landscape) のような単一のディスプレイの向きに制限しない。ただし、特定の表示装置の向きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合は除く。</p>
+  <p>コンテンツは、その表示及び操作を、縦向き (portrait) 又は横向き (landscape) のような単一のディスプレイの向きに制限しない。ただし、特定のディスプレイの向きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-1" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>な場合は除く。</p>
    				
-   <div class="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="5"><span>注記</span></div><p class="">特定のディスプレイの向きが必要不可欠となり得る例としては、銀行の小切手、ピアノのアプリケーション、プロジェクターもしくはテレビ向けのスライド、又はコンテンツが必ずしも横向き (landscape) もしくは縦向き (portrait) のディスプレイの向きに制限されないバーチャルリアリティのコンテンツが挙げられる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="5"><span>注記</span></div><p class="">特定のディスプレイの向きが必要不可欠となり得る例としては、銀行の小切手、ピアノのアプリケーション、プロジェクターもしくはテレビ向けのスライド、又はコンテンツが必ずしも横向き (landscape) もしくは縦向き (portrait) のディスプレイの向きに制限されないバーチャルリアリティのコンテンツが挙げられる。</p></div>
    					
 </section>
 
-
-                <section class="sc" id="identify-input-purpose">
+            
+            <section class="guideline" id="identify-input-purpose"><div class="header-wrapper"><h4 id="x1-3-5-identify-input-purpose"><bdi class="secno">達成基準 1.3.5</bdi> 入力目的の特定</h4><a class="self-link" href="#identify-input-purpose" aria-label="Permalink for Section 1.3.5"></a></div>
 	
-	<h4 id="x1-3-5-identify-input-purpose"><span class="secno">達成基準 1.3.5 </span>入力目的の特定<span class="permalink"><a href="#identify-input-purpose" aria-label="Permalink for 1.3.5 Identify Input Purpose" title="Permalink for 1.3.5 Identify Input Purpose"><span>§</span></a></span></h4>
+	
 	
 	<div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html">Understanding Identify Input Purpose</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#identify-input-purpose">How to Meet Identify Input Purpose</a></div><p class="conformance-level">(レベル AA)</p>
 	
-	
-	
-	<p>利用者の情報を集める入力フィールドのそれぞれの目的は、次の場合に <a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a> である:</p>
+	<p>利用者の情報を集める入力フィールドのそれぞれの目的は、次の場合に<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-3" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である:</p>
   
   <ul>
     <li>入力フィールドが、<a href="#input-purposes">ユーザインタフェース コンポーネントの入力目的の節</a>で示される目的を提供している、 かつ</li>
@@ -1328,313 +728,268 @@ details.respec-tests-details > li {
   
 </section>
 
-              
-                <section class="sc" id="identify-purpose">
+            
+            <section class="guideline" id="identify-purpose"><div class="header-wrapper"><h4 id="x1-3-6-identify-purpose"><bdi class="secno">達成基準 1.3.6</bdi> 目的の特定</h4><a class="self-link" href="#identify-purpose" aria-label="Permalink for Section 1.3.6"></a></div>
    					
-   <h4 id="x1-3-6-identify-purpose"><span class="secno">達成基準 1.3.6 </span>目的の特定<span class="permalink"><a href="#identify-purpose" aria-label="Permalink for 1.3.6 Identify Purpose" title="Permalink for 1.3.6 Identify Purpose"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/identify-purpose.html">Understanding Identify Purpose</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#identify-purpose">How to Meet Identify Purpose</a></div><p class="conformance-level">(レベル AAA)</p>
    					
-   
-	   					
-  <p>マークアップ言語で実装されたコンテンツでは、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>、アイコン、<a href="#dfn-regions" class="internalDFN" data-link-type="dfn">領域</a>の目的は<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。</p>
+  <p>マークアップ言語で実装されたコンテンツでは、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-1" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>、アイコン、<a href="#dfn-regions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-regions-1" title="コンテンツの知覚可能、プログラムによる解釈が可能なセクション">領域</a>の目的は<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-4" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である。</p>
 </section>
 
-
-          </section>
-
-            <section class="guideline" id="distinguishable">
-                <h3 id="x1-4-distinguishable"><span class="secno">ガイドライン 1.4 </span>判別可能<span class="permalink"><a href="#distinguishable" aria-label="Permalink for 1.4 Distinguishable" title="Permalink for 1.4 Distinguishable"><span>§</span></a></span></h3>
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/distinguishable.html">Understanding Distinguishable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#distinguishable">How to Meet Distinguishable</a></div>
-                <p>コンテンツを、利用者にとって見やすく、聞きやすいものにすること。これには、前景と背景を区別することも含む。</p>
-
-                <section class="sc" id="use-of-color">
+            
+            
+         </section>
+         
+         
+         <section class="guideline" id="distinguishable"><div class="header-wrapper"><h3 id="x1-4-distinguishable"><bdi class="secno">ガイドライン 1.4</bdi> 判別可能</h3><a class="self-link" href="#distinguishable" aria-label="Permalink for Section 1.4"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/distinguishable.html">Understanding Distinguishable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#distinguishable">How to Meet Distinguishable</a></div><p>コンテンツを、利用者にとって見やすく、聞きやすいものにすること。これには、前景と背景を区別することも含む。</p>
+            
+            <section class="guideline" id="use-of-color"><div class="header-wrapper"><h4 id="x1-4-1-use-of-color"><bdi class="secno">達成基準 1.4.1</bdi> 色の使用</h4><a class="self-link" href="#use-of-color" aria-label="Permalink for Section 1.4.1"></a></div>
    
-   <h4 id="x1-4-1-use-of-color"><span class="secno">達成基準 1.4.1 </span>色の使用<span class="permalink"><a href="#use-of-color" aria-label="Permalink for 1.4.1 Use of Color" title="Permalink for 1.4.1 Use of Color"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html">Understanding Use of Color</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#use-of-color">How to Meet Use of Color</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>色が、情報を伝える、動作を示す、反応を促す、又は視覚的な要素を判別するための唯一の視覚的手段になっていない。
-   </p>
+   <p>色が、情報を伝える、動作を示す、反応を促す、又は視覚的な要素を判別するための唯一の視覚的手段になっていない。</p>
    
-   <div class="note" id="issue-container-generatedID-1"><div role="heading" class="note-title marker" id="h-note-1" aria-level="5"><span>注記</span></div><p class="">この達成基準は、特に色の知覚に関するものである。その他の知覚形態については、色やその他の視覚的提示のコーディングへのプログラムによるアクセスも含めて、<a href="#adaptable">ガイドライン 1.3</a> で網羅されている。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-1"><div role="heading" class="note-title marker" id="h-note-1" aria-level="5"><span>注記</span></div><p class="">この達成基準は、特に色の知覚に関するものである。その他の知覚形態については、色やその他の視覚的提示のコーディングへのプログラムによるアクセスも含めて、<a href="#adaptable">ガイドライン 1.3</a> で網羅されている。</p></div>
   
 </section>
 
-
-                <section class="sc" id="audio-control">
+            
+            <section class="guideline" id="audio-control"><div class="header-wrapper"><h4 id="x1-4-2-audio-control"><bdi class="secno">達成基準 1.4.2</bdi> 音声の制御</h4><a class="self-link" href="#audio-control" aria-label="Permalink for Section 1.4.2"></a></div>
    
-   <h4 id="x1-4-2-audio-control"><span class="secno">達成基準 1.4.2 </span>音声の制御<span class="permalink"><a href="#audio-control" aria-label="Permalink for 1.4.2 Audio Control" title="Permalink for 1.4.2 Audio Control"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-control.html">Understanding Audio Control</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#audio-control">How to Meet Audio Control</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>ウェブページ上にある音声が自動的に再生され、3 秒より長く続く場合、その音声を一時停止又は停止する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>、もしくはシステム全体の音量レベルに影響を与えずに音量レベルを調整できるメカニズムが利用できる。
-   </p>
+   <p>ウェブページ上にある音声が自動的に再生され、3 秒より長く続く場合、その音声を一時停止又は停止する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-1" title="結果を得るためのプロセス又は手法。">メカニズム</a>、もしくはシステム全体の音量レベルに影響を与えずに音量レベルを調整できるメカニズムが利用できる。</p>
    
-   <div class="note" id="issue-container-generatedID-2"><div role="heading" class="note-title marker" id="h-note-2" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-2"><div role="heading" class="note-title marker" id="h-note-2" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。</p></div>
    
 </section>
-
-                <section class="sc" id="contrast-minimum">
+            
+            <section class="guideline" id="contrast-minimum"><div class="header-wrapper"><h4 id="x1-4-3-contrast-minimum"><bdi class="secno">達成基準 1.4.3</bdi> コントラスト (最低限)</h4><a class="self-link" href="#contrast-minimum" aria-label="Permalink for Section 1.4.3"></a></div>
    
-   <h4 id="x1-4-3-contrast-minimum"><span class="secno">達成基準 1.4.3 </span>コントラスト (最低限)<span class="permalink"><a href="#contrast-minimum" aria-label="Permalink for 1.4.3 Contrast (Minimum)" title="Permalink for 1.4.3 Contrast (Minimum)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html">Understanding Contrast (Minimum)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum">How to Meet Contrast (Minimum)</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>及び<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>の視覚的提示に、少なくとも 4.5:1 の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn">コントラスト比</a>がある。ただし、次の場合は除く:
-   </p>
+   <p><a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-2" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>及び<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-images-of-text-1" title="特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。">文字画像</a>の視覚的提示に、少なくとも 4.5:1 の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-contrast-ratio-1" title="(L1 + 0.05) / (L2 + 0.05) ここでは、">コントラスト比</a>がある。ただし、次の場合は除く:</p>
    
    <dl>
       
       <dt>大きな文字</dt>
       
-      <dd>
-         
-         <p><a href="#dfn-large-scale" class="internalDFN" data-link-type="dfn">サイズの大きな</a>テキスト及びサイズの大きな文字画像に、少なくとも 3:1 のコントラスト比がある。
-         </p>
+      <dd><p><a href="#dfn-large-scale" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-large-scale-1" title="少なくとも 18 ポイント、又は 14 ポイントの太字。あるいは、中国語、日本語、及び韓国語 (CJK) のフォントは、それと同等の文字サイズ。">サイズの大きな</a>テキスト及びサイズの大きな文字画像に、少なくとも 3:1 のコントラスト比がある。</p>
          
       </dd>
       
-      <dt>付随的</dt>
+      <dt> 付随的</dt>
       
-      <dd>
-         
-         <p>テキスト又は文字画像において、次の場合はコントラストの要件はない。アクティブではない<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の一部である、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn">純粋な装飾</a>である、誰も視覚的に確認できない、又は重要な他の視覚的なコンテンツを含む写真の一部分である。
-         </p>
+      <dd><p>テキスト又は文字画像において、次の場合はコントラストの要件はない。アクティブではない<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-2" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>の一部である、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-pure-decoration-2" title="見栄えのためだけのもので、情報は提供せず、機能性も備えていないもの。">純粋な装飾</a>である、誰も視覚的に確認できない、又は重要な他の視覚的なコンテンツを含む写真の一部分である。</p>
          
       </dd>
       
       <dt>ロゴタイプ</dt>
       
-      <dd>
-         
-         <p>ロゴ又はブランド名の一部である文字には、最低限のコントラストの要件はない。</p>
+      <dd><p>ロゴ又はブランド名の一部である文字には、最低限のコントラストの要件はない。</p>
          
       </dd>
       
    </dl>
    
 </section>
-
-                <section class="sc" id="resize-text">
+            
+            <section class="guideline" id="resize-text"><div class="header-wrapper"><h4 id="x1-4-4-resize-text"><bdi class="secno">達成基準 1.4.4</bdi> テキストのサイズ変更</h4><a class="self-link" href="#resize-text" aria-label="Permalink for Section 1.4.4"></a></div>
    
-   <h4 id="x1-4-4-resize-text"><span class="secno">達成基準 1.4.4 </span>テキストのサイズ変更<span class="permalink"><a href="#resize-text" aria-label="Permalink for 1.4.4 Resize text" title="Permalink for 1.4.4 Resize text"><span>§</span></a></span></h4>
    
-   <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html">Understanding Resize text</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#resize-text">How to Meet Resize text</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-captions" class="internalDFN" data-link-type="dfn">キャプション</a>及び<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>を除き、<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>は、コンテンツ又は機能を損なうことなく、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>なしで 200％ までサイズ変更できる。
-   </p>
+   <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html">Understanding Resize Text</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#resize-text">How to Meet Resize Text</a></div><p class="conformance-level">(レベル AA)</p>
+   
+   <p><a href="#dfn-captions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-captions-3" title="そのメディアのコンテンツを理解するのに必要な、会話及び会話でない音声情報に対する、同期した視覚、及び／又はテキストによる代替。">キャプション</a>及び<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-images-of-text-2" title="特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。">文字画像</a>を除き、<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-3" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>は、コンテンツ又は機能を損なうことなく、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-2" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>なしで 200％ までサイズ変更できる。</p>
    
 </section>
-
-                <section class="sc" id="images-of-text">
+            
+            <section class="guideline" id="images-of-text"><div class="header-wrapper"><h4 id="x1-4-5-images-of-text"><bdi class="secno">達成基準 1.4.5</bdi> 文字画像</h4><a class="self-link" href="#images-of-text" aria-label="Permalink for Section 1.4.5"></a></div>
    
-   <h4 id="x1-4-5-images-of-text"><span class="secno">達成基準 1.4.5 </span>文字画像<span class="permalink"><a href="#images-of-text" aria-label="Permalink for 1.4.5 Images of Text" title="Permalink for 1.4.5 Images of Text"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html">Understanding Images of Text</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#images-of-text">How to Meet Images of Text</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p>使用している技術で意図した視覚的提示が可能である場合、<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>ではなく<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>が情報伝達に用いられている。ただし、次に挙げる場合を除く:
-   </p>
+   <p>使用している技術で意図した視覚的提示が可能である場合、<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-images-of-text-3" title="特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。">文字画像</a>ではなく<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-4" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>が情報伝達に用いられている。ただし、次に挙げる場合を除く:</p>
    
    <dl>
       
       <dt>カスタマイズ可能</dt>
       
-      <dd>
-         
-         <p>文字画像は、利用者の要求に応じた<a href="#dfn-visually-customized" class="internalDFN" data-link-type="dfn">視覚的なカスタマイズ</a>ができる。
-         </p>
+      <dd><p>文字画像は、利用者の要求に応じた<a href="#dfn-visually-customized" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-visually-customized-1" title="フォント、サイズ、色、及び背景を設定できること。">視覚的なカスタマイズ</a>ができる。</p>
          
       </dd>
       
       <dt>必要不可欠</dt>
       
-      <dd>
-         
-         <p>テキストの特定の提示が、伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である。
-         </p>
+      <dd><p>テキストの特定の提示が、伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-2" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>である。</p>
          
       </dd>
       
    </dl>
    
-   <div class="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-3" aria-level="5"><span>注記</span></div><p class="">ロゴタイプ (ロゴ又はブランド名の一部である文字) は必要不可欠なものであると考えられる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-3" aria-level="5"><span>注記</span></div><p class="">ロゴタイプ (ロゴ又はブランド名の一部である文字) は必要不可欠なものであると考えられる。</p></div>
    
 </section>
-
-                <section class="sc" id="contrast-enhanced">
+            
+            <section class="guideline" id="contrast-enhanced"><div class="header-wrapper"><h4 id="x1-4-6-contrast-enhanced"><bdi class="secno">達成基準 1.4.6</bdi> コントラスト (高度)</h4><a class="self-link" href="#contrast-enhanced" aria-label="Permalink for Section 1.4.6"></a></div>
    
-   <h4 id="x1-4-6-contrast-enhanced"><span class="secno">達成基準 1.4.6</span> コントラスト (高度)<span class="permalink"><a href="#contrast-enhanced" aria-label="Permalink for 1.4.6 Contrast (Enhanced)" title="Permalink for 1.4.6 Contrast (Enhanced)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html">Understanding Contrast (Enhanced)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#contrast-enhanced">How to Meet Contrast (Enhanced)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>及び<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>の視覚的提示に、少なくとも 7:1 の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn">コントラスト比</a>がある。ただし、次の場合は除く:
-   </p>
+   <p><a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-5" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>及び<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-images-of-text-4" title="特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。">文字画像</a>の視覚的提示に、少なくとも 7:1 の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-contrast-ratio-2" title="(L1 + 0.05) / (L2 + 0.05) ここでは、">コントラスト比</a>がある。ただし、次の場合は除く:</p>
    
    <dl>
       
       <dt>大きな文字</dt>
       
-      <dd>
-         
-         <p><a href="#dfn-large-scale" class="internalDFN" data-link-type="dfn">サイズの大きな</a>テキスト及びサイズの大きな文字画像に、少なくとも 4.5:1 のコントラスト比がある。
-         </p>
+      <dd><p><a href="#dfn-large-scale" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-large-scale-2" title="少なくとも 18 ポイント、又は 14 ポイントの太字。あるいは、中国語、日本語、及び韓国語 (CJK) のフォントは、それと同等の文字サイズ。">サイズの大きな</a>テキスト及びサイズの大きな文字画像に、少なくとも 4.5:1 のコントラスト比がある。</p>
          
       </dd>
       
-      <dt>付随的</dt>
+      <dt> 付随的</dt>
       
-      <dd>
-         
-         <p>テキスト又は文字画像において、次の場合はコントラストの要件はない。アクティブではない<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の一部である、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn">純粋な装飾</a>である、誰も視覚的に確認できない、又は重要な他の視覚的なコンテンツを含む写真の一部分である。
-         </p>
+      <dd><p>テキスト又は文字画像において、次の場合はコントラストの要件はない。アクティブではない<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-3" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>の一部である、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-pure-decoration-3" title="見栄えのためだけのもので、情報は提供せず、機能性も備えていないもの。">純粋な装飾</a>である、誰も視覚的に確認できない、又は重要な他の視覚的なコンテンツを含む写真の一部分である。</p>
          
       </dd>
       
       <dt>ロゴタイプ</dt>
       
-      <dd>
-         
-         <p>ロゴ又はブランド名の一部である文字には、最低限のコントラストの要件はない。</p>
+      <dd><p>ロゴ又はブランド名の一部である文字には、最低限のコントラストの要件はない。</p>
          
       </dd>
       
    </dl>
    
 </section>
-
-                <section class="sc" id="low-or-no-background-audio">
+            
+            <section class="guideline" id="low-or-no-background-audio"><div class="header-wrapper"><h4 id="x1-4-7-low-or-no-background-audio"><bdi class="secno">達成基準 1.4.7</bdi> 小さな背景音、又は背景音なし</h4><a class="self-link" href="#low-or-no-background-audio" aria-label="Permalink for Section 1.4.7"></a></div>
    
-   <h4 id="x1-4-7-low-or-no-background-audio"><span class="secno">達成基準 1.4.7 </span>小さな背景音、又は背景音なし<span class="permalink"><a href="#low-or-no-background-audio" aria-label="Permalink for 1.4.7 Low or No Background Audio" title="Permalink for 1.4.7 Low or No Background Audio"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio.html">Understanding Low or No Background Audio</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#low-or-no-background-audio">How to Meet Low or No Background Audio</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn">収録済</a>の<a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn">音声しか</a>含まないコンテンツで、(1) 前景に主として発話を含み、(2) 音声 <a href="#dfn-captcha" class="internalDFN" data-link-type="dfn">CAPTCHA</a> 又は音声ロゴではなく、かつ、(3) 例えば、歌やラップなどのように、主として音楽表現を意図した発声ではないものについては、次に挙げる事項のうち、少なくとも一つを満たしている:
-   </p>
+   <p><a href="#dfn-prerecorded" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-prerecorded-8" title="ライブではない情報。">収録済</a>の<a href="#dfn-audio-only" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-only-3" title="a time-based presentation that contains only audio (no video and no interaction)">音声しか</a>含まないコンテンツで、(1) 前景に主として発話を含み、(2) 音声 <a href="#dfn-captcha" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-captcha-2" title="コンピュータと人間とを判別する完全自動化されたチューリングテスト (Completely Automated Public Turing test to tell Computers and Humans Apart) の頭文字語。">CAPTCHA</a> 又は音声ロゴではなく、かつ、(3) 例えば、歌やラップなどのように、主として音楽表現を意図した発声ではないものについては、次に挙げる事項のうち、少なくとも一つを満たしている:</p>
    
    <dl>
       
       <dt>背景音なし</dt>
       
-      <dd>
-         
-         <p>音声は背景音を含まない。</p>
+      <dd><p>音声は背景音を含まない。</p>
          
       </dd>
       
       <dt>消音</dt>
       
-      <dd>
-         
-         <p>背景音を消すことができる。</p>
+      <dd><p>背景音を消すことができる。</p>
          
       </dd>
       
       <dt>20 デシベル</dt>
       
-      <dd>
+      <dd><p>背景音は、前景にある発話のコンテンツより少なくとも 20 デシベルは低い。ただし、継続時間が 2 秒以内で発生頻度が低い背景音は除く。</p>
          
-         <p>背景音は、前景にある発話のコンテンツより少なくとも 20 デシベルは低い。ただし、継続時間が 2 秒以内で発生頻度が低い背景音は除く。
-         </p>
-         
-         <div class="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-4" aria-level="5"><span>注記</span></div><p class="">デシベルの定義によれば、この要件を満たす背景音は、前景にある発話のコンテンツの約 4 分の 1 の大きさになる。
-         </p></div>
+         <div class="note" role="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-4" aria-level="5"><span>注記</span></div><p class="">デシベルの定義によれば、この要件を満たす背景音は、前景にある発話のコンテンツの約 4 分の 1 の大きさになる。</p></div>
          
       </dd>
       
    </dl>
    
 </section>
-
-                <section class="sc" id="visual-presentation">
+            
+            <section class="guideline" id="visual-presentation"><div class="header-wrapper"><h4 id="x1-4-8-visual-presentation"><bdi class="secno">達成基準 1.4.8</bdi> 視覚的提示</h4><a class="self-link" href="#visual-presentation" aria-label="Permalink for Section 1.4.8"></a></div>
    
-   <h4 id="x1-4-8-visual-presentation"><span class="secno">達成基準 1.4.8 </span>視覚的提示<span class="permalink"><a href="#visual-presentation" aria-label="Permalink for 1.4.8 Visual Presentation" title="Permalink for 1.4.8 Visual Presentation"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html">Understanding Visual Presentation</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#visual-presentation">How to Meet Visual Presentation</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-blocks-of-text" class="internalDFN" data-link-type="dfn">テキストブロック</a>の視覚的提示において、次を実現する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる:
-   </p>
+   <p><a href="#dfn-blocks-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-blocks-of-text-1" title="一文よりも長いテキスト。">テキストブロック</a>の視覚的提示において、次を実現する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-2" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる:</p>
    <ul>
      <li>利用者が、前景色と背景色を選択できる。</li>   
      <li>幅が 80 字を越えない (全角文字の場合は、40 字)。</li>   
      <li>テキストが、均等割り付けされていない (両端揃えではない)。</li>   
      <li>段落中の行送りは、少なくとも 1.5 文字分ある。そして、段落の間隔は、その行送りの少なくとも 1.5 倍以上ある。</li>   
-     <li>テキストは、支援技術なしで 200％までサイズ変更でき、利用者が<a href="#dfn-on-a-full-screen-window" class="internalDFN" data-link-type="dfn">全画面表示</a>にしたウィンドウで 1 行のテキストを読むときに横スクロールする必要がない。</li>   
+     <li>テキストは、支援技術なしで 200％までサイズ変更でき、利用者が<a href="#dfn-on-a-full-screen-window" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-on-a-full-screen-window-1" title="最も普及したサイズのデスクトップやラップトップのディスプレイで、ビューポートを最大化した状態。">全画面表示</a>にしたウィンドウで 1 行のテキストを読むときに横スクロールする必要がない。</li>   
   </ul>
   
 </section>
 
-
-                <section class="sc" id="images-of-text-no-exception">
+            
+            <section class="guideline" id="images-of-text-no-exception"><div class="header-wrapper"><h4 id="x1-4-9-images-of-text-no-exception"><bdi class="secno">達成基準 1.4.9</bdi> 文字画像 (例外なし)</h4><a class="self-link" href="#images-of-text-no-exception" aria-label="Permalink for Section 1.4.9"></a></div>
    
-   <h4 id="x1-4-9-images-of-text-no-exception"><span class="secno">達成基準 1.4.9 </span>文字画像 (例外なし)<span class="permalink"><a href="#images-of-text-no-exception" aria-label="Permalink for 1.4.9 Images of Text (No Exception)" title="Permalink for 1.4.9 Images of Text (No Exception)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/images-of-text-no-exception.html">Understanding Images of Text (No Exception)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#images-of-text-no-exception">How to Meet Images of Text (No Exception)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>は、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn">純粋な装飾</a>に用いられているか、<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>の特定の提示が伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である場合に用いられている。
-   </p>
+   <p><a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-images-of-text-5" title="特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。">文字画像</a>は、<a href="#dfn-pure-decoration" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-pure-decoration-4" title="見栄えのためだけのもので、情報は提供せず、機能性も備えていないもの。">純粋な装飾</a>に用いられているか、<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-6" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>の特定の提示が伝えようとする情報にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-3" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>である場合に用いられている。</p>
    
-   <div class="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-5" aria-level="5"><span>注記</span></div><p class="">ロゴタイプ (ロゴ又はブランド名の一部である文字) は必要不可欠なものであると考えられる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-5" aria-level="5"><span>注記</span></div><p class="">ロゴタイプ (ロゴ又はブランド名の一部である文字) は必要不可欠なものであると考えられる。</p></div>
    
 </section>
-
-                <section class="sc" id="reflow">
+            
+            <section class="guideline" id="reflow"><div class="header-wrapper"><h4 id="x1-4-10-reflow"><bdi class="secno">達成基準 1.4.10</bdi> リフロー</h4><a class="self-link" href="#reflow" aria-label="Permalink for Section 1.4.10"></a></div>
    					
-   <h4 id="x1-4-10-reflow"><span class="secno">達成基準 1.4.10 </span>リフロー<span class="permalink"><a href="#reflow" aria-label="Permalink for 1.4.10 Reflow" title="Permalink for 1.4.10 Reflow"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/reflow.html">Understanding Reflow</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#reflow">How to Meet Reflow</a></div><p class="conformance-level">(レベル AA)</p>
    					
-   
-   					
    <p>コンテンツは、情報又は機能を損なうことなく、かつ、以下において 2 次元スクロールを必要とせずに提示できる:</p>
    <ul>
-       <li>320 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn">CSS ピクセル</a>に相当する幅の縦スクロールのコンテンツ。</li>
-       <li>256 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn">CSS ピクセル</a>に相当する高さの横スクロールのコンテンツ。</li>
+       <li>320 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-css-pixels-1" title="約 0.0213 度の視野角。">CSS ピクセル</a>に相当する幅の縦スクロールのコンテンツ。</li>
+       <li>256 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-css-pixels-2" title="約 0.0213 度の視野角。">CSS ピクセル</a>に相当する高さの横スクロールのコンテンツ。</li>
    </ul>
    <p>利用や意味の理解に 2 次元のレイアウトが必須である一部のコンテンツを除く。</p>
   
-   <div class="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>注記</span></div><p class="">320 CSS ピクセルは、400% ズーム時の開始ビューポート幅 1280 CSS ピクセルに相当する。横スクロールになるように設計されたウェブコンテンツ (例えば、縦書きのテキスト) の場合、256 CSS ピクセルは、400% ズーム時の開始ビューポート高さ 1024 CSS ピクセルに相当する。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-6" aria-level="5"><span>注記</span></div><p class="">320 CSS ピクセルは、400% ズーム時の開始ビューポート幅 1280 CSS ピクセルに相当する。横スクロールになるように設計されたウェブコンテンツ (例えば、縦書きのテキスト) の場合、256 CSS ピクセルは、400% ズーム時の開始ビューポート高さ 1024 CSS ピクセルに相当する。</p></div>
    
-   <div class="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>注記</span></div><p class="">2 次元のレイアウトを必要とするコンテンツの例としては、理解のために必要な画像 (地図、図解など)、映像、ゲーム、プレゼンテーション、データテーブル (個々のセルではない)、及びコンテンツを操作している間にツールバーを表示しておく必要のあるインタフェースが挙げられる。コンテンツのそのような部分には、2 次元スクロールを提供することが許容される。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>注記</span></div><p class="">2 次元のレイアウトを必要とするコンテンツの例としては、理解のために必要な画像 (地図、図解など)、映像、ゲーム、プレゼンテーション、データテーブル (個々のセルではない)、及びコンテンツを操作している間にツールバーを表示しておく必要のあるインタフェースが挙げられる。コンテンツのそのような部分には、2 次元スクロールを提供することが許容される。</p></div>
    				
 </section>
 
-
-                <section class="sc" id="non-text-contrast">
-   					
-   <h4 id="x1-4-11-non-text-contrast"><span class="secno">達成基準 1.4.11 </span>非テキストのコントラスト<span class="permalink"><a href="#non-text-contrast" aria-label="Permalink for 1.4.11 Non-text Contrast" title="Permalink for 1.4.11 Non-text Contrast"><span>§</span></a></span></h4>
-   					
-   <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">Understanding Non-text Contrast</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#non-text-contrast">How to Meet Non-text Contrast</a></div><p class="conformance-level">(レベル AA)</p>
+            
+            <section class="guideline" id="non-text-contrast"><div class="header-wrapper"><h4 id="x1-4-11-non-text-contrast"><bdi class="secno">達成基準 1.4.11</bdi> 非テキストのコントラスト</h4><a class="self-link" href="#non-text-contrast" aria-label="Permalink for Section 1.4.11"></a></div>
    					
    
    					
-   <p>以下の視覚的<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>には、隣接した色との間で少なくとも 3:1 の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn">コントラスト比</a>がある。</p>
+   <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">Understanding Non-text Contrast</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#non-text-contrast">How to Meet Non-text Contrast</a></div><p class="conformance-level">(レベル AA)</p>
+   					
+   <p>以下の視覚的<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-presentation-2" title="rendering of the content in a form to be perceived by users">提示</a>には、隣接した色との間で少なくとも 3:1 の<a href="#dfn-contrast-ratio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-contrast-ratio-3" title="(L1 + 0.05) / (L2 + 0.05) ここでは、">コントラスト比</a>がある。</p>
    					
    <dl>
       						
-      <dt>ユーザインタフェース コンポーネント</dt>
+      <dt>ユーザインタフェース コンポーネント </dt>
       						
-     <dd><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>及び<a href="#dfn-states" class="internalDFN" data-link-type="dfn">状態 (state)</a> を特定するのに必要な視覚的な情報。ただし、アクティブではないユーザインタフェース コンポーネントや、そのコンポーネントの見た目がユーザエージェントによって提示されていてコンテンツ制作者が変更していない場合は除く。</dd>
+     <dd><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-4" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>及び<a href="#dfn-states" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-states-1" title="利用者のアクション又は自動プロセスに応答して変化し得るユーザインタフェースコンポーネントの特性を表現する動的プロパティ。">状態 (state)</a> を特定するのに必要な視覚的な情報。ただし、アクティブではないユーザインタフェース コンポーネントや、そのコンポーネントの見た目がユーザエージェントによって提示されていてコンテンツ制作者が変更していない場合は除く。</dd>
       						
-      <dt>グラフィカルオブジェクト</dt>
+      <dt>グラフィカルオブジェクト </dt>
       						
-      <dd>コンテンツを理解するのに必要なグラフィック部分。ただし、そのグラフィック特有の提示が、情報を伝えるうえで<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合は除く。</dd>
+      <dd>コンテンツを理解するのに必要なグラフィック部分。ただし、そのグラフィック特有の提示が、情報を伝えるうえで<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-4" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>な場合は除く。</dd>
       						
    </dl>
   
 </section>
 
-
-                 <section class="sc" id="text-spacing">
+            
+             <section class="guideline" id="text-spacing"><div class="header-wrapper"><h4 id="x1-4-12-text-spacing"><bdi class="secno">達成基準 1.4.12</bdi> テキストの間隔</h4><a class="self-link" href="#text-spacing" aria-label="Permalink for Section 1.4.12"></a></div>
    					
-   <h4 id="x1-4-12-text-spacing"><span class="secno">達成基準 1.4.12 </span>テキストの間隔<span class="permalink"><a href="#text-spacing" aria-label="Permalink for 1.4.12 Text Spacing" title="Permalink for 1.4.12 Text Spacing"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html">Understanding Text Spacing</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#text-spacing">How to Meet Text Spacing</a></div><p class="conformance-level">(レベル AA)</p>
    					
-   
-	
-   <p>以下の<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a><a href="#dfn-style-properties" class="internalDFN" data-link-type="dfn">スタイルプロパティ</a>をサポートするマークアップ言語を用いて実装されているコンテンツにおいては、以下をすべて設定し、かつ他のスタイルプロパティを変更しないことによって、コンテンツ又は機能の損失が生じない:</p>
+   <p>以下の<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-7" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a><a href="#dfn-style-properties" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-style-properties-1" title="ユーザエージェントによってコンテンツ要素が (画面、音声スピーカー、点字ディスプレイなどを介して) レンダリングされるとき、その値の提示 (フォント、色、サイズ、位置、パディング、音量、合成音声の韻律など) を定義するプロパティ。">スタイルプロパティ</a>をサポートするマークアップ言語を用いて実装されているコンテンツにおいては、以下をすべて設定し、かつ他のスタイルプロパティを変更しないことによって、コンテンツ又は機能の損失が生じない:</p>
    
    <ul>
      <li>行の間隔 (行送り) をフォントサイズの少なくとも 1.5 倍に設定する</li>
@@ -1647,128 +1002,127 @@ details.respec-tests-details > li {
  
 </section>
 
-
-                    <section class="sc" id="content-on-hover-or-focus">
+            
+                <section class="guideline" id="content-on-hover-or-focus"><div class="header-wrapper"><h4 id="x1-4-13-content-on-hover-or-focus"><bdi class="secno">達成基準 1.4.13</bdi> ホバー又はフォーカスで表示されるコンテンツ</h4><a class="self-link" href="#content-on-hover-or-focus" aria-label="Permalink for Section 1.4.13"></a></div>
    					
-   <h4 id="x1-4-13-content-on-hover-or-focus"><span class="secno">達成基準 1.4.13 </span>ホバー又はフォーカスで表示されるコンテンツ<span class="permalink"><a href="#content-on-hover-or-focus" aria-label="Permalink for 1.4.13 Content on Hover or Focus" title="Permalink for 1.4.13 Content on Hover or Focus"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html">Understanding Content on Hover or Focus</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#content-on-hover-or-focus">How to Meet Content on Hover or Focus</a></div><p class="conformance-level">(レベル AA)</p>
        
-   
-   					
     	<p>ポインタホバー又はキーボードフォーカスを受け取ってから外すことで、追加コンテンツを表示させてから非表示にさせる場合は、以下の要件を全て満たす:</p>
 
   <dl>
 
-    <dt>非表示にすることができる</dt>
-    <dd>ポインタホバー又はキーボードフォーカスを動かさずに追加コンテンツを非表示にする<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が存在する。ただし、追加コンテンツが<a href="#dfn-input-error" class="internalDFN" data-link-type="dfn">入力エラー</a>を伝える場合や、他のコンテンツを不明瞭にしたり置き換えたりしない場合は除く。</dd>
+    <dt>非表示にすることができる </dt>
+    <dd>ポインタホバー又はキーボードフォーカスを動かさずに追加コンテンツを非表示にする<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-3" title="結果を得るためのプロセス又は手法。">メカニズム</a>が存在する。ただし、追加コンテンツが<a href="#dfn-input-error" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-input-error-1" title="利用者が入力した情報で、受け付けられないもの。">入力エラー</a>を伝える場合や、他のコンテンツを不明瞭にしたり置き換えたりしない場合は除く。</dd>
 
-    <dt>ホバーすることができる</dt>
+    <dt>ホバーすることができる </dt>
    <dd>ポインタホバーによって追加コンテンツを表示させることができる場合、その追加コンテンツを消すことなく、ポインタを追加コンテンツ上で動かすことができる。</dd>
 
-    <dt>表示が継続される</dt>
+    <dt>表示が継続される </dt>
     <dd>ホバーやフォーカスが解除される、利用者が非表示にする、又はその情報が有効でなくなるまでは、追加コンテンツが表示され続ける。</dd>
 
   </dl>
     	
     	<p>例外: 追加コンテンツの視覚的提示がユーザエージェントによって制御されていて、かつコンテンツ制作者が変更していない場合は例外とする。</p>
 
-    	<div class="note" id="issue-container-generatedID-8"><div role="heading" class="note-title marker" id="h-note-8" aria-level="5"><span>注記</span></div><p class="">ユーザエージェントによって制御されている追加コンテンツの例としては、HTML の <a href="https://www.w3.org/TR/html/dom.html#the-title-attribute"><code>title</code> 属性</a>を用いて作られているブラウザのツールチップが挙げられる。</p></div>
-     <div class="note" id="issue-container-generatedID-9"><div role="heading" class="note-title marker" id="h-note-9" aria-level="5"><span>注記</span></div><p class="">ホバー時やフォーカス時に表示されるカスタムツールチップ、サブメニュー、他の非モーダルポップアップは、この達成基準の適用対象となる「追加コンテンツ」の例である。</p></div><!--OddPage-->
+    	<div class="note" role="note" id="issue-container-generatedID-8"><div role="heading" class="note-title marker" id="h-note-8" aria-level="5"><span>注記</span></div><p class="">ユーザエージェントによって制御されている追加コンテンツの例としては、HTML の <a href="https://www.w3.org/TR/html/dom.html#the-title-attribute"><code>title</code> 属性</a>を用いて作られているブラウザのツールチップが挙げられる。</p></div>
+     <div class="note" role="note" id="issue-container-generatedID-9"><div role="heading" class="note-title marker" id="h-note-9" aria-level="5"><span>注記</span></div><p class="">ホバー時やフォーカス時に表示されるカスタムツールチップ、サブメニュー、他の非モーダルポップアップは、この達成基準の適用対象となる「追加コンテンツ」の例である。</p></div>
 
   </section>
 
-            </section>
-
-        </section>
-        <section class="principle" id="operable">
-            <h2 id="x2-operable"><span class="secno">2. </span>操作可能 <span class="permalink"><a href="#operable" aria-label="Permalink for 2. Operable " title="Permalink for 2. Operable "><span>§</span></a></span></h2>
-            <p>ユーザインタフェース コンポーネント及びナビゲーションは操作可能でなければならない。</p>
-
-            <section class="guideline" id="keyboard-accessible">
-                <h3 id="x2-1-keyboard-accessible"><span class="secno">ガイドライン 2.1 </span>キーボード操作可能<span class="permalink"><a href="#keyboard-accessible" aria-label="Permalink for 2.1 Keyboard Accessible" title="Permalink for 2.1 Keyboard Accessible"><span>§</span></a></span></h3>
-
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html">Understanding Keyboard Accessible</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard-accessible">How to Meet Keyboard Accessible</a></div>
-                <p>すべての機能をキーボードから利用できるようにすること。</p>
-
-                <section class="sc" id="keyboard">
+            
+            
+         </section>
+         
+         
+      </section>
+      
+      <section class="principle" id="operable"><div class="header-wrapper"><h2 id="x2-operable"><bdi class="secno">2. </bdi>操作可能</h2><a class="self-link" href="#operable" aria-label="Permalink for Section 2."></a></div>
+         
+         
+         
+         <p>ユーザインタフェース コンポーネント及びナビゲーションは操作可能でなければならない。</p>
+         
+         
+         <section class="guideline" id="keyboard-accessible"><div class="header-wrapper"><h3 id="x2-1-keyboard-accessible"><bdi class="secno">ガイドライン 2.1</bdi> キーボード操作可能</h3><a class="self-link" href="#keyboard-accessible" aria-label="Permalink for Section 2.1"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible.html">Understanding Keyboard Accessible</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard-accessible">How to Meet Keyboard Accessible</a></div><p>すべての機能をキーボードから利用できるようにすること。</p>
+            
+            <section class="guideline" id="keyboard"><div class="header-wrapper"><h4 id="x2-1-1-keyboard"><bdi class="secno">達成基準 2.1.1</bdi> キーボード</h4><a class="self-link" href="#keyboard" aria-label="Permalink for Section 2.1.1"></a></div>
    
-   <h4 id="x2-1-1-keyboard"><span class="secno">達成基準 2.1.1 </span>キーボード<span class="permalink"><a href="#keyboard" aria-label="Permalink for 2.1.1 Keyboard" title="Permalink for 2.1.1 Keyboard"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html">Understanding Keyboard</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard">How to Meet Keyboard</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>コンテンツのすべての<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>は、個々のキーストロークに特定のタイミングを要することなく、<a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn">キーボードインタフェース</a>を通じて操作可能である。ただし、その根本的な機能が利用者の動作による終点だけではない軌跡に依存する入力を必要とする場合は除く。
-   </p>
+   <p>コンテンツのすべての<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-functionality-1" title="利用者の操作により実現可能なプロセス及び結果。">機能</a>は、個々のキーストロークに特定のタイミングを要することなく、<a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-keyboard-interface-1" title="キーストローク入力を取得するためにソフトウェアが用いるインタフェース。">キーボードインタフェース</a>を通じて操作可能である。ただし、その根本的な機能が利用者の動作による終点だけではない軌跡に依存する入力を必要とする場合は除く。</p>
    
-   <div class="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記</span></div><p class="">上記の例外は、根本的な機能に関するものであり、入力手法に関するものではない。例えば、テキスト入力に手書き入力を用いるのであれば、その入力手法 (手書き) は利用者の動作による軌跡に依存した入力を必要とするが、その根本的な機能 (テキスト入力) は利用者の動作による軌跡に依存した入力を必要とするものではない。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-10" aria-level="5"><span>注記</span></div><p class="">上記の例外は、根本的な機能に関するものであり、入力手法に関するものではない。例えば、テキスト入力に手書き入力を用いるのであれば、その入力手法 (手書き) は利用者の動作による軌跡に依存した入力を必要とするが、その根本的な機能 (テキスト入力) は利用者の動作による軌跡に依存した入力を必要とするものではない。</p></div>
    
-   <div class="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記</span></div><p class="">これは、キーボード操作に加えて、マウス入力、又はその他の入力手段を提供することを禁ずるものでも妨げるものでもない。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-11" aria-level="5"><span>注記</span></div><p class="">これは、キーボード操作に加えて、マウス入力、又はその他の入力手段を提供することを禁ずるものでも妨げるものでもない。</p></div>
    
 </section>
-
-                <section class="sc" id="no-keyboard-trap">
+            
+            <section class="guideline" id="no-keyboard-trap"><div class="header-wrapper"><h4 id="x2-1-2-no-keyboard-trap"><bdi class="secno">達成基準 2.1.2</bdi> キーボードトラップなし</h4><a class="self-link" href="#no-keyboard-trap" aria-label="Permalink for Section 2.1.2"></a></div>
    
-   <h4 id="x2-1-2-no-keyboard-trap"><span class="secno">達成基準 2.1.2 </span>キーボードトラップなし<span class="permalink"><a href="#no-keyboard-trap" aria-label="Permalink for 2.1.2 No Keyboard Trap" title="Permalink for 2.1.2 No Keyboard Trap"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html">Understanding No Keyboard Trap</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#no-keyboard-trap">How to Meet No Keyboard Trap</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn">キーボードインタフェース</a>を用いてキーボードフォーカスをそのウェブページのあるコンポーネントに移動できる場合、キーボードインタフェースだけを用いてそのコンポーネントからフォーカスを外すことが可能である。さらに、修飾キーを伴わない矢印キー、Tab キー、又はフォーカスを外すその他の標準的な方法でフォーカスを外せない場合は、フォーカスを外す方法が利用者に通知される。
-   </p>
+   <p><a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-keyboard-interface-2" title="キーストローク入力を取得するためにソフトウェアが用いるインタフェース。">キーボードインタフェース</a>を用いてキーボードフォーカスをそのウェブページのあるコンポーネントに移動できる場合、キーボードインタフェースだけを用いてそのコンポーネントからフォーカスを外すことが可能である。さらに、修飾キーを伴わない矢印キー、Tab キー、又はフォーカスを外すその他の標準的な方法でフォーカスを外せない場合は、フォーカスを外す方法が利用者に通知される。</p>
    
-   <div class="note" id="issue-container-generatedID-12"><div role="heading" class="note-title marker" id="h-note-12" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-12"><div role="heading" class="note-title marker" id="h-note-12" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。</p></div>
    
 </section>
-
-                <section class="sc" id="keyboard-no-exception">
+            
+            <section class="guideline" id="keyboard-no-exception"><div class="header-wrapper"><h4 id="x2-1-3-keyboard-no-exception"><bdi class="secno">達成基準 2.1.3</bdi> キーボード (例外なし)</h4><a class="self-link" href="#keyboard-no-exception" aria-label="Permalink for Section 2.1.3"></a></div>
    
-   <h4 id="x2-1-3-keyboard-no-exception"><span class="secno">達成基準 2.1.3 </span>キーボード (例外なし)<span class="permalink"><a href="#keyboard-no-exception" aria-label="Permalink for 2.1.3 Keyboard (No Exception)" title="Permalink for 2.1.3 Keyboard (No Exception)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard-no-exception.html">Understanding Keyboard (No Exception)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#keyboard-no-exception">How to Meet Keyboard (No Exception)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>コンテンツのすべての<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>は、個々のキーストロークに特定のタイミングを要することなく、<a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn">キーボードインタフェース</a>を通じて操作可能である。
-   </p>
+   <p>コンテンツのすべての<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-functionality-2" title="利用者の操作により実現可能なプロセス及び結果。">機能</a>は、個々のキーストロークに特定のタイミングを要することなく、<a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-keyboard-interface-3" title="キーストローク入力を取得するためにソフトウェアが用いるインタフェース。">キーボードインタフェース</a>を通じて操作可能である。</p>
    
 </section>
-              
-                <section class="sc" id="character-key-shortcuts">
+            
+            <section class="guideline" id="character-key-shortcuts"><div class="header-wrapper"><h4 id="x2-1-4-character-key-shortcuts"><bdi class="secno">達成基準 2.1.4</bdi> 文字キーのショートカット</h4><a class="self-link" href="#character-key-shortcuts" aria-label="Permalink for Section 2.1.4"></a></div>
    					
-   <h4 id="x2-1-4-character-key-shortcuts"><span class="secno">達成基準 2.1.4 </span>文字キーのショートカット<span class="permalink"><a href="#character-key-shortcuts" aria-label="Permalink for 2.1.4 Character Key Shortcuts" title="Permalink for 2.1.4 Character Key Shortcuts"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html">Understanding Character Key Shortcuts</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#character-key-shortcuts">How to Meet Character Key Shortcuts</a></div><p class="conformance-level">(レベル A)</p>
    					
-   
-	
-  <p>文字 (大文字と小文字を含む)、句読点、数字、又は記号のみを使用した<a href="#dfn-keyboard-shortcuts" class="internalDFN" data-link-type="dfn">キーボードショートカット</a>がコンテンツに実装されている場合、少なくとも次のいずれかを満たしている:</p>
+  <p>文字 (大文字と小文字を含む)、句読点、数字、又は記号のみを使用した<a href="#dfn-keyboard-shortcuts" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-keyboard-shortcuts-1" title="一つ以上のキーを押すことによる、動作のトリガーの代替手段">キーボードショートカット</a>がコンテンツに実装されている場合、少なくとも次のいずれかを満たしている:</p>
 
   <dl>
    
    <dt>解除</dt>
-    <dd>ショートカットを解除する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる</dd>
+    <dd>ショートカットを解除する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-4" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる </dd>
       						
    <dt>再割当て</dt>
-     <dd>一つ以上のキーボードの非印字キー (例えば Ctrl、Alt) を含むようにショートカットを再割当てするメカニズムが利用できる</dd>
+     <dd>一つ以上のキーボードの非印字キー (例えば Ctrl、Alt) を含むようにショートカットを再割当てするメカニズムが利用できる </dd>
 
     <dt>フォーカス中にのみ有効化</dt>
-    <dd><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>のキーボードショートカットは、そのコンポーネントがフォーカスをもっているときのみ有効になる。</dd>
+    <dd><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-5" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>のキーボードショートカットは、そのコンポーネントがフォーカスをもっているときのみ有効になる。</dd>
     
   </dl>  
 </section>
 
-                
-            </section>
-
-            <section class="guideline" id="enough-time">
-                <h3 id="x2-2-enough-time"><span class="secno">ガイドライン 2.2 </span>十分な時間<span class="permalink"><a href="#enough-time" aria-label="Permalink for 2.2 Enough Time" title="Permalink for 2.2 Enough Time"><span>§</span></a></span></h3>
-
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/enough-time.html">Understanding Enough Time</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#enough-time">How to Meet Enough Time</a></div>
-                <p>利用者がコンテンツを読み、使用するために十分な時間を提供すること。</p>
-
-                <section class="sc" id="timing-adjustable">
+            
+            
+         </section>
+         
+         
+         <section class="guideline" id="enough-time"><div class="header-wrapper"><h3 id="x2-2-enough-time"><bdi class="secno">ガイドライン 2.2</bdi> 十分な時間</h3><a class="self-link" href="#enough-time" aria-label="Permalink for Section 2.2"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/enough-time.html">Understanding Enough Time</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#enough-time">How to Meet Enough Time</a></div><p>利用者がコンテンツを読み、使用するために十分な時間を提供すること。</p>
+            
+            <section class="guideline" id="timing-adjustable"><div class="header-wrapper"><h4 id="x2-2-1-timing-adjustable"><bdi class="secno">達成基準 2.2.1</bdi> タイミング調整可能</h4><a class="self-link" href="#timing-adjustable" aria-label="Permalink for Section 2.2.1"></a></div>
    
-   <h4 id="x2-2-1-timing-adjustable"><span class="secno">達成基準 2.2.1 </span>タイミング調整可能<span class="permalink"><a href="#timing-adjustable" aria-label="Permalink for 2.2.1 Timing Adjustable" title="Permalink for 2.2.1 Timing Adjustable"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html">Understanding Timing Adjustable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#timing-adjustable">How to Meet Timing Adjustable</a></div><p class="conformance-level">(レベル A)</p>
    
@@ -1778,973 +1132,1016 @@ details.respec-tests-details > li {
       
       <dt>解除</dt>
       
-      <dd>
-         
-         <p>制限時間があるコンテンツを利用する前に、利用者がその制限時間を解除することができる。又は、</p>
+      <dd><p>制限時間があるコンテンツを利用する前に、利用者がその制限時間を解除することができる。又は、</p>
          
       </dd>
       
       <dt>調整</dt>
       
-      <dd>
-         
-         <p>制限時間があるコンテンツを利用する前に、利用者が少なくともデフォルト設定の 10 倍を超える、大幅な制限時間の調整をすることができる。又は、
-         </p>
+      <dd><p>制限時間があるコンテンツを利用する前に、利用者が少なくともデフォルト設定の 10 倍を超える、大幅な制限時間の調整をすることができる。又は、</p>
          
       </dd>
       
       <dt>延長</dt>
       
-      <dd>
-         
-         <p>時間切れになる前に利用者に警告し、かつ少なくとも 20 秒間の猶予をもって、例えば「スペースキーを押す」などの簡単な操作により、利用者が制限時間を少なくとも 10 倍以上延長することができる。又は、
-         </p>
+      <dd><p>時間切れになる前に利用者に警告し、かつ少なくとも 20 秒間の猶予をもって、例えば「スペースキーを押す」などの簡単な操作により、利用者が制限時間を少なくとも 10 倍以上延長することができる。又は、</p>
          
       </dd>
       
       <dt>リアルタイムの例外</dt>
       
-      <dd>
-         
-         <p>リアルタイムのイベント (例えば、オークション) において制限時間が必須の要素で、その制限時間に代わる手段が存在しない。又は、
-         </p>
+      <dd><p>リアルタイムのイベント (例えば、オークション) において制限時間が必須の要素で、その制限時間に代わる手段が存在しない。又は、</p>
          
       </dd>
       
       <dt>必要不可欠な例外</dt>
       
-      <dd>
-         
-         <p>制限時間が<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>なもので、制限時間を延長することがコンテンツの動作を無効にすることになる。又は、
-         </p>
+      <dd><p>制限時間が<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-5" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>なもので、制限時間を延長することがコンテンツの動作を無効にすることになる。又は、</p>
          
       </dd>
       
-      <dt> 20 時間の例外</dt>
+      <dt>20 時間の例外</dt>
       
-      <dd>
-         
-         <p>制限時間が 20 時間よりも長い。</p>
+      <dd><p>制限時間が 20 時間よりも長い。</p>
          
       </dd>
       
    </dl>
    
-   <div class="note" id="issue-container-generatedID-13"><div role="heading" class="note-title marker" id="h-note-13" aria-level="5"><span>注記</span></div><p class="">この達成基準は、制限時間の結果として、コンテンツ又は状況の予期せぬ変化を引き起こさないように利用者がタスクを完了できるようにするためのものである。この達成基準は、利用者の動作の結果としてのコンテンツ又はコンテキストの変化を制限する<a href="#on-focus">達成基準 3.2.1</a> と併せて考慮すること。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-13"><div role="heading" class="note-title marker" id="h-note-13" aria-level="5"><span>注記</span></div><p class="">この達成基準は、制限時間の結果として、コンテンツ又は状況の予期せぬ変化を引き起こさないように利用者がタスクを完了できるようにするためのものである。この達成基準は、利用者の動作の結果としてのコンテンツ又はコンテキストの変化を制限する<a href="#on-focus">達成基準 3.2.1</a> と併せて考慮すること。</p></div>
    
 </section>
-
-                <section class="sc" id="pause-stop-hide">
+            
+            <section class="guideline" id="pause-stop-hide"><div class="header-wrapper"><h4 id="x2-2-2-pause-stop-hide"><bdi class="secno">達成基準 2.2.2</bdi> 一時停止、停止、非表示</h4><a class="self-link" href="#pause-stop-hide" aria-label="Permalink for Section 2.2.2"></a></div>
    
-   <h4 id="x2-2-2-pause-stop-hide"><span class="secno">達成基準 2.2.2 </span>一時停止、停止、非表示<span class="permalink"><a href="#pause-stop-hide" aria-label="Permalink for 2.2.2 Pause, Stop, Hide" title="Permalink for 2.2.2 Pause, Stop, Hide"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html">Understanding Pause, Stop, Hide</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#pause-stop-hide">How to Meet Pause, Stop, Hide</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>動きのある、<a href="#dfn-blinking" class="internalDFN" data-link-type="dfn">点滅</a>している、スクロールする、又は自動更新する情報は、次のすべての事項を満たしている
-   </p>
+   <p>動きのある、<a href="#dfn-blinking" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-blinking-1" title="注意を引く意図で、二つの視覚的な状態を交互に切り替えること。">点滅</a>している、スクロールする、又は自動更新する情報は、次のすべての事項を満たしている</p>
    
    <dl>
       
       <dt>動き、点滅、スクロール</dt>
       
-      <dd>
-         
-         <p>動きのある、点滅している、又はスクロールしている情報が、(1) 自動的に開始し、(2) 5 秒よりも長く継続し、かつ、(3) その他のコンテンツと並行して提示される場合、利用者がそれらを<a href="#dfn-pause" class="internalDFN" data-link-type="dfn">一時停止</a>、停止、又は非表示にすることのできるメカニズムがある。ただし、その動き、点滅、又はスクロールが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な動作の一部である場合は除く。
-         </p>
+      <dd><p>動きのある、点滅している、又はスクロールしている情報が、(1) 自動的に開始し、(2) 5 秒よりも長く継続し、かつ、(3) その他のコンテンツと並行して提示される場合、利用者がそれらを<a href="#dfn-pause" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-pause-1" title="利用者の要求により停止し、利用者の要求があるまで再開しない。">一時停止</a>、停止、又は非表示にすることのできるメカニズムがある。ただし、その動き、点滅、又はスクロールが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-6" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>な動作の一部である場合は除く。</p>
          
       </dd>
       
       <dt>自動更新</dt>
       
-      <dd>
-         
-         <p>自動更新する情報が、(1) 自動的に開始し、 (2) その他のコンテンツと並行して提示される場合、利用者がそれを一時停止、停止、もしくは非表示にする、又はその更新頻度を調整することのできるメカニズムがある。ただし、その自動更新が必要不可欠な動作の一部である場合は除く。
-         </p>
+      <dd><p>自動更新する情報が、(1) 自動的に開始し、 (2) その他のコンテンツと並行して提示される場合、利用者がそれを一時停止、停止、もしくは非表示にする、又はその更新頻度を調整することのできるメカニズムがある。ただし、その自動更新が必要不可欠な動作の一部である場合は除く。</p>
          
       </dd>
       
    </dl>
    
-   <div class="note" id="issue-container-generatedID-14"><div role="heading" class="note-title marker" id="h-note-14" aria-level="5"><span>注記</span></div><p class="">画面がちらつく、又は閃光を放つコンテンツに関する要件は、<a href="#seizures-and-physical-reactions">ガイドライン 2.3</a> を参照。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-14"><div role="heading" class="note-title marker" id="h-note-14" aria-level="5"><span>注記</span></div><p class="">画面がちらつく、又は閃光を放つコンテンツに関する要件は、<a href="#seizures-and-physical-reactions">ガイドライン 2.3</a> を参照。</p></div>
    
-   <div class="note" id="issue-container-generatedID-15"><div role="heading" class="note-title marker" id="h-note-15" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-15"><div role="heading" class="note-title marker" id="h-note-15" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。</p></div>
    
-   <div class="note" id="issue-container-generatedID-16"><div role="heading" class="note-title marker" id="h-note-16" aria-level="5"><span>注記</span></div><p class="">定期的にソフトウェアによって自動的に更新されるコンテンツ、又はユーザエージェントにストリーム配信されるコンテンツでは、コンテンツ再生の一時停止と再開の操作の間に生成、又は受信される情報を保持、又は提示する必要はない。これは技術的に不可能であることが考えられ、多くの状況において利用者の混乱を招くことにつながる可能性があるためである。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-16"><div role="heading" class="note-title marker" id="h-note-16" aria-level="5"><span>注記</span></div><p class="">定期的にソフトウェアによって自動的に更新されるコンテンツ、又はユーザエージェントにストリーム配信されるコンテンツでは、コンテンツ再生の一時停止と再開の操作の間に生成、又は受信される情報を保持、又は提示する必要はない。これは技術的に不可能であることが考えられ、多くの状況において利用者の混乱を招くことにつながる可能性があるためである。</p></div>
    
-   <div class="note" id="issue-container-generatedID-17"><div role="heading" class="note-title marker" id="h-note-17" aria-level="5"><span>注記</span></div><p class="">コンテンツの読み込み中やそれに類似した状況の一部として表示されるアニメーションについては、この段階ですべての利用者に対していかなるインタラクションも発生する可能性がなく、かつコンテンツ読み込みの進行状況を表示しないことが利用者の混乱を招いたり、コンテンツが動作を停止した、又はコンテンツが破損しているという誤解を生じたりする可能性がある場合には、必要不可欠なものと考えることができる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-17"><div role="heading" class="note-title marker" id="h-note-17" aria-level="5"><span>注記</span></div><p class="">コンテンツの読み込み中やそれに類似した状況の一部として表示されるアニメーションについては、この段階ですべての利用者に対していかなるインタラクションも発生する可能性がなく、かつコンテンツ読み込みの進行状況を表示しないことが利用者の混乱を招いたり、コンテンツが動作を停止した、又はコンテンツが破損しているという誤解を生じたりする可能性がある場合には、必要不可欠なものと考えることができる。</p></div>
    
 </section>
-
-                <section class="sc" id="no-timing">
+            
+            <section class="guideline" id="no-timing"><div class="header-wrapper"><h4 id="x2-2-3-no-timing"><bdi class="secno">達成基準 2.2.3</bdi> タイミング非依存</h4><a class="self-link" href="#no-timing" aria-label="Permalink for Section 2.2.3"></a></div>
    
-   <h4 id="x2-2-3-no-timing"><span class="secno">達成基準 2.2.3 </span>タイミング非依存<span class="permalink"><a href="#no-timing" aria-label="Permalink for 2.2.3 No Timing" title="Permalink for 2.2.3 No Timing"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/no-timing.html">Understanding No Timing</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#no-timing">How to Meet No Timing</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>タイミングは、コンテンツによって提示されるイベント又は動作の<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な部分ではない。ただし、インタラクティブではない<a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn">同期したメディア</a>及び<a href="#dfn-real-time-events" class="internalDFN" data-link-type="dfn">リアルタイムのイベント</a>は除く。
-   </p>
+   <p>タイミングは、コンテンツによって提示されるイベント又は動作の<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-7" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>な部分ではない。ただし、インタラクティブではない<a href="#dfn-synchronized-media" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-synchronized-media-8" title="情報を提示するために、他のフォーマットと同期した音声もしくは映像、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアがメディアによるテキストの代替であって、そのように明確にラベル付けされているものは除く。">同期したメディア</a>及び<a href="#dfn-real-time-events" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-real-time-events-1" title="a) 閲覧と同時に発生し、かつ b) コンテンツによる生成だけでは完結しないイベント。">リアルタイムのイベント</a>は除く。</p>
    
 </section>
-
-                <section class="sc" id="interruptions">
+            
+            <section class="guideline" id="interruptions"><div class="header-wrapper"><h4 id="x2-2-4-interruptions"><bdi class="secno">達成基準 2.2.4</bdi> 割り込み</h4><a class="self-link" href="#interruptions" aria-label="Permalink for Section 2.2.4"></a></div>
    
-   <h4 id="x2-2-4-interruptions"><span class="secno">達成基準 2.2.4 </span>割り込み<span class="permalink"><a href="#interruptions" aria-label="Permalink for 2.2.4 Interruptions" title="Permalink for 2.2.4 Interruptions"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/interruptions.html">Understanding Interruptions</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#interruptions">How to Meet Interruptions</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>割り込みは、利用者が延期、又は抑制することができる。ただし、<a href="#dfn-emergency" class="internalDFN" data-link-type="dfn">緊急</a>を要する割り込みは除く。
-   </p>
+   <p>割り込みは、利用者が延期、又は抑制することができる。ただし、<a href="#dfn-emergency" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-emergency-1" title="健康、安全、又は財産を守るために即座の行動を必要とする、突然で予期しない状況又は出来事。">緊急</a>を要する割り込みは除く。</p>
    
 </section>
-
-                <section class="sc" id="re-authenticating">
+            
+            <section class="guideline" id="re-authenticating"><div class="header-wrapper"><h4 id="x2-2-5-re-authenticating"><bdi class="secno">達成基準 2.2.5</bdi> 再認証</h4><a class="self-link" href="#re-authenticating" aria-label="Permalink for Section 2.2.5"></a></div>
    
-   <h4 id="x2-2-5-re-authenticating"><span class="secno">達成基準 2.2.5 </span>再認証<span class="permalink"><a href="#re-authenticating" aria-label="Permalink for 2.2.5 Re-authenticating" title="Permalink for 2.2.5 Re-authenticating"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/re-authenticating.html">Understanding Re-authenticating</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#re-authenticating">How to Meet Re-authenticating</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>認証済のセッションが切れた場合は、再認証後でもデータを失うことなく利用者が操作を継続できる。
-   </p>
+   <p>認証済のセッションが切れた場合は、再認証後でもデータを失うことなく利用者が操作を継続できる。</p>
    
 </section>
-
-                <section class="sc" id="timeouts">
+            
+            <section class="guideline" id="timeouts"><div class="header-wrapper"><h4 id="x2-2-6-timeouts"><bdi class="secno">達成基準 2.2.6</bdi> タイムアウト</h4><a class="self-link" href="#timeouts" aria-label="Permalink for Section 2.2.6"></a></div>
    					
-   <h4 id="x2-2-6-timeouts"><span class="secno">達成基準 2.2.6 </span>タイムアウト<span class="permalink"><a href="#timeouts" aria-label="Permalink for 2.2.6 Timeouts" title="Permalink for 2.2.6 Timeouts"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/timeouts.html">Understanding Timeouts</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#timeouts">How to Meet Timeouts</a></div><p class="conformance-level">(レベル AAA)</p>
    					
-   
-   					
-   <p>データの損失を引き起こす恐れのある<a href="#dfn-user-inactivity" class="internalDFN" data-link-type="dfn">利用者の無操作</a>の残り時間が警告される。ただし、利用者が 20 時間以上何もしなくてもデータが保持される場合は、この限りではない。</p>
+   <p>データの損失を引き起こす恐れのある<a href="#dfn-user-inactivity" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-inactivity-1" title="利用者がいかなる操作も行わない時間が続くこと。">利用者の無操作</a>の残り時間が警告される。ただし、利用者が 20 時間以上何もしなくてもデータが保持される場合は、この限りではない。</p>
   
-<div class="note" id="issue-container-generatedID-18"><div role="heading" class="note-title marker" id="h-note-18" aria-level="5"><span>注記</span></div><p class="">プライバシー関連の規制により、利用者を認証する前や利用者のデータが保存される前に、利用者の明確な同意が必要になる可能性がある。利用者が未成年の場合、ほとんどの司法管轄、国又は地域で、利用者からの明示的な同意を要請することができない。この達成基準に適合するためのアプローチとしてデータの保存を検討する場合は、プライバシーの専門家や弁護士に相談するのが望ましい。</p></div>
+<div class="note" role="note" id="issue-container-generatedID-18"><div role="heading" class="note-title marker" id="h-note-18" aria-level="5"><span>注記</span></div><p class="">プライバシー関連の規制により、利用者を認証する前や利用者のデータが保存される前に、利用者の明確な同意が必要になる可能性がある。利用者が未成年の場合、ほとんどの司法管轄、国又は地域で、利用者からの明示的な同意を要請することができない。この達成基準に適合するためのアプローチとしてデータの保存を検討する場合は、プライバシーの専門家や弁護士に相談するのが望ましい。</p></div>
   
 </section>
  
-
-            </section>
-
-            <section class="guideline" id="seizures-and-physical-reactions">
-                <h3 id="x2-3-seizures-and-physical-reactions"><span class="secno">ガイドライン 2.3 </span>発作と身体的反応<span class="permalink"><a href="#seizures-and-physical-reactions" aria-label="Permalink for 2.3 Seizures and Physical Reactions" title="Permalink for 2.3 Seizures and Physical Reactions"><span>§</span></a></span></h3>
-
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/seizures-and-physical-reactions.html">Understanding Seizures and Physical Reactions</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#seizures-and-physical-reactions">How to Meet Seizures and Physical Reactions</a></div>
-                <p>発作や身体的反応を引き起こすようなコンテンツを設計しないこと。</p>
-
-                <section class="sc" id="three-flashes-or-below-threshold">
+            
+            
+         </section>
+         
+         
+         <section class="guideline" id="seizures-and-physical-reactions"><div class="header-wrapper"><h3 id="x2-3-seizures-and-physical-reactions"><bdi class="secno">ガイドライン 2.3</bdi> 発作と身体的反応</h3><a class="self-link" href="#seizures-and-physical-reactions" aria-label="Permalink for Section 2.3"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/seizures-and-physical-reactions.html">Understanding Seizures and Physical Reactions</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#seizures-and-physical-reactions">How to Meet Seizures and Physical Reactions</a></div><p>発作や身体的反応を引き起こすようなコンテンツを設計しないこと。</p>
+            
+            <section class="guideline" id="three-flashes-or-below-threshold"><div class="header-wrapper"><h4 id="x2-3-1-three-flashes-or-below-threshold"><bdi class="secno">達成基準 2.3.1</bdi> 3 回の閃光、又は閾値以下</h4><a class="self-link" href="#three-flashes-or-below-threshold" aria-label="Permalink for Section 2.3.1"></a></div>
    
-   <h4 id="x2-3-1-three-flashes-or-below-threshold"><span class="secno">達成基準 2.3.1 </span>3 回の閃光、又は閾値以下<span class="permalink"><a href="#three-flashes-or-below-threshold" aria-label="Permalink for 2.3.1 Three Flashes or Below Threshold" title="Permalink for 2.3.1 Three Flashes or Below Threshold"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html">Understanding Three Flashes or Below Threshold</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#three-flashes-or-below-threshold">How to Meet Three Flashes or Below Threshold</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>には、どの 1 秒間においても 3 回を超える閃光を放つものがない、又は<a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">閃光</a>が<a href="#dfn-general-flash-and-red-flash-thresholds" class="internalDFN" data-link-type="dfn">一般閃光閾値及び赤色閃光閾値</a>を下回っている。
-   </p>
+   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-1" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>には、どの 1 秒間においても 3 回を超える閃光を放つものがない、又は<a href="#dfn-flashes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-flashes-1" title="相対輝度の相反する変化の組合せで、十分な広さを持ち、かつ特定の頻度の場合に、一部の人に発作を誘発する恐れがあるもの。">閃光</a>が<a href="#dfn-general-flash-and-red-flash-thresholds" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-general-flash-and-red-flash-thresholds-1" title="次のいずれかに該当する場合、閃光、又は急速に変化する映像シーケンスは、閾値を下回っている (すなわち、コンテンツは基準を満たしている) ことになる:">一般閃光閾値及び赤色閃光閾値</a>を下回っている。</p>
    
-   <div class="note" id="issue-container-generatedID-19"><div role="heading" class="note-title marker" id="h-note-19" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-19"><div role="heading" class="note-title marker" id="h-note-19" aria-level="5"><span>注記</span></div><p class="">この達成基準を満たさないコンテンツでは、利用者がそのウェブページ全体を使用できない恐れがあるため、ウェブページ上のすべてのコンテンツは他の達成基準を満たすために用いられているか否かにかかわらず、この達成基準を満たさなければならない。<a href="#cc5">適合要件 5: 非干渉</a>を参照。</p></div>
    
 </section>
-
-                <section class="sc" id="three-flashes">
+            
+            <section class="guideline" id="three-flashes"><div class="header-wrapper"><h4 id="x2-3-2-three-flashes"><bdi class="secno">達成基準 2.3.2</bdi> 3 回の閃光</h4><a class="self-link" href="#three-flashes" aria-label="Permalink for Section 2.3.2"></a></div>
    
-   <h4 id="x2-3-2-three-flashes"><span class="secno">達成基準 2.3.2 </span>3 回の閃光<span class="permalink"><a href="#three-flashes" aria-label="Permalink for 2.3.2 Three Flashes" title="Permalink for 2.3.2 Three Flashes"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/three-flashes.html">Understanding Three Flashes</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#three-flashes">How to Meet Three Flashes</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>には、どの 1 秒間においても 3 回を超える<a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">閃光</a>を放つものがない。
-   </p>
+   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-2" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>には、どの 1 秒間においても 3 回を超える<a href="#dfn-flashes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-flashes-2" title="相対輝度の相反する変化の組合せで、十分な広さを持ち、かつ特定の頻度の場合に、一部の人に発作を誘発する恐れがあるもの。">閃光</a>を放つものがない。</p>
    
 </section>
-                
-                <section class="sc" id="animation-from-interactions">
+            
+            <section class="guideline" id="animation-from-interactions"><div class="header-wrapper"><h4 id="x2-3-3-animation-from-interactions"><bdi class="secno">達成基準 2.3.3</bdi> インタラクションによるアニメーション</h4><a class="self-link" href="#animation-from-interactions" aria-label="Permalink for Section 2.3.3"></a></div>
    					
-   <h4 id="x2-3-3-animation-from-interactions"><span class="secno">達成基準 2.3.3 </span>インタラクションによるアニメーション<span class="permalink"><a href="#animation-from-interactions" aria-label="Permalink for 2.3.3 Animation from Interactions" title="Permalink for 2.3.3 Animation from Interactions"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html">Understanding Animation from Interactions</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#animation-from-interactions">How to Meet Animation from Interactions</a></div><p class="conformance-level">(レベル AAA)</p>
    					
-   
-
-  <p>アニメーションが、機能又は伝達されている情報に<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>でない限り、インタラクションによって引き起こされる<a href="#dfn-motion-animation" class="internalDFN" data-link-type="dfn">モーションアニメーション</a>を無効にできる。</p>
+  <p>アニメーションが、機能又は伝達されている情報に<a href="#dfn-motion-animation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-motion-animation-1" title="動いているような錯覚を作り出す、又は滑らかに遷移しているような感覚を与えるための、状態間へのステップの追加。">必要不可欠</a>でない限り、インタラクションによって引き起こされる<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-8" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">モーションアニメーション</a>を無効にできる。</p>
    				
 </section>
 
-
-            </section>
-
-            <section class="guideline" id="navigable">
-                <h3 id="x2-4-navigable"><span class="secno">ガイドライン 2.4 </span>ナビゲーション可能<span class="permalink"><a href="#navigable" aria-label="Permalink for 2.4 Navigable" title="Permalink for 2.4 Navigable"><span>§</span></a></span></h3>
-
-                <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/navigable.html">Understanding Navigable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#navigable">How to Meet Navigable</a></div>
-                <p>利用者がナビゲートしたり、コンテンツを探し出したり、現在位置を確認したりすることを手助けする手段を提供すること。</p>
-
-                <section class="sc" id="bypass-blocks">
+            
+            
+         </section>
+         
+         
+         <section class="guideline" id="navigable"><div class="header-wrapper"><h3 id="x2-4-navigable"><bdi class="secno">ガイドライン 2.4</bdi> ナビゲーション可能</h3><a class="self-link" href="#navigable" aria-label="Permalink for Section 2.4"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/navigable.html">Understanding Navigable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#navigable">How to Meet Navigable</a></div><p>利用者がナビゲートしたり、コンテンツを探し出したり、現在位置を確認したりすることを手助けする手段を提供すること。</p>
+            
+            <section class="guideline" id="bypass-blocks"><div class="header-wrapper"><h4 id="x2-4-1-bypass-blocks"><bdi class="secno">達成基準 2.4.1</bdi> ブロックスキップ</h4><a class="self-link" href="#bypass-blocks" aria-label="Permalink for Section 2.4.1"></a></div>
    
-   <h4 id="x2-4-1-bypass-blocks"><span class="secno">達成基準 2.4.1 </span>ブロックスキップ<span class="permalink"><a href="#bypass-blocks" aria-label="Permalink for 2.4.1 Bypass Blocks" title="Permalink for 2.4.1 Bypass Blocks"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html">Understanding Bypass Blocks</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#bypass-blocks">How to Meet Bypass Blocks</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>複数の<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>上で繰り返されているコンテンツのブロックをスキップする<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。
-   </p>
+   <p>複数の<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-3" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>上で繰り返されているコンテンツのブロックをスキップする<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-5" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる。</p>
    
 </section>
-
-                <section class="sc" id="page-titled">
+            
+            <section class="guideline" id="page-titled"><div class="header-wrapper"><h4 id="x2-4-2-page-titled"><bdi class="secno">達成基準 2.4.2</bdi> ページタイトル</h4><a class="self-link" href="#page-titled" aria-label="Permalink for Section 2.4.2"></a></div>
    
-   <h4 id="x2-4-2-page-titled"><span class="secno">達成基準 2.4.2 </span>ページタイトル<span class="permalink"><a href="#page-titled" aria-label="Permalink for 2.4.2 Page Titled" title="Permalink for 2.4.2 Page Titled"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html">Understanding Page Titled</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#page-titled">How to Meet Page Titled</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>には、主題又は目的を説明したタイトルがある。
-   </p>
+   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-4" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>には、主題又は目的を説明したタイトルがある。</p>
    
 </section>
-
-                <section class="sc" id="focus-order">
+            
+            <section class="guideline" id="focus-order"><div class="header-wrapper"><h4 id="x2-4-3-focus-order"><bdi class="secno">達成基準 2.4.3</bdi> フォーカス順序</h4><a class="self-link" href="#focus-order" aria-label="Permalink for Section 2.4.3"></a></div>
    
-   <h4 id="x2-4-3-focus-order"><span class="secno">達成基準 2.4.3 </span>フォーカス順序<span class="permalink"><a href="#focus-order" aria-label="Permalink for 2.4.3 Focus Order" title="Permalink for 2.4.3 Focus Order"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html">Understanding Focus Order</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#focus-order">How to Meet Focus Order</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>が<a href="#dfn-navigated-sequentially" class="internalDFN" data-link-type="dfn">順を追ってナビゲート</a>できて、そのナビゲーション順が意味又は操作に影響を及ぼす場合、フォーカス可能なコンポーネントは、意味及び操作性を損なわない順序でフォーカスを受け取る。
-   </p>
+   <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-5" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>が<a href="#dfn-navigated-sequentially" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-navigated-sequentially-1" title="キーボードインタフェースを用いて (一つの要素から次へ) フォーカスを移動するために、定義された順序でナビゲートすること。">順を追ってナビゲート</a>できて、そのナビゲーション順が意味又は操作に影響を及ぼす場合、フォーカス可能なコンポーネントは、意味及び操作性を損なわない順序でフォーカスを受け取る。</p>
    
 </section>
-
-                <section class="sc" id="link-purpose-in-context">
+            
+            <section class="guideline" id="link-purpose-in-context"><div class="header-wrapper"><h4 id="x2-4-4-link-purpose-in-context"><bdi class="secno">達成基準 2.4.4</bdi> リンクの目的 (コンテキスト内)</h4><a class="self-link" href="#link-purpose-in-context" aria-label="Permalink for Section 2.4.4"></a></div>
    
-   <h4 id="x2-4-4-link-purpose-in-context"><span class="secno">達成基準 2.4.4 </span>リンクの目的 (コンテキスト内)<span class="permalink"><a href="#link-purpose-in-context" aria-label="Permalink for 2.4.4 Link Purpose (In Context)" title="Permalink for 2.4.4 Link Purpose (In Context)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html">Understanding Link Purpose (In Context)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-in-context">How to Meet Link Purpose (In Context)</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-purpose-of-each-link" class="internalDFN" data-link-type="dfn">それぞれのリンクの目的</a>が、リンクのテキスト単独で、又はリンクのテキストと<a href="#dfn-programmatically-determined-link-context" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>なリンクのコンテキストから判断できる。ただし、リンクの目的が<a href="#dfn-ambiguous-to-users-in-general" class="internalDFN" data-link-type="dfn">ほとんどの利用者にとって曖昧</a>な場合は除く。
-   </p>
+   <p><a href="#dfn-purpose-of-each-link" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-purpose-of-each-link-1" title="ハイパーリンクを動作させたときに得られる結果の本質。">それぞれのリンクの目的</a>が、リンクのテキスト単独で、又はリンクのテキストと<a href="#dfn-programmatically-determined-link-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determined-link-context-1" title="リンクとの関係性からプログラムによる解釈が可能であり、リンクテキストと結びつけることができ、様々な感覚モダリティで利用者に提示することができる付加的情報。">プログラムによる解釈が可能</a>なリンクのコンテキストから判断できる。ただし、リンクの目的が<a href="#dfn-ambiguous-to-users-in-general" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-ambiguous-to-users-in-general-1" title="リンク、及びリンクと同時に利用者に提供されているウェブページのどの情報からも、そのリンクの目的を判断できない (すなわち、障害がない閲覧者でも、そのリンクを動作させるまで、そのリンクが何をするのか分からない)。">ほとんどの利用者にとって曖昧</a>な場合は除く。</p>
    
 </section>
-
-                <section class="sc" id="multiple-ways">
+            
+            <section class="guideline" id="multiple-ways"><div class="header-wrapper"><h4 id="x2-4-5-multiple-ways"><bdi class="secno">達成基準 2.4.5</bdi> 複数の手段</h4><a class="self-link" href="#multiple-ways" aria-label="Permalink for Section 2.4.5"></a></div>
    
-   <h4 id="x2-4-5-multiple-ways"><span class="secno">達成基準 2.4.5 </span>複数の手段<span class="permalink"><a href="#multiple-ways" aria-label="Permalink for 2.4.5 Multiple Ways" title="Permalink for 2.4.5 Multiple Ways"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/multiple-ways.html">Understanding Multiple Ways</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#multiple-ways">How to Meet Multiple Ways</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn">ウェブページ一式</a>の中で、ある<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>を見つける複数の手段が利用できる。ただし、ウェブページが一連の<a href="#dfn-processes" class="internalDFN" data-link-type="dfn">プロセス</a>の中の 1 ステップ又は結果である場合は除く。
-   </p>
+   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-1" title="共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作されたウェブページの集合。">ウェブページ一式</a>の中で、ある<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-6" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>を見つける複数の手段が利用できる。ただし、ウェブページが一連の<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-1" title="ある活動を完了させるために必要な利用者の一連の動作。">プロセス</a>の中の 1 ステップ又は結果である場合は除く。</p>
    
 </section>
-
-                <section class="sc" id="headings-and-labels">
+            
+            <section class="guideline" id="headings-and-labels"><div class="header-wrapper"><h4 id="x2-4-6-headings-and-labels"><bdi class="secno">達成基準 2.4.6</bdi> 見出し及びラベル</h4><a class="self-link" href="#headings-and-labels" aria-label="Permalink for Section 2.4.6"></a></div>
    
-   <h4 id="x2-4-6-headings-and-labels"><span class="secno">達成基準 2.4.6 </span>見出し及びラベル<span class="permalink"><a href="#headings-and-labels" aria-label="Permalink for 2.4.6 Headings and Labels" title="Permalink for 2.4.6 Headings and Labels"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html">Understanding Headings and Labels</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#headings-and-labels">How to Meet Headings and Labels</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p>見出し及び<a href="#dfn-labels" class="internalDFN" data-link-type="dfn">ラベル</a>は、主題又は目的を説明している。
-   </p>
+   <p>見出し及び<a href="#dfn-labels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-labels-1" title="テキスト、又はテキストによる代替を伴うコンポーネントで、ウェブコンテンツ内のコンポーネントを識別するために利用者に提示されているもの。">ラベル</a>は、主題又は目的を説明している。</p>
    
 </section>
-
-                <section class="sc" id="focus-visible">
+            
+            <section class="guideline" id="focus-visible"><div class="header-wrapper"><h4 id="x2-4-7-focus-visible"><bdi class="secno">達成基準 2.4.7</bdi> フォーカスの可視化</h4><a class="self-link" href="#focus-visible" aria-label="Permalink for Section 2.4.7"></a></div>
    
-   <h4 id="x2-4-7-focus-visible"><span class="secno">達成基準 2.4.7 </span>フォーカスの可視化<span class="permalink"><a href="#focus-visible" aria-label="Permalink for 2.4.7 Focus Visible" title="Permalink for 2.4.7 Focus Visible"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html">Understanding Focus Visible</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#focus-visible">How to Meet Focus Visible</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p>キーボード操作が可能なあらゆるユーザインタフェースには、フォーカスインジケータが見える操作モードがある。
-   </p>
+   <p>キーボード操作が可能なあらゆるユーザインタフェースには、フォーカスインジケータが見える操作モードがある。</p>
    
 </section>
-
-                <section class="sc" id="location">
+            
+            <section class="guideline" id="location"><div class="header-wrapper"><h4 id="x2-4-8-location"><bdi class="secno">達成基準 2.4.8</bdi> 現在位置</h4><a class="self-link" href="#location" aria-label="Permalink for Section 2.4.8"></a></div>
    
-   <h4 id="x2-4-8-location"><span class="secno">達成基準 2.4.8 </span>現在位置<span class="permalink"><a href="#location" aria-label="Permalink for 2.4.8 Location" title="Permalink for 2.4.8 Location"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/location.html">Understanding Location</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#location">How to Meet Location</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn">ウェブページ一式</a>の中での利用者の位置に関する情報が利用できる。
-   </p>
+   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-2" title="共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作されたウェブページの集合。">ウェブページ一式</a>の中での利用者の位置に関する情報が利用できる。</p>
    
 </section>
-
-                <section class="sc" id="link-purpose-link-only">
+            
+            <section class="guideline" id="link-purpose-link-only"><div class="header-wrapper"><h4 id="x2-4-9-link-purpose-link-only"><bdi class="secno">達成基準 2.4.9</bdi> リンクの目的 (リンクのみ)</h4><a class="self-link" href="#link-purpose-link-only" aria-label="Permalink for Section 2.4.9"></a></div>
    
-   <h4 id="x2-4-9-link-purpose-link-only"><span class="secno">達成基準 2.4.9 </span>リンクの目的 (リンクのみ)<span class="permalink"><a href="#link-purpose-link-only" aria-label="Permalink for 2.4.9 Link Purpose (Link Only)" title="Permalink for 2.4.9 Link Purpose (Link Only)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only.html">Understanding Link Purpose (Link Only)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-link-only">How to Meet Link Purpose (Link Only)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>それぞれのリンクの目的を、リンクのテキスト単独で特定できる<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。ただし、リンクの目的が<a href="#dfn-ambiguous-to-users-in-general" class="internalDFN" data-link-type="dfn">ほとんどの利用者にとって曖昧</a>な場合は除く。
-   </p>
+   <p>それぞれのリンクの目的を、リンクのテキスト単独で特定できる<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-6" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる。ただし、リンクの目的が<a href="#dfn-ambiguous-to-users-in-general" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-ambiguous-to-users-in-general-2" title="リンク、及びリンクと同時に利用者に提供されているウェブページのどの情報からも、そのリンクの目的を判断できない (すなわち、障害がない閲覧者でも、そのリンクを動作させるまで、そのリンクが何をするのか分からない)。">ほとんどの利用者にとって曖昧</a>な場合は除く。</p>
    
 </section>
-
-                <section class="sc" id="section-headings">
+            
+            <section class="guideline" id="section-headings"><div class="header-wrapper"><h4 id="x2-4-10-section-headings"><bdi class="secno">達成基準 2.4.10</bdi> セクション見出し</h4><a class="self-link" href="#section-headings" aria-label="Permalink for Section 2.4.10"></a></div>
    
-   <h4 id="x2-4-10-section-headings"><span class="secno">達成基準 2.4.10 </span>セクション見出し<span class="permalink"><a href="#section-headings" aria-label="Permalink for 2.4.10 Section Headings" title="Permalink for 2.4.10 Section Headings"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/section-headings.html">Understanding Section Headings</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#section-headings">How to Meet Section Headings</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-section" class="internalDFN" data-link-type="dfn">セクション</a>見出しを用いて、コンテンツが整理されている。
-   </p>
+   <p><a href="#dfn-section" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-section-1" title="一つ以上の関連する話題、又は考えについて書かれたコンテンツの自己完結している部分。">セクション</a>見出しを用いて、コンテンツが整理されている。</p>
    
-   <div class="note" id="issue-container-generatedID-20"><div role="heading" class="note-title marker" id="h-note-20" aria-level="5"><span>注記</span></div><p class="">見出しはその一般的な意味で用いられており、タイトルや様々なタイプのコンテンツに見出しを付加するその他の手段を含む。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-20"><div role="heading" class="note-title marker" id="h-note-20" aria-level="5"><span>注記</span></div><p class="">見出しはその一般的な意味で用いられており、タイトルや様々なタイプのコンテンツに見出しを付加するその他の手段を含む。</p></div>
    
-   <div class="note" id="issue-container-generatedID-21"><div role="heading" class="note-title marker" id="h-note-21" aria-level="5"><span>注記</span></div><p class="">この達成基準は、文書におけるセクションを対象としており、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>は対象としていない。ユーザインタフェース コンポーネントについては、<a href="#name-role-value">達成基準 4.1.2</a> が対象にしている。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-21"><div role="heading" class="note-title marker" id="h-note-21" aria-level="5"><span>注記</span></div><p class="">この達成基準は、文書におけるセクションを対象としており、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-6" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>は対象としていない。ユーザインタフェース コンポーネントについては、<a href="#name-role-value">達成基準 4.1.2</a> が対象にしている。</p></div>
    
 </section>
 
-            </section>
-
-            <section class="guideline" id="input-modalities">
-                <h3 id="x2-5-input-modalities"><span class="secno">ガイドライン 2.5 </span>入力モダリティ<span class="permalink"><a href="#input-modalities" aria-label="Permalink for 2.5 Input Modalities" title="Permalink for 2.5 Input Modalities"><span>§</span></a></span></h3>
-                
-                <p>利用者がキーボード以外の様々な入力を通じて機能を操作しやすくすること。</p>
-
-                <section class="sc" id="pointer-gestures">
+            
+            
+         </section>
+         
+         
+         <section class="guideline" id="input-modalities"><div class="header-wrapper"><h3 id="x2-5-input-modalities"><bdi class="secno">ガイドライン 2.5</bdi> 入力モダリティ</h3><a class="self-link" href="#input-modalities" aria-label="Permalink for Section 2.5"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/input-modalities.html">Understanding Input Modalities</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#input-modalities">How to Meet Input Modalities</a></div><p class="change">[New]</p>
+            
+            <p>利用者がキーボード以外の様々な入力を通じて機能を操作しやすくすること。</p>
+            
+            <section class="guideline" id="pointer-gestures"><div class="header-wrapper"><h4 id="x2-5-1-pointer-gestures"><bdi class="secno">達成基準 2.5.1</bdi> ポインタのジェスチャ</h4><a class="self-link" href="#pointer-gestures" aria-label="Permalink for Section 2.5.1"></a></div>
    					
-   <h4 id="x2-5-1-pointer-gestures"><span class="secno">達成基準 2.5.1 </span>ポインタのジェスチャ<span class="permalink"><a href="#pointer-gestures" aria-label="Permalink for 2.5.1 Pointer Gestures" title="Permalink for 2.5.1 Pointer Gestures"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures.html">Understanding Pointer Gestures</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#pointer-gestures">How to Meet Pointer Gestures</a></div><p class="conformance-level">(レベル A)</p>
    					
-   
+   <p>マルチポイント又は軌跡ベースのジェスチャを使って操作する<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-functionality-3" title="利用者の操作により実現可能なプロセス及び結果。">機能</a>はすべて、軌跡ベースのジェスチャなしの<a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-single-pointer-1" title="シングルタップ・クリック、ダブルタップ・クリック、長押し、軌跡ベースのジェスチャなど、画面と一つの接点で動作するポインタ入力。">シングルポインタ</a>で操作することができる。ただし、マルチポイント又は軌跡ベースのジェスチャが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-9" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>である場合は例外とする。</p>
    					
-   <p>マルチポイント又は軌跡ベースのジェスチャを使って操作する<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>はすべて、軌跡ベースのジェスチャなしの<a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn">シングルポインタ</a>で操作することができる。ただし、マルチポイント又は軌跡ベースのジェスチャが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である場合は例外とする。</p>
-   					
-   <div class="note" id="issue-container-generatedID-22"><div role="heading" class="note-title marker" id="h-note-22" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツに適用される (ユーザエージェントや支援技術の操作に必要なアクションには適用されない)。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-22"><div role="heading" class="note-title marker" id="h-note-22" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツに適用される (ユーザエージェントや支援技術の操作に必要なアクションには適用されない)。</p></div>
 	
 </section>
 
-
-                <section class="sc" id="pointer-cancellation">
+            
+            <section class="guideline" id="pointer-cancellation"><div class="header-wrapper"><h4 id="x2-5-2-pointer-cancellation"><bdi class="secno">達成基準 2.5.2</bdi> ポインタのキャンセル</h4><a class="self-link" href="#pointer-cancellation" aria-label="Permalink for Section 2.5.2"></a></div>
    					
-   <h4 id="x2-5-2-pointer-cancellation"><span class="secno">達成基準 2.5.2 </span>ポインタのキャンセル<span class="permalink"><a href="#pointer-cancellation" aria-label="Permalink for 2.5.2 Pointer Cancellation" title="Permalink for 2.5.2 Pointer Cancellation"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html">Understanding Pointer Cancellation</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#pointer-cancellation">How to Meet Pointer Cancellation</a></div><p class="conformance-level">(レベル A)</p>
    					
-   
-   					
-   <p><a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn">シングルポインタ</a>を使って操作できる<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>は、以下の要件の少なくとも 一つを満たす。</p>
+   <p><a href="#dfn-single-pointer" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-single-pointer-2" title="シングルタップ・クリック、ダブルタップ・クリック、長押し、軌跡ベースのジェスチャなど、画面と一つの接点で動作するポインタ入力。">シングルポインタ</a>を使って操作できる<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-functionality-4" title="利用者の操作により実現可能なプロセス及び結果。">機能</a>は、以下の要件の少なくとも 一つを満たす。</p>
    					
    <dl>
    
-   <dt>ダウンイベントがない</dt>
-     <dd>機能を実行する目的でポインタの<a href="#dfn-down-event" class="internalDFN" data-link-type="dfn">ダウンイベント</a>を使用していない。</dd>
+   <dt>ダウンイベントがない </dt>
+     <dd>機能を実行する目的でポインタの<a href="#dfn-down-event" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-down-event-1" title="トリガ刺激が depressed (押し下げられた) となった時に発生するプラットフォームのイベント。">ダウンイベント</a>を使用していない。</dd>
       						
-   <dt>中止又は元に戻すことができる</dt>
-     <dd>機能の完了には<a href="#dfn-up-event" class="internalDFN" data-link-type="dfn">アップイベント</a>を使用し、かつ機能の完了前に中止する、又は機能の完了後に元に戻すための<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。</dd>
+   <dt>中止又は元に戻すことができる </dt>
+     <dd>機能の完了には<a href="#dfn-up-event" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-up-event-1" title="ポインタのトリガが解除されたときに生じるプラットフォームイベント。">アップイベント</a>を使用し、かつ機能の完了前に中止する、又は機能の完了後に元に戻すための<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-7" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる。</dd>
       						
-   <dt>アップイベントで反転</dt>
+   <dt>アップイベントで反転 </dt>
      <dd>アップイベントによって、先のダウンイベントのすべての結果が反転する。</dd>
       						
    <dt>必要不可欠</dt>
-     <dd>ダウンイベントによって機能を完了させることが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である。</dd>
+     <dd>ダウンイベントによって機能を完了させることが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-10" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>である。</dd>
       						
    </dl>
-   <div class="note" id="issue-container-generatedID-23"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>注記</span></div><p class="">キーボードまたはテンキーパッドのキープレスをエミュレートする機能は必須と考えられる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-23"><div role="heading" class="note-title marker" id="h-note-23" aria-level="5"><span>注記</span></div><p class="">キーボードまたはテンキーパッドのキープレスをエミュレートする機能は必須と考えられる。</p></div>
    					
-  <div class="note" id="issue-container-generatedID-24"><div role="heading" class="note-title marker" id="h-note-24" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツに適用される (ユーザエージェントや支援技術の操作に必要なアクションには適用されない)。</p></div>
+  <div class="note" role="note" id="issue-container-generatedID-24"><div role="heading" class="note-title marker" id="h-note-24" aria-level="5"><span>注記</span></div><p class="">この要件は、ポインタの動作を解釈するウェブコンテンツに適用される (ユーザエージェントや支援技術の操作に必要なアクションには適用されない)。</p></div>
 	
 </section>
 
-
-              	<section class="sc" id="label-in-name">
-   <h4 id="x2-5-3-label-in-name"><span class="secno">達成基準 2.5.3 </span>ラベルを含む名前 (name)<span class="permalink"><a href="#label-in-name" aria-label="Permalink for 2.5.3 Label in Name" title="Permalink for 2.5.3 Label in Name"><span>§</span></a></span></h4>
-   <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html">Understanding Label in Name</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#label-in-name">How to Meet Label in Name</a></div><p class="conformance-level">(レベル A)</p>
+            
+            	<section class="guideline" id="label-in-name"><div class="header-wrapper"><h4 id="x2-5-3-label-in-name"><bdi class="secno">達成基準 2.5.3</bdi> ラベルを含む名前 (name)</h4><a class="self-link" href="#label-in-name" aria-label="Permalink for Section 2.5.3"></a></div>
    
+   <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html">Understanding Label in Name</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#label-in-name">How to Meet Label in Name</a></div><p class="conformance-level">(レベル A)</p>
 	
-  <p><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>が<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>又は<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>を含む<a href="#dfn-labels" class="internalDFN" data-link-type="dfn">ラベル</a>を持つ場合、視覚的に提示されたテキストが<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> に含まれている。</p>
+  <p><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-7" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>が<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-8" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>又は<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-images-of-text-6" title="特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。">文字画像</a>を含む<a href="#dfn-labels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-labels-2" title="テキスト、又はテキストによる代替を伴うコンポーネントで、ウェブコンテンツ内のコンポーネントを識別するために利用者に提示されているもの。">ラベル</a>を持つ場合、視覚的に提示されたテキストが<a href="#dfn-name" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-name-2" title="ソフトウェアが、ウェブコンテンツのコンポーネントを利用者に識別させることができるテキスト。">名前 (name) </a>に含まれている。</p>
 
-  <div class="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-25" aria-level="5"><span>注記</span></div><p class="">ベストプラクティスは、ラベルのテキストを名前 (name) の最初に使用することである。</p></div>
+  <div class="note" role="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-25" aria-level="5"><span>注記</span></div><p class="">ベストプラクティスは、ラベルのテキストを名前 (name) の最初に使用することである。</p></div>
 	
 </section>
 
             	
-                <section class="sc" id="motion-actuation">
+            <section class="guideline" id="motion-actuation"><div class="header-wrapper"><h4 id="x2-5-4-motion-actuation"><bdi class="secno">達成基準 2.5.4</bdi> 動きによる起動</h4><a class="self-link" href="#motion-actuation" aria-label="Permalink for Section 2.5.4"></a></div>
    					
-   <h4 id="x2-5-4-motion-actuation"><span class="secno">達成基準 2.5.4 </span>動きによる起動<span class="permalink"><a href="#motion-actuation" aria-label="Permalink for 2.5.4 Motion Actuation" title="Permalink for 2.5.4 Motion Actuation"><span>§</span></a></span></h4>
+   
   
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation.html">Understanding Motion Actuation</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#motion-actuation">How to Meet Motion Actuation</a></div><p class="conformance-level">(レベル A)</p>
    					
-   
-   					
-   <p>デバイスの動き又は利用者の動きで操作できる<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>は、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>でも操作でき、かつ偶発的な起動を防ぐために動きへの反応を無効化することができる。ただし、以下の場合は例外とする。</p>
+   <p>デバイスの動き又は利用者の動きで操作できる<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-functionality-5" title="利用者の操作により実現可能なプロセス及び結果。">機能</a>は、<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-8" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>でも操作でき、かつ偶発的な起動を防ぐために動きへの反応を無効化することができる。ただし、以下の場合は例外とする。</p>
    
    <dl>
    
-   <dt>サポートされたインタフェース</dt>
-     <dd><a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポーテッド</a>なインタフェースを通じて機能を操作するために動きが用いられる。</dd>
+   <dt>サポートされたインタフェース </dt>
+     <dd><a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-supported-1" title="利用者の支援技術だけでなく、ブラウザ及びその他のユーザエージェントにあるアクセシビリティ機能でサポートされていること。">アクセシビリティ サポーテッド</a>なインタフェースを通じて機能を操作するために動きが用いられる。</dd>
    
    <dt>必要不可欠</dt>
-   <dd>その機能にとって動きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>であり、この達成基準に従うと動作を無効化してしまう。</dd>
+   <dd>その機能にとって動きが<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-11" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>であり、この達成基準に従うと動作を無効化してしまう。</dd>
    
    </dl>
    				
 </section>
 
-
-                <section class="sc" id="target-size">
+            
+            <section class="guideline" id="target-size"><div class="header-wrapper"><h4 id="x2-5-5-target-size"><bdi class="secno">達成基準 2.5.5</bdi> ターゲットのサイズ</h4><a class="self-link" href="#target-size" aria-label="Permalink for Section 2.5.5"></a></div>
    					
-   <h4 id="x2-5-5-target-size"><span class="secno">達成基準 2.5.5 </span>ターゲットのサイズ<span class="permalink"><a href="#target-size" aria-label="Permalink for 2.5.5 Target Size" title="Permalink for 2.5.5 Target Size"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/target-size.html">Understanding Target Size</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#target-size">How to Meet Target Size</a></div><p class="conformance-level">(レベル AAA)</p>
    					
-   
-	
-  <p><a href="#dfn-pointer-inputs" class="internalDFN" data-link-type="dfn">ポインタ入力</a>の<a href="#dfn-target" class="internalDFN" data-link-type="dfn">ターゲット</a>のサイズが 44 × 44 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn">CSS ピクセル</a>以上である。ただし、以下の場合は例外とする。</p>
+  <p><a href="#dfn-pointer-inputs" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-pointer-inputs-1" title="マウス、ペン、タッチ接触のように、画面上の特定の座標 (又は複数の座標群) をターゲットにできるデバイスからの入力。">ポインタ入力</a>の<a href="#dfn-targets" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-targets-1" title="ユーザインタフェース コンポーネントのインタラクティブな領域のような、ポインタアクションを受け入れるディスプレイの領域">ターゲット</a>のサイズが 44 × 44 <a href="#dfn-css-pixels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-css-pixels-3" title="約 0.0213 度の視野角。">CSS ピクセル</a>以上である。ただし、以下の場合は例外とする。</p>
 <dl>
-	<dt>同等のものが存在する</dt> 
+	<dt>同等のものが存在する </dt> 
   <dd>そのターゲットと同等のリンク又はコントロールが同じページに 44 × 44 CSS ピクセル以上のサイズで存在する。</dd>
-	<dt>インラインである</dt> 
+	<dt>インラインである </dt> 
   <dd>そのターゲットが文中、又はテキストブロック内に存在する。</dd>
-	<dt>ユーザエージェントのコントロールである</dt> 
+	<dt>ユーザエージェントのコントロールである </dt> 
   <dd>ターゲットのサイズがユーザエージェントによって定められており、かつコンテンツ制作者が変更していない。</dd>
 	<dt>必要不可欠</dt> 
-  <dd>そのターゲットを特定の方法で提示することが、情報伝達にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>である。</dd>
+  <dd>そのターゲットを特定の方法で提示することが、情報伝達にとって<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-12" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>である。</dd>
 </dl>  
    
 </section>
 
-
-                <section class="sc" id="concurrent-input-mechanisms">
-   <h4 id="x2-5-6-concurrent-input-mechanisms"><span class="secno">達成基準 2.5.6 </span>入力メカニズムの共存<span class="permalink"><a href="#concurrent-input-mechanisms" aria-label="Permalink for 2.5.6 Concurrent Input Mechanisms" title="Permalink for 2.5.6 Concurrent Input Mechanisms"><span>§</span></a></span></h4>
+            
+            <section class="guideline" id="concurrent-input-mechanisms"><div class="header-wrapper"><h4 id="x2-5-6-concurrent-input-mechanisms"><bdi class="secno">達成基準 2.5.6</bdi> 入力メカニズムの共存</h4><a class="self-link" href="#concurrent-input-mechanisms" aria-label="Permalink for Section 2.5.6"></a></div>
+   
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms.html">Understanding Concurrent Input Mechanisms</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#concurrent-input-mechanisms">How to Meet Concurrent Input Mechanisms</a></div><p class="conformance-level">(レベル AAA)</p>
-  
-  <p>プラットフォームで提供されている入力モダリティの使用を、ウェブコンテンツが制限しない。ただし、その制限が<a href="#dfn-essential" class="internalDFN" data-link-type="dfn">必要不可欠</a>な場合、コンテンツのセキュリティのために必要な場合、又は利用者による設定を尊重するうえで必要な場合は例外とする。</p><!--OddPage-->   					
+  <p>プラットフォームで提供されている入力モダリティの使用を、ウェブコンテンツが制限しない。ただし、その制限が<a href="#dfn-essential" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-essential-13" title="もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、かつ、適合する他の方法では情報及び機能を実現できない。">必要不可欠</a>な場合、コンテンツのセキュリティのために必要な場合、又は利用者による設定を尊重するうえで必要な場合は例外とする。</p>   					
 </section>
 
-
-            </section>
-
-        </section>
-        <section class="principle" id="understandable">
-            <h2 id="x3-understandable"><span class="secno">3. </span> 理解可能 <span class="permalink"><a href="#understandable" aria-label="Permalink for 3.  Understandable " title="Permalink for 3.  Understandable "><span>§</span></a></span></h2>
-            <p>情報及びユーザインタフェースの操作は理解可能でなければならない。</p>
-
-            <section class="guideline" id="readable">
-                <h3 id="x3-1-readable"><span class="secno">ガイドライン 3.1 </span>読み取り可能<span class="permalink"><a href="#readable" aria-label="Permalink for 3.1 Readable" title="Permalink for 3.1 Readable"><span>§</span></a></span></h3>
-<div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/readable.html">Understanding Readable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#readable">How to Meet Readable</a></div>
-                <p>テキストコンテンツの読み取りと理解を可能にすること。</p>
-
-                <section class="sc" id="language-of-page">
+            
+            
+         </section>
+         
+         
+      </section>
+      
+      <section class="principle" id="understandable"><div class="header-wrapper"><h2 id="x3-understandable"><bdi class="secno">3. </bdi>理解可能</h2><a class="self-link" href="#understandable" aria-label="Permalink for Section 3."></a></div>
+         
+         
+         
+         <p>情報及びユーザインタフェースの操作は理解可能でなければならない。</p>
+         
+         
+         <section class="guideline" id="readable"><div class="header-wrapper"><h3 id="x3-1-readable"><bdi class="secno">ガイドライン 3.1</bdi> 読み取り可能</h3><a class="self-link" href="#readable" aria-label="Permalink for Section 3.1"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/readable.html">Understanding Readable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#readable">How to Meet Readable</a></div><p>テキストコンテンツの読み取りと理解を可能にすること。</p>
+            
+            <section class="guideline" id="language-of-page"><div class="header-wrapper"><h4 id="x3-1-1-language-of-page"><bdi class="secno">達成基準 3.1.1</bdi> ページの言語</h4><a class="self-link" href="#language-of-page" aria-label="Permalink for Section 3.1.1"></a></div>
    
-   <h4 id="x3-1-1-language-of-page"><span class="secno">達成基準 3.1.1 </span>ページの言語<span class="permalink"><a href="#language-of-page" aria-label="Permalink for 3.1.1 Language of Page" title="Permalink for 3.1.1 Language of Page"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html">Understanding Language of Page</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#language-of-page">How to Meet Language of Page</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>それぞれの<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>のデフォルトの<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">自然言語</a>がどの言語であるか、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。
-   </p>
+   <p>それぞれの<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-7" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>のデフォルトの<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-1" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>がどの言語であるか、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-5" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である。</p>
    
 </section>
-
-                <section class="sc" id="language-of-parts">
+            
+            <section class="guideline" id="language-of-parts"><div class="header-wrapper"><h4 id="x3-1-2-language-of-parts"><bdi class="secno">達成基準 3.1.2</bdi> 一部分の言語</h4><a class="self-link" href="#language-of-parts" aria-label="Permalink for Section 3.1.2"></a></div>
    
-   <h4 id="x3-1-2-language-of-parts"><span class="secno">達成基準 3.1.2 </span>一部分の言語<span class="permalink"><a href="#language-of-parts" aria-label="Permalink for 3.1.2 Language of Parts" title="Permalink for 3.1.2 Language of Parts"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html">Understanding Language of Parts</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#language-of-parts">How to Meet Language of Parts</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p>コンテンツの一節、又は語句それぞれの<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">自然言語</a>がどの言語であるか、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。ただし、固有名詞、技術用語、言語が不明な語句、及びすぐ前後にあるテキストの言語の一部になっている単語又は語句は除く。
-   </p>
+   <p>コンテンツの一節、又は語句それぞれの<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-2" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>がどの言語であるか、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-6" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である。ただし、固有名詞、技術用語、言語が不明な語句、及びすぐ前後にあるテキストの言語の一部になっている単語又は語句は除く。</p>
    
 </section>
-
-                <section class="sc" id="unusual-words">
+            
+            <section class="guideline" id="unusual-words"><div class="header-wrapper"><h4 id="x3-1-3-unusual-words"><bdi class="secno">達成基準 3.1.3</bdi> 一般的ではない用語</h4><a class="self-link" href="#unusual-words" aria-label="Permalink for Section 3.1.3"></a></div>
    
-   <h4 id="x3-1-3-unusual-words"><span class="secno">達成基準 3.1.3 </span>一般的ではない用語<span class="permalink"><a href="#unusual-words" aria-label="Permalink for 3.1.3 Unusual Words" title="Permalink for 3.1.3 Unusual Words"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/unusual-words.html">Understanding Unusual Words</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#unusual-words">How to Meet Unusual Words</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-idioms" class="internalDFN" data-link-type="dfn">慣用句</a>及び<a href="#dfn-jargon" class="internalDFN" data-link-type="dfn">業界用語</a>を含めて、一般的ではない、又は<a href="#dfn-used-in-an-unusual-or-restricted-way" class="internalDFN" data-link-type="dfn">限定された用法で使われている</a>単語、又は語句の、明確な定義を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。
-   </p>
+   <p><a href="#dfn-idioms" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-idioms-1" title="個々の単語の意味からはその意味を推測できず、特定の単語を変えると意味が通じなくなる言い回し。">慣用句</a>及び<a href="#dfn-jargon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-jargon-1" title="特定の分野の人々が特定の用法で用いる単語。">業界用語</a>を含めて、一般的ではない、又は<a href="#dfn-used-in-an-unusual-or-restricted-way" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-used-in-an-unusual-or-restricted-way-1" title="そのコンテンツを正しく理解するために、どの定義で使われているのかを利用者が正確に知る必要があるような使われ方をしている言葉。">限定された用法で使われている</a>単語、又は語句の、明確な定義を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-8" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる。</p>
    
 </section>
-
-                <section class="sc" id="abbreviations">
+            
+            <section class="guideline" id="abbreviations"><div class="header-wrapper"><h4 id="x3-1-4-abbreviations"><bdi class="secno">達成基準 3.1.4</bdi> 略語</h4><a class="self-link" href="#abbreviations" aria-label="Permalink for Section 3.1.4"></a></div>
    
-   <h4 id="x3-1-4-abbreviations"><span class="secno">達成基準 3.1.4 </span>略語<span class="permalink"><a href="#abbreviations" aria-label="Permalink for 3.1.4 Abbreviations" title="Permalink for 3.1.4 Abbreviations"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/abbreviations.html">Understanding Abbreviations</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#abbreviations">How to Meet Abbreviations</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-abbreviations" class="internalDFN" data-link-type="dfn">略語</a>の元の語、又は意味を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。
-   </p>
+   <p><a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-9" title="結果を得るためのプロセス又は手法。">略語</a>の元の語、又は意味を特定する<a href="#dfn-abbreviations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-abbreviations-1" title="単語、語句、又は名称の短縮形で、その略語が言語の一部になっていないもの。">メカニズム</a>が利用できる。</p>
    
 </section>
-
-                <section class="sc" id="reading-level">
+            
+            <section class="guideline" id="reading-level"><div class="header-wrapper"><h4 id="x3-1-5-reading-level"><bdi class="secno">達成基準 3.1.5</bdi> 読解レベル</h4><a class="self-link" href="#reading-level" aria-label="Permalink for Section 3.1.5"></a></div>
    
-   <h4 id="x3-1-5-reading-level"><span class="secno">達成基準 3.1.5 </span>読解レベル<span class="permalink"><a href="#reading-level" aria-label="Permalink for 3.1.5 Reading Level" title="Permalink for 3.1.5 Reading Level"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/reading-level.html">Understanding Reading Level</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#reading-level">How to Meet Reading Level</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>固有名詞や題名を取り除いた状態で、テキストが<a href="#dfn-lower-secondary-education-level" class="internalDFN" data-link-type="dfn">前期中等教育レベル</a>を超えた読解力を必要とする場合は、<a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn">補足コンテンツ</a>又は前期中等教育レベルを超えた読解力を必要としない版が利用できる。
-   </p>
+   <p>固有名詞や題名を取り除いた状態で、テキストが<a href="#dfn-lower-secondary-education-level" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-lower-secondary-education-level-1" title="6 年間の学校教育卒業の後に始まり、初等教育の開始から 9 年後に終わる、2 年、又は 3 年の教育期間。">前期中等教育レベル</a>を超えた読解力を必要とする場合は、<a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-supplementary-content-1" title="元のコンテンツを説明、又はより明確にするために付加されたコンテンツ。">補足コンテンツ</a>又は前期中等教育レベルを超えた読解力を必要としない版が利用できる。</p>
    
 </section>
-
-                <section class="sc" id="pronunciation">
+            
+            <section class="guideline" id="pronunciation"><div class="header-wrapper"><h4 id="x3-1-6-pronunciation"><bdi class="secno">達成基準 3.1.6</bdi> 発音</h4><a class="self-link" href="#pronunciation" aria-label="Permalink for Section 3.1.6"></a></div>
    
-   <h4 id="x3-1-6-pronunciation"><span class="secno">達成基準 3.1.6 </span>発音<span class="permalink"><a href="#pronunciation" aria-label="Permalink for 3.1.6 Pronunciation" title="Permalink for 3.1.6 Pronunciation"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/pronunciation.html">Understanding Pronunciation</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#pronunciation">How to Meet Pronunciation</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>文脈において、発音が分からないと単語の意味が不明瞭になる場合、その単語の明確な発音を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。
-   </p>
+   <p>文脈において、発音が分からないと単語の意味が不明瞭になる場合、その単語の明確な発音を特定する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-10" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる。</p>
    
 </section>
-
-            </section>
-
-            <section class="guideline" id="predictable">
-                <h3 id="x3-2-predictable"><span class="secno">ガイドライン 3.2 </span>予測可能<span class="permalink"><a href="#predictable" aria-label="Permalink for 3.2 Predictable" title="Permalink for 3.2 Predictable"><span>§</span></a></span></h3>
-<div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/predictable.html">Understanding Predictable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#predictable">How to Meet Predictable</a></div>
-                <p>ウェブページの表示や挙動を予測可能にすること。</p>
-
-                <section class="sc" id="on-focus">
+            
+            
+         </section>
+         
+         
+         <section class="guideline" id="predictable"><div class="header-wrapper"><h3 id="x3-2-predictable"><bdi class="secno">ガイドライン 3.2</bdi> 予測可能</h3><a class="self-link" href="#predictable" aria-label="Permalink for Section 3.2"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/predictable.html">Understanding Predictable</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#predictable">How to Meet Predictable</a></div><p>ウェブページの表示や挙動を予測可能にすること。</p>
+            
+            <section class="guideline" id="on-focus"><div class="header-wrapper"><h4 id="x3-2-1-on-focus"><bdi class="secno">達成基準 3.2.1</bdi> フォーカス時</h4><a class="self-link" href="#on-focus" aria-label="Permalink for Section 3.2.1"></a></div>
    
-   <h4 id="x3-2-1-on-focus"><span class="secno">達成基準 3.2.1 </span>フォーカス時<span class="permalink"><a href="#on-focus" aria-label="Permalink for 3.2.1 On Focus" title="Permalink for 3.2.1 On Focus"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html">Understanding On Focus</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#on-focus">How to Meet On Focus</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>いずれの<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインターフェイス コンポーネント</a>も、フォーカスを受け取ったときに<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">コンテキストの変化</a>を引き起こさない。
-   </p>
+   <p>いずれの<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-9" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインターフェイス コンポーネント</a>も、フォーカスを受け取ったときに<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-change-of-context-1" title="大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。">コンテキストの変化</a>を引き起こさない。</p>
    
 </section>
-
-                <section class="sc" id="on-input">
+            
+            <section class="guideline" id="on-input"><div class="header-wrapper"><h4 id="x3-2-2-on-input"><bdi class="secno">達成基準 3.2.2</bdi> 入力時</h4><a class="self-link" href="#on-input" aria-label="Permalink for Section 3.2.2"></a></div>
    
-   <h4 id="x3-2-2-on-input"><span class="secno">達成基準 3.2.2 </span>入力時<span class="permalink"><a href="#on-input" aria-label="Permalink for 3.2.2 On Input" title="Permalink for 3.2.2 On Input"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/on-input.html">Understanding On Input</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#on-input">How to Meet On Input</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の設定を変更することが、<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">コンテキストの変化</a>を自動的に引き起こさない。ただし、利用者が使用する前にその挙動を知らせてある場合を除く。
-   </p>
+   <p><a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-10" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>の設定を変更することが、<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-change-of-context-2" title="大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。">コンテキストの変化</a>を自動的に引き起こさない。ただし、利用者が使用する前にその挙動を知らせてある場合を除く。</p>
    
 </section>
-
-                <section class="sc" id="consistent-navigation">
+            
+            <section class="guideline" id="consistent-navigation"><div class="header-wrapper"><h4 id="x3-2-3-consistent-navigation"><bdi class="secno">達成基準 3.2.3</bdi> 一貫したナビゲーション</h4><a class="self-link" href="#consistent-navigation" aria-label="Permalink for Section 3.2.3"></a></div>
    
-   <h4 id="x3-2-3-consistent-navigation"><span class="secno">達成基準 3.2.3 </span>一貫したナビゲーション<span class="permalink"><a href="#consistent-navigation" aria-label="Permalink for 3.2.3 Consistent Navigation" title="Permalink for 3.2.3 Consistent Navigation"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html">Understanding Consistent Navigation</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#consistent-navigation">How to Meet Consistent Navigation</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn">ウェブページ一式</a>の中にある複数の<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>上で繰り返されているナビゲーションのメカニズムは、繰り返されるたびに<a href="#dfn-same-relative-order" class="internalDFN" data-link-type="dfn">相対的に同じ順序</a>で出現する。ただし、利用者が変更した場合は除く。
-   </p>
+   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-3" title="共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作されたウェブページの集合。">ウェブページ一式</a>の中にある複数の<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-8" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>上で繰り返されているナビゲーションのメカニズムは、繰り返されるたびに<a href="#dfn-same-relative-order" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-same-relative-order-1" title="他の項目との相対位置が同じ。">相対的に同じ順序</a>で出現する。ただし、利用者が変更した場合は除く。</p>
    
 </section>
-
-                <section class="sc" id="consistent-identification">
+            
+            <section class="guideline" id="consistent-identification"><div class="header-wrapper"><h4 id="x3-2-4-consistent-identification"><bdi class="secno">達成基準 3.2.4</bdi> 一貫した識別性</h4><a class="self-link" href="#consistent-identification" aria-label="Permalink for Section 3.2.4"></a></div>
    
-   <h4 id="x3-2-4-consistent-identification"><span class="secno">達成基準 3.2.4 </span>一貫した識別性<span class="permalink"><a href="#consistent-identification" aria-label="Permalink for 3.2.4 Consistent Identification" title="Permalink for 3.2.4 Consistent Identification"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html">Understanding Consistent Identification</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#consistent-identification">How to Meet Consistent Identification</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn">ウェブページ一式</a>の中で<a href="#dfn-same-functionality" class="internalDFN" data-link-type="dfn">同じ機能</a>を有するコンポーネントは、一貫して識別できる。
-   </p>
+   <p><a href="#dfn-set-of-web-pages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-set-of-web-pages-4" title="共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作されたウェブページの集合。">ウェブページ一式</a>の中で<a href="#dfn-same-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-same-functionality-1" title="使うと同じ結果が得られること。">同じ機能</a>を有するコンポーネントは、一貫して識別できる。</p>
    
 </section>
-
-                <section class="sc" id="change-on-request">
+            
+            <section class="guideline" id="change-on-request"><div class="header-wrapper"><h4 id="x3-2-5-change-on-request"><bdi class="secno">達成基準 3.2.5</bdi> 要求による変化</h4><a class="self-link" href="#change-on-request" aria-label="Permalink for Section 3.2.5"></a></div>
    
-   <h4 id="x3-2-5-change-on-request"><span class="secno">達成基準 3.2.5 </span>要求による変化<span class="permalink"><a href="#change-on-request" aria-label="Permalink for 3.2.5 Change on Request" title="Permalink for 3.2.5 Change on Request"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/change-on-request.html">Understanding Change on Request</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#change-on-request">How to Meet Change on Request</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">コンテキストの変化</a>は利用者の要求によってだけ生じるか、又は、そのような変化を止める<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>が利用できる。
-   </p>
+   <p><a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-change-of-context-3" title="大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。">コンテキストの変化</a>は利用者の要求によってだけ生じるか、又は、そのような変化を止める<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-11" title="結果を得るためのプロセス又は手法。">メカニズム</a>が利用できる。</p>
    
 </section>
-
-            </section>
-
-            <section class="guideline" id="input-assistance">
-                <h3 id="x3-3-input-assistance"><span class="secno">ガイドライン 3.3 </span>入力支援<span class="permalink"><a href="#input-assistance" aria-label="Permalink for 3.3 Input Assistance" title="Permalink for 3.3 Input Assistance"><span>§</span></a></span></h3>
-
-<div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/input-assistance.html">Understanding Input Assistance</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#input-assistance">How to Meet Input Assistance</a></div>
-
-                <p>利用者の間違いを防ぎ、修正を支援すること。</p>
-
-                <section class="sc" id="error-identification">
+            				
+            
+         </section>
+         
+         
+         <section class="guideline" id="input-assistance"><div class="header-wrapper"><h3 id="x3-3-input-assistance"><bdi class="secno">ガイドライン 3.3</bdi> 入力支援</h3><a class="self-link" href="#input-assistance" aria-label="Permalink for Section 3.3"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/input-assistance.html">Understanding Input Assistance</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#input-assistance">How to Meet Input Assistance</a></div><p>利用者の間違いを防ぎ、修正を支援すること。</p>
+            
+            <section class="guideline" id="error-identification"><div class="header-wrapper"><h4 id="x3-3-1-error-identification"><bdi class="secno">達成基準 3.3.1</bdi> エラーの特定</h4><a class="self-link" href="#error-identification" aria-label="Permalink for Section 3.3.1"></a></div>
    
-   <h4 id="x3-3-1-error-identification"><span class="secno">達成基準 3.3.1 </span>エラーの特定<span class="permalink"><a href="#error-identification" aria-label="Permalink for 3.3.1 Error Identification" title="Permalink for 3.3.1 Error Identification"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html">Understanding Error Identification</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-identification">How to Meet Error Identification</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p><a href="#dfn-input-error" class="internalDFN" data-link-type="dfn">入力エラー</a>が自動的に検出された場合は、エラーとなっている箇所が特定され、そのエラーが利用者にテキストで説明される。
-   </p>
+   <p><a href="#dfn-input-error" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-input-error-2" title="利用者が入力した情報で、受け付けられないもの。">入力エラー</a>が自動的に検出された場合は、エラーとなっている箇所が特定され、そのエラーが利用者にテキストで説明される。</p>
    
 </section>
-
-                <section class="sc" id="labels-or-instructions">
+            
+            <section class="guideline" id="labels-or-instructions"><div class="header-wrapper"><h4 id="x3-3-2-labels-or-instructions"><bdi class="secno">達成基準 3.3.2</bdi> ラベル又は説明</h4><a class="self-link" href="#labels-or-instructions" aria-label="Permalink for Section 3.3.2"></a></div>
    
-   <h4 id="x3-3-2-labels-or-instructions"><span class="secno">達成基準 3.3.2 </span>ラベル又は説明<span class="permalink"><a href="#labels-or-instructions" aria-label="Permalink for 3.3.2 Labels or Instructions" title="Permalink for 3.3.2 Labels or Instructions"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html">Understanding Labels or Instructions</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#labels-or-instructions">How to Meet Labels or Instructions</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>コンテンツが利用者の入力を要求する場合は、<a href="#dfn-labels" class="internalDFN" data-link-type="dfn">ラベル</a>又は説明文が提供されている。
-   </p>
+   <p>コンテンツが利用者の入力を要求する場合は、<a href="#dfn-labels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-labels-3" title="テキスト、又はテキストによる代替を伴うコンポーネントで、ウェブコンテンツ内のコンポーネントを識別するために利用者に提示されているもの。">ラベル</a>又は説明文が提供されている。</p>
    
 </section>
-
-                <section class="sc" id="error-suggestion">
+            
+            <section class="guideline" id="error-suggestion"><div class="header-wrapper"><h4 id="x3-3-3-error-suggestion"><bdi class="secno">達成基準 3.3.3</bdi> エラー修正の提案</h4><a class="self-link" href="#error-suggestion" aria-label="Permalink for Section 3.3.3"></a></div>
    
-   <h4 id="x3-3-3-error-suggestion"><span class="secno">達成基準 3.3.3 </span>エラー修正の提案<span class="permalink"><a href="#error-suggestion" aria-label="Permalink for 3.3.3 Error Suggestion" title="Permalink for 3.3.3 Error Suggestion"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion.html">Understanding Error Suggestion</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-suggestion">How to Meet Error Suggestion</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p><a href="#dfn-input-error" class="internalDFN" data-link-type="dfn">入力エラー</a>が自動的に検出され、修正方法を提案できる場合、その提案が利用者に提示される。ただし、セキュリティ又はコンテンツの目的を損なう場合は除く。
-   </p>
+   <p><a href="#dfn-input-error" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-input-error-3" title="利用者が入力した情報で、受け付けられないもの。">入力エラー</a>が自動的に検出され、修正方法を提案できる場合、その提案が利用者に提示される。ただし、セキュリティ又はコンテンツの目的を損なう場合は除く。</p>
    
 </section>
-
-                <section class="sc" id="error-prevention-legal-financial-data">
+            
+            <section class="guideline" id="error-prevention-legal-financial-data"><div class="header-wrapper"><h4 id="x3-3-4-error-prevention-legal-financial-data"><bdi class="secno">達成基準 3.3.4</bdi> 誤り防止 (法的、金融、データ)</h4><a class="self-link" href="#error-prevention-legal-financial-data" aria-label="Permalink for Section 3.3.4"></a></div>
    
-   <h4 id="x3-3-4-error-prevention-legal-financial-data"><span class="secno">達成基準 3.3.4 </span>誤り防止 (法的、金融、データ)<span class="permalink"><a href="#error-prevention-legal-financial-data" aria-label="Permalink for 3.3.4 Error Prevention (Legal, Financial, Data)" title="Permalink for 3.3.4 Error Prevention (Legal, Financial, Data)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html">Understanding Error Prevention (Legal, Financial, Data)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-prevention-legal-financial-data">How to Meet Error Prevention (Legal, Financial, Data)</a></div><p class="conformance-level">(レベル AA)</p>
    
-   <p>利用者にとって<a href="#dfn-legal-commitments" class="internalDFN" data-link-type="dfn">法律行為</a>もしくは金融取引が生じる、<a href="#dfn-user-controllable" class="internalDFN" data-link-type="dfn">利用者が制御可能な</a>データストレージシステム上のデータを変更もしくは削除する、又は利用者が試験の解答を送信する<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>では、次に挙げる事項のうち、少なくとも一つを満たしている
-   </p>
+   <p>利用者にとって<a href="#dfn-legal-commitments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-legal-commitments-1" title="法的に拘束力のある義務あるいは利益が発生する取引。">法律行為</a>もしくは金融取引が生じる、<a href="#dfn-user-controllable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-controllable-1" title="利用者によってアクセスされることを意図したデータ。">利用者が制御可能な</a>データストレージシステム上のデータを変更もしくは削除する、又は利用者が試験の解答を送信する<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-9" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>では、次に挙げる事項のうち、少なくとも一つを満たしている</p>
 
    <dl>
      <dt>取消</dt><dd>送信を取り消すことができる。</dd>
      <dt>チェック</dt><dd>利用者が入力したデータの入力エラーがチェックされ、利用者には修正する機会が提供される。</dd>
-     <dt>確認</dt><dd>送信を完了する前に、利用者が情報の見直し、確認及び修正をするメカニズムが利用できる。</dd>
+     <dt>確認 </dt><dd>送信を完了する前に、利用者が情報の見直し、確認及び修正をするメカニズムが利用できる。</dd>
   </dl>
   
 </section>
 
-
-                <section class="sc" id="help">
+            
+            <section class="guideline" id="help"><div class="header-wrapper"><h4 id="x3-3-5-help"><bdi class="secno">達成基準 3.3.5</bdi> ヘルプ</h4><a class="self-link" href="#help" aria-label="Permalink for Section 3.3.5"></a></div>
    
-   <h4 id="x3-3-5-help"><span class="secno">達成基準 3.3.5 </span>ヘルプ<span class="permalink"><a href="#help" aria-label="Permalink for 3.3.5 Help" title="Permalink for 3.3.5 Help"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/help.html">Understanding Help</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#help">How to Meet Help</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p><a href="#dfn-context-sensitive-help" class="internalDFN" data-link-type="dfn">コンテキストに応じたヘルプ</a>が利用できる。
-   </p>
+   <p><a href="#dfn-context-sensitive-help" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-context-sensitive-help-1" title="そのとき実行されている機能に関する情報を提供するヘルプのテキスト。">コンテキストに応じたヘルプ</a>が利用できる。</p>
    
 </section>
-
-                <section class="sc" id="error-prevention-all">
+            
+            <section class="guideline" id="error-prevention-all"><div class="header-wrapper"><h4 id="x3-3-6-error-prevention-all"><bdi class="secno">達成基準 3.3.6</bdi> 誤り防止 (すべて)</h4><a class="self-link" href="#error-prevention-all" aria-label="Permalink for Section 3.3.6"></a></div>
    
-   <h4 id="x3-3-6-error-prevention-all"><span class="secno">達成基準 3.3.6 </span>誤り防止 (すべて)<span class="permalink"><a href="#error-prevention-all" aria-label="Permalink for 3.3.6 Error Prevention (All)" title="Permalink for 3.3.6 Error Prevention (All)"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-all.html">Understanding Error Prevention (All)</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#error-prevention-all">How to Meet Error Prevention (All)</a></div><p class="conformance-level">(レベル AAA)</p>
    
-   <p>利用者に情報の送信を要求する<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>では、次に挙げる事項のうち、少なくとも一つを満たしている
-   </p>
+   <p>利用者に情報の送信を要求する<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-10" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>では、次に挙げる事項のうち、少なくとも一つを満たしている</p>
    
    <dl>
      <dt>取消</dt><dd>送信を取り消すことができる。</dd>
      <dt>チェック</dt><dd>利用者が入力したデータの入力エラーがチェックされ、利用者には修正する機会が提供される。</dd>
-     <dt>確認</dt><dd>送信を完了する前に、利用者が情報の見直し、確認及び修正をするメカニズムが利用できる。</dd>
-  </dl><!--OddPage-->
+     <dt>確認 </dt><dd>送信を完了する前に、利用者が情報の見直し、確認及び修正をするメカニズムが利用できる。</dd>
+  </dl>
 
 </section>
 
-
-            </section>
-
-        </section>
-        <section class="principle" id="robust">
-            <h2 id="x4-robust"><span class="secno">4. </span> 堅牢 (robust) <span class="permalink"><a href="#robust" aria-label="Permalink for 4.  Robust " title="Permalink for 4.  Robust "><span>§</span></a></span></h2>
-            <p>コンテンツは、支援技術を含む様々なユーザエージェントが確実に解釈できるように十分に堅牢 (robust) でなければならない。</p>
-
-            <section class="guideline" id="compatible">
-                <h3 id="x4-1-compatible"><span class="secno">ガイドライン 4.1 </span>互換性<span class="permalink"><a href="#compatible" aria-label="Permalink for 4.1 Compatible" title="Permalink for 4.1 Compatible"><span>§</span></a></span></h3>
-
-<div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/compatible.html">Understanding Compatible</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#compatible">How to Meet Compatible</a></div>
-
-                <p>現在及び将来の、支援技術を含むユーザエージェントとの互換性を最大化すること。</p>
-
-                <section class="sc" id="parsing">
+            
+            
+         </section>
+         
+         
+      </section>
+      
+      <section class="principle" id="robust"><div class="header-wrapper"><h2 id="x4-robust"><bdi class="secno">4. </bdi>堅牢 (robust)</h2><a class="self-link" href="#robust" aria-label="Permalink for Section 4."></a></div>
+         
+         
+         
+         <p>コンテンツは、支援技術を含む様々なユーザエージェントが確実に解釈できるように十分に堅牢 (robust) でなければならない。</p>
+         
+         
+         <section class="guideline" id="compatible"><div class="header-wrapper"><h3 id="x4-1-compatible"><bdi class="secno">ガイドライン 4.1</bdi> 互換性</h3><a class="self-link" href="#compatible" aria-label="Permalink for Section 4.1"></a></div>
+            
+            
+            
+            <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/compatible.html">Understanding Compatible</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#compatible">How to Meet Compatible</a></div><p>現在及び将来の、支援技術を含むユーザエージェントとの互換性を最大化すること。</p>
+            
+            <section class="guideline" id="parsing"><div class="header-wrapper"><h4 id="x4-1-1-parsing"><bdi class="secno">達成基準 4.1.1</bdi> 構文解析</h4><a class="self-link" href="#parsing" aria-label="Permalink for Section 4.1.1"></a></div>
    
-   <h4 id="x4-1-1-parsing"><span class="secno">達成基準 4.1.1 </span>構文解析<span class="permalink"><a href="#parsing" aria-label="Permalink for 4.1.1 Parsing" title="Permalink for 4.1.1 Parsing"><span>§</span></a></span></h4>
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html">Understanding Parsing</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#parsing">How to Meet Parsing</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>マークアップ言語を用いて実装されているコンテンツにおいては、要素には完全な開始タグ及び終了タグがあり、要素は仕様に準じて入れ子になっていて、要素には重複した属性がなく、どの ID も一意的である。ただし、仕様で認められているものを除く。
-   </p>
+   <p>マークアップ言語を用いて実装されているコンテンツにおいては、要素には完全な開始タグ及び終了タグがあり、要素は仕様に準じて入れ子になっていて、要素には重複した属性がなく、どの ID も一意的である。ただし、仕様で認められているものを除く。</p>
    
    <div class="note" role="note" id="issue-container-generatedID-26"><div role="heading" class="note-title marker" id="h-note-26" aria-level="5"><span>注記</span></div><p class="">HTML 又は XML を使用するすべてのコンテンツでは、この達成基準は常に満たされているとみなすべきである。</p></div>
-   
-  <div class="note" role="note" id="issue-container-generatedID-27"><div role="heading" class="note-title marker" id="h-note-27" aria-level="5"><span>注記</span></div><div class="">
-      <p>この基準が作成されて以降、HTML Living Standard は、ユーザーエージェントが不完全なタグ、不正な要素のネスト、重複した属性、および一意でない ID をどのように処理しなければならないかを規定する明確な要件を採用した。 [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>]</p>
+
+   <div class="note" role="note" id="issue-container-generatedID-27"><div role="heading" class="note-title marker" id="h-note-27" aria-level="5"><span>注記</span></div><div class=""><p>この基準が作成されて以降、HTML Living Standard は、ユーザーエージェントが不完全なタグ、不正な要素のネスト、重複した属性、および一意でない ID をどのように処理しなければならないかを規定する明確な要件を採用した。[<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>]</p>
       
       <p>HTML Standard では、これらのケースのいくつかをコンテンツ制作者に対する不適合として扱うが、仕様ではユーザエージェントがこれらのケースの一貫した処理をサポートすることを要求しているため、この達成基準の説明にある「仕様で認められているもの」とみなせる。実際には、この基準自体は、もはや障害のある人々に何の利益ももたらさない。</p>
       
       <p>不適切に入れ子にされた要素による役割の欠落、ID の重複による不正な状態や名前などの問題は、別の達成基準で扱われており、4.1.1 の問題としてではなく、それらの基準に基づいて報告されるべきである。</p>
    </div></div>
-
-</section>
-
-                <section class="sc" id="name-role-value">
    
-   <h4 id="x4-1-2-name-role-value"><span class="secno">達成基準 4.1.2 </span>名前 (name)・役割 (role)・値 (value)<span class="permalink"><a href="#name-role-value" aria-label="Permalink for 4.1.2 Name, Role, Value" title="Permalink for 4.1.2 Name, Role, Value"><span>§</span></a></span></h4>
+</section>
+            
+            <section class="guideline" id="name-role-value"><div class="header-wrapper"><h4 id="x4-1-2-name-role-value"><bdi class="secno">達成基準 4.1.2</bdi> 名前 (name)・役割 (role)・値 (value)</h4><a class="self-link" href="#name-role-value" aria-label="Permalink for Section 4.1.2"></a></div>
+   
+   
    
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html">Understanding Name, Role, Value</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#name-role-value">How to Meet Name, Role, Value</a></div><p class="conformance-level">(レベル A)</p>
    
-   <p>すべての<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> 及び<a href="#dfn-role" class="internalDFN" data-link-type="dfn">役割 (role)</a> は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" class="internalDFN" data-link-type="dfn">プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。
-   </p>
+   <p>すべての<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-11" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a> (フォームを構成する要素、リンク、スクリプトが生成するコンポーネントなど) では、<a href="#dfn-name" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-name-3" title="ソフトウェアが、ウェブコンテンツのコンポーネントを利用者に識別させることができるテキスト。">名前 (name)</a> 及び<a href="#dfn-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-role-1" title="ソフトウェアがウェブコンテンツ内のコンポーネントの機能の識別を可能にするためのテキスト又は番号。">役割 (role)</a> は、<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-7" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>である。又、状態、プロパティ、利用者が設定可能な値は<a href="#dfn-programmatically-set" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-set-1" title="支援技術を含むユーザエージェントがサポートしている手法を用いて、ソフトウェアによって設定されること。">プログラムによる設定</a>が可能である。そして、<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-3" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-1" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>が、これらの項目に対する変更通知を利用できる。</p>
    
-   <div class="note" id="issue-container-generatedID-27"><div role="heading" class="note-title marker" id="h-note-27" aria-level="5"><span>注記</span></div><p class="">この達成基準は、主に独自のユーザインタフェース コンポーネントを開発、又はスクリプトで実装するコンテンツ制作者に向けたものである。例えば、標準的な HTML のコントロールを仕様に沿って使用していれば、既にこの達成基準を満たしていることになる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-28"><div role="heading" class="note-title marker" id="h-note-28" aria-level="5"><span>注記</span></div><p class="">この達成基準は、主に独自のユーザインタフェース コンポーネントを開発、又はスクリプトで実装するコンテンツ制作者に向けたものである。例えば、標準的な HTML のコントロールを仕様に沿って使用していれば、既にこの達成基準を満たしていることになる。</p></div>
    
 </section>
-                
-                <section class="sc new" id="status-messages">
+            
+            <section class="guideline" id="status-messages"><div class="header-wrapper"><h4 id="x4-1-3-status-messages"><bdi class="secno">達成基準 4.1.3</bdi> ステータスメッセージ</h4><a class="self-link" href="#status-messages" aria-label="Permalink for Section 4.1.3"></a></div>
    					
-   <h4 id="x4-1-3-status-messages"><span class="secno">達成基準 4.1.3 </span>ステータスメッセージ<span class="permalink"><a href="#status-messages" aria-label="Permalink for 4.1.3 Status Messages" title="Permalink for 4.1.3 Status Messages"><span>§</span></a></span></h4>
+   
    					
    <div class="doclinks"><a href="https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html">Understanding Status Messages</a> <span class="screenreader">|</span> <br><a href="https://www.w3.org/WAI/WCAG21/quickref/#status-messages">How to Meet Status Messages</a></div><p class="conformance-level">(レベル AA)</p>
    					
-   
-	
-   <p>マークアップ言語を使って実装されたコンテンツでは、<a href="#dfn-status-messages" class="internalDFN" data-link-type="dfn">ステータスメッセージ</a>は、<a href="#dfn-role" class="internalDFN" data-link-type="dfn">役割 (role)</a> 又はプロパティを通して<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>であり、フォーカスを受けとらなくても<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>によって利用者に提示することができる。</p><!--OddPage-->
+   <p>マークアップ言語を使って実装されたコンテンツでは、<a href="#dfn-status-messages" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-status-messages-1" title="コンテンツ内の変化であって、コンテキストの変化ではなく、かつ、アクションの成否もしくは結果、アプリケーションの処理待ち状態、プロセスの進捗、又はエラーの存在に関する情報を利用者に提供するもの。">ステータスメッセージ</a>は、<a href="#dfn-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-role-2" title="ソフトウェアがウェブコンテンツ内のコンポーネントの機能の識別を可能にするためのテキスト又は番号。">役割 (role)</a> 又はプロパティを通して<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-8" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>であり、フォーカスを受けとらなくても<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-4" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>によって利用者に提示することができる。</p>
    				
 </section>
 
-                
-           </section>
-
-        </section>
-        <section id="conformance">
-            <h2 id="x5-conformance"><span class="secno">5. </span>適合<span class="permalink"><a href="#conformance" aria-label="Permalink for 5. Conformance" title="Permalink for 5. Conformance"><span>§</span></a></span></h2>
-            <p>この節では、WCAG 2.1 への<a href="#dfn-conform" class="internalDFN" data-link-type="dfn">適合</a>に関する要件を列挙する。又、任意である適合表明の作成方法に関する情報も提供する。最後に、<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポーテッド</a>とは何かを説明する。なぜならば、適合においては技術のアクセシビリティ サポーテッドな使用方法だけに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存する</a>ことができるからである。アクセシビリティ サポーテッドという概念については、<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conformance</a> でさらに詳しい説明がある。</p>
-        	
-        	<section id="interpreting-normative-requirements">
-        		<h3 id="x5-1-interpreting-normative-requirements"><span class="secno">5.1 </span>規定要件の解釈<span class="permalink"><a href="#interpreting-normative-requirements" aria-label="Permalink for 5.1 Interpreting Normative Requirements" title="Permalink for 5.1 Interpreting Normative Requirements"><span>§</span></a></span></h3>
-        		
-        		<p>WCAG 2.1 の主要な内容は<a href="#dfn-normative" class="internalDFN" data-link-type="dfn">規定</a>であり適合表明を満たす要件を定義する。入門用資料、附録、「規定ではない」と示された節、図、事例と注記は<a href="#dfn-informative" class="internalDFN" data-link-type="dfn">参考情報</a> (規定ではない)である。規定ではない資料は、ガイドラインの解釈を手助けする参考情報を提供するが適合表明を満たす要件は提示しない。</p>
-        		<p>キーワード「<em class="rfc2119" title="MAY">してもよい(MAY)</em>」、「<em class="rfc2119" title="MUST">しなければならない(MUST)</em>」、「<em class="rfc2119" title="MUST NOT">してはならない(MUST NOT)</em>」、「<em class="rfc2119" title="NOT RECOMMENDED">推奨されない(NOT RECOMENDED)</em>」、「<em class="rfc2119" title="RECOMMENDED">推奨される(RECOMMENDED)</em>」、「<em class="rfc2119" title="SHOULD">すべきである(SHOULD)</em>」、及び「<em class="rfc2119" title="SHOULD NOT">しないほうがよい(SHOULD NOT)</em>」は、[<cite><a class="bibref" href="#bib-rfc2119">RFC2119</a></cite>]に述べられているように解釈される。</p>
-        	</section>
-
-            <section id="conformance-reqs">
-                <h3 id="x5-2-conformance-requirements"><span class="secno">5.2 </span>適合要件<span class="permalink"><a href="#conformance-reqs" aria-label="Permalink for 5.2 Conformance Requirements" title="Permalink for 5.2 Conformance Requirements"><span>§</span></a></span></h3>
-                <p>ウェブページが WCAG 2.1 に適合するためには、以下に挙げるすべての適合要件を満たしていなければならない:</p>
-
-                <section id="cc1">
-                    <h4 id="x5-2-1-conformance-level"><span class="secno">5.2.1 </span>適合レベル<span class="permalink"><a href="#cc1" aria-label="Permalink for 5.2.1 Conformance Level" title="Permalink for 5.2.1 Conformance Level"><span>§</span></a></span></h4>
-                    <p>以下に挙げる適合レベルの一つを完全に満たしていること。</p>
-                    <ul>
-                        <li>レベル A (適合の最低レベル) で適合するには、<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>がレベル A 達成基準のすべてを<a href="#dfn-satisfies" class="internalDFN" data-link-type="dfn">満たす</a>か、又は<a href="#dfn-conforming-alternate-version" class="internalDFN" data-link-type="dfn">適合している代替版</a>を提供する。</li>
-                        <li>レベル AA で適合するには、ウェブページはレベル A 及びレベル AA 達成基準のすべてを満たすか、又はレベル AA に適合している代替版を提供する。</li>
-                        <li>レベル AAA で適合するには、ウェブページがレベル A、レベル AA、及びレベル AAA 達成基準のすべてを満たすか、又はレベル AAA に適合している代替版を提供する。</li>
-                    </ul>
-                    <div class="note" id="issue-container-generatedID-28"><div role="heading" class="note-title marker" id="h-note-28" aria-level="5"><span>注記</span></div><p class="">ウェブページは、記載したレベルでのみ WCAG 2.1 に適合できるが、コンテンツ制作者は、その適合レベルよりも高いレベルの達成基準の達成状況を (表明の中で) 示すことを推奨される。</p></div>
-                    <div class="note" id="issue-container-generatedID-29"><div role="heading" class="note-title marker" id="h-note-29" aria-level="5"><span>注記</span></div><p class="">コンテンツの中には、レベル AAA 達成基準のすべてを満たすことのできないものもあるため、サイト全体の一般的な方針としてレベル AAA での適合を要件とすることは推奨されない。</p></div>
-                </section>
-
-                <section id="cc2">
-                    <h4 id="x5-2-2-full-pages"><span class="secno">5.2.2 </span>ウェブページ全体<span class="permalink"><a href="#cc2" aria-label="Permalink for 5.2.2 Full pages" title="Permalink for 5.2.2 Full pages"><span>§</span></a></span></h4>
-                    <p><a href="#dfn-conform" class="internalDFN" data-link-type="dfn">適合</a> (及び適合レベル) は<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>全体に対するもののみであり、ウェブページの一部が除外されている場合には適合にならない。</p>
-                    <div class="note" id="issue-container-generatedID-30"><div role="heading" class="note-title marker" id="h-note-30" aria-level="5"><span>注記</span></div><p class="">適合の判断をするときに、例えば、詳細な説明又は映像の代替の提示のように、代替となるものがそのページから直接得られる場合は、ページのコンテンツの一部に対する代替コンテンツはそのページの一部であるとみなされる。</p></div>
-                    <div class="note" id="issue-container-generatedID-31"><div role="heading" class="note-title marker" id="h-note-31" aria-level="5"><span>注記</span></div><p class="">コンテンツ制作者が制御できないコンテンツがあるために適合できないウェブページについては、<a href="#conformance-partial">部分適合に関する記述</a>を行うことを検討するとよい。</p></div>
-                  <div class="note" id="issue-container-generatedID-32"><div role="heading" class="note-title marker" id="h-note-32" aria-level="5"><span>注記</span></div><p class="new">ウェブページ全体には、様々な画面サイズ向けに自動的に提示される個々のウェブページのバリエーションを含む (例: レスポンジブウェブページのバリエーション)。ウェブページ全体が適合するためには、個々のバリエーションが適合するか、適合する代替版が必要である。</p></div>
-                </section>
-
-                <section id="cc3">
-                    <h4 id="x5-2-3-complete-processes"><span class="secno">5.2.3 </span>プロセス全体<span class="permalink"><a href="#cc3" aria-label="Permalink for 5.2.3 Complete processes" title="Permalink for 5.2.3 Complete processes"><span>§</span></a></span></h4>
-                    <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>が<a href="#dfn-processes" class="internalDFN" data-link-type="dfn">プロセス</a>を提示する一連の流れのウェブページ群 (つまり、ある目的を達成するために完了させる必要のある一連の手順) に含まれる場合、そのプロセス中のすべてのウェブページが指定したレベル又はそれ以上のレベルで適合している (もし、プロセス中のウェブページが一つでも特定のレベル又はそれ以上のレベルに適合していない場合、そのレベルに適合できない)。</p>
-                    <p class="example">あるオンラインストアには、製品を選択して購入するための一連のウェブページがある。このプロセスに含まれるあるウェブページが適合するためには、最初から最後 (支払い) までのすべてのウェブページが適合していなければならない。</p>
-                </section>
-
-                <section id="cc4">
-                    <h4 id="x5-2-4-only-accessibility-supported-ways-of-using-technologies"><span class="secno">5.2.4 </span>技術のアクセシビリティ サポーテッドな使用方法だけ<span class="permalink"><a href="#cc4" aria-label="Permalink for 5.2.4 Only Accessibility-Supported Ways of Using Technologies" title="Permalink for 5.2.4 Only Accessibility-Supported Ways of Using Technologies"><span>§</span></a></span></h4>
-                    <p>達成基準を満たすために、用いる<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">技術</a>の<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポーテッド</a>な使用方法だけに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>している。アクセシビリティ サポーテッドではない方法で提供されている情報又は機能は、アクセシビリティ サポーテッドな方法でも利用できる(<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding accessibility support</a> を参照)。</p>
-                </section>
-
-                <section id="cc5">
-                    <h4 id="x5-2-5-non-interference"><span class="secno">5.2.5 </span>非干渉<span class="permalink"><a href="#cc5" aria-label="Permalink for 5.2.5 Non-Interference" title="Permalink for 5.2.5 Non-Interference"><span>§</span></a></span></h4>
-                    <p><a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">技術</a>が<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポーテッド</a>ではない方法で用いられている場合、又は適合しない方法で用いられている場合、利用者がウェブページの他の部分へアクセスすることを妨げていない。加えて、全体として<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>は、以下のそれぞれの条件の下で適合要件を満たしていること:</p>
-                    <ol>
-                        <li><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>していない技術がユーザエージェントで有効になっているとき</li>
-                        <li>依存していない技術がユーザエージェントで無効になっているとき、及び</li>
-                        <li>依存していない技術がユーザエージェントでサポートされていないとき</li>
-                    </ol>
-                    <p>さらに、適合するために依存していないコンテンツも含めて、ページ上のすべてのコンテンツには以下の達成基準が適用される。なぜならば、これらを満たしていないことにより、ページの利用を妨げる可能性があるためである。</p>
-                    <ul>
-                        <li><strong>1.4.2 - 音声の制御</strong>、</li>
-                        <li><strong>2.1.2 - キーボードトラップなし</strong>、</li>
-                        <li><strong>2.3.1 - 3 回の閃光、又は閾値以下</strong>、及び</li>
-                        <li><strong>2.2.2 - 一時停止、停止、非表示</strong></li>
-                    </ul>
-                    <div class="note" id="issue-container-generatedID-33"><div role="heading" class="note-title marker" id="h-note-33" aria-level="5"><span>注記</span></div><p class="">もし、あるページが適合できないならば (例えば、適合のテストページや事例のページの場合)、そのページを適合の範囲、あるいは、適合表明の範囲に含めることはできない。</p></div>
-                    <p>事例を含む、より詳細な情報は、<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conformance Requirements</a> を参照。</p>
-                </section>
+            
+            
+         </section>
+         
+         
+      </section>
+      
+      <section id="conformance"><div class="header-wrapper"><h2 id="x5-conformance"><bdi class="secno">5. </bdi>適合</h2><a class="self-link" href="#conformance" aria-label="Permalink for Section 5."></a></div>
+         
+         
+         
+         
+         <p>この節では、WCAG 2.1 への<a href="#dfn-conform" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-conform-1" title="与えられた規格、ガイドライン、又は仕様のすべての要件を満たすこと。">適合</a>に関する要件を列挙する。又、任意である適合表明の作成方法に関する情報も提供する。最後に、<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-supported-2" title="利用者の支援技術だけでなく、ブラウザ及びその他のユーザエージェントにあるアクセシビリティ機能でサポートされていること。">アクセシビリティ サポーテッド</a>とは何かを説明する。なぜならば、適合においては技術のアクセシビリティ サポーテッドな使用方法だけに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-1" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存する</a>ことができるからである。アクセシビリティ サポーテッドという概念については、<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance">Understanding Conformance</a> でさらに詳しい説明がある。</p>
+         	
+         	
+         <section id="interpreting-normative-requirements"><div class="header-wrapper"><h3 id="x5-1-interpreting-normative-requirements"><bdi class="secno">5.1 </bdi> 規定要件の解釈</h3><a class="self-link" href="#interpreting-normative-requirements" aria-label="Permalink for Section 5.1"></a></div>
+            		
+            
+            		
+            		
+            <p>WCAG 2.1 の主要な内容は<a href="#dfn-normative" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-normative-1" title="適合に必須なもの。">規定</a>であり適合表明を満たす要件を定義する。入門用資料、附録、「規定ではない」と示された節、図、事例と注記は<a href="#dfn-informative" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-informative-1" title="情報提供を目的としており、適合するために必須ではないもの。">参考情報</a> (規定ではない)である。規定ではない資料は、ガイドラインの解釈を手助けする参考情報を提供するが適合表明を満たす要件は提示しない。</p>
+            		
+            <p>キーワード「してもよい (<em class="rfc2119">MAY</em>) 」、「しなければならない (<em class="rfc2119">MUST</em>) 」、「してはならない (<em class="rfc2119">MUST NOT</em>) 」、「推奨されない (<em class="rfc2119">NOT RECOMENDED</em>) 」、「推奨される (<em class="rfc2119">RECOMMENDED</em>) 」、「すべきである(<em class="rfc2119">SHOULD</em>) 」、及び「しないほうがよい (<em class="rfc2119">SHOULD NOT</em>) 」は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>]に述べられているように解釈される。</p>
+            	
+         </section>
+         
+         
+         <section id="conformance-reqs"><div class="header-wrapper"><h3 id="x5-2-conformance-requirements"><bdi class="secno">5.2</bdi> 適合要件</h3><a class="self-link" href="#conformance-reqs" aria-label="Permalink for Section 5.2"></a></div>
+            
+            
+            
+            <p>ウェブページが WCAG 2.1 に適合するためには、以下に挙げるすべての適合要件を満たしていなければならない:</p>
+            
+            				
+            
+            
+            <section id="cc1"><div class="header-wrapper"><h4 id="x5-2-1-conformance-level"><bdi class="secno">5.2.1 </bdi>適合レベル</h4><a class="self-link" href="#cc1" aria-label="Permalink for Section 5.2.1"></a></div>
+               
+               
+               
+               <p>以下に挙げる適合レベルの一つを完全に満たしていること。</p>
+               
+               <ul>
+                  
+                  <li>レベル A (適合の最低レベル) で適合するには、<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-11" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>がレベル A 達成基準のすべてを<a href="#dfn-satisfies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-satisfies-1" title="ページに適用した際、その達成基準が &apos;false&apos; と判定されないこと。">満たす</a>か、又は<a href="#dfn-conforming-alternate-versions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-conforming-alternate-versions-1" title="以下の事項を満たす版のことを指す:">適合している代替版</a>を提供する。</li>
+                  
+                  <li>レベル AA で適合するには、ウェブページはレベル A 及びレベル AA 達成基準のすべてを満たすか、又はレベル AA に適合している代替版を提供する。</li>
+                  
+                  <li>レベル AAA で適合するには、ウェブページがレベル A、レベル AA、及びレベル AAA 達成基準のすべてを満たすか、又はレベル AAA に適合している代替版を提供する。</li>
+                  
+               </ul>
+               
+               <div class="note" role="note" id="issue-container-generatedID-29"><div role="heading" class="note-title marker" id="h-note-29" aria-level="5"><span>注記</span></div><p class="">ウェブページは、記載したレベルでのみ WCAG 2.1 に適合できるが、コンテンツ制作者は、その適合レベルよりも高いレベルの達成基準の達成状況を (表明の中で) 示すことを推奨される。</p></div>
+               
+               <div class="note" role="note" id="issue-container-generatedID-30"><div role="heading" class="note-title marker" id="h-note-30" aria-level="5"><span>注記</span></div><p class="">コンテンツの中には、レベル AAA 達成基準のすべてを満たすことのできないものもあるため、サイト全体の一般的な方針としてレベル AAA での適合を要件とすることは推奨されない。</p></div>
+               
             </section>
-
-            <section id="conformance-claims">
-                <h3 id="x5-3-conformance-claims-optional"><span class="secno">5.3 </span>適合表明 (任意) <span class="permalink"><a href="#conformance-claims" aria-label="Permalink for 5.3 Conformance Claims (Optional) " title="Permalink for 5.3 Conformance Claims (Optional) "><span>§</span></a></span></h3>
-                <p>適合は、<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>に対してのみ定義されている。しかし、適合表明は 1 ページ、一連のウェブページ群、又は複数の関連するウェブページに対して行ってもよい。</p>
-
-                <section id="conformance-required">
-                    <h4 id="x5-3-1-required-components-of-a-conformance-claim"><span class="secno">5.3.1 </span>適合表明の必須要素<span class="permalink"><a href="#conformance-required" aria-label="Permalink for 5.3.1 Required Components of a Conformance Claim" title="Permalink for 5.3.1 Required Components of a Conformance Claim"><span>§</span></a></span></h4>
-                    <p>適合表明は、<strong>必須ではない</strong>。コンテンツ制作者は、適合表明をしなくても、WCAG 2.1 に適合することができる。しかし、もし適合表明をする場合には、その適合表明には以下の情報が含まれてい<strong>なければならない</strong>:</p>
-                    <ol>
-                        <li>表明<strong>日</strong></li>
-                        <li><strong>ガイドライン名、バージョン、及び URI</strong> "Web Content Accessibility Guidelines 2.1 (<a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>)"</li>
-                        <li>満たしている<strong>適合レベル</strong>: (レベル A、AA、又は AAA)</li>
-                        <li>
-                            <p>対象となる<strong>ウェブページに関する簡潔な説明</strong>: 例えば、サブドメインも表明の対象に含まれているかどうかも含む、表明の対象となっている URI のリスト。</p>
-                            <div class="note" id="issue-container-generatedID-34"><div role="heading" class="note-title marker" id="h-note-34" aria-level="5"><span>注記</span></div><p class="">表明において、ウェブページはリストを用いて表してもよいし、すべての URI を含む表現を用いて表してもよい。</p></div>
-                            <div class="note" id="issue-container-generatedID-35"><div role="heading" class="note-title marker" id="h-note-35" aria-level="5"><span>注記</span></div><p class="">顧客がウェブサイト上でインストールするまで URI が存在しないウェブベースの製品がある。その場合、その製品はインストールされると適合した状態になる、といった記述をすることができる。</p></div>
-                        </li>
-                        <li><strong><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>している<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">ウェブコンテンツ技術</a></strong>のリスト</li>
-                    </ol>
-                    <div class="note" id="issue-container-generatedID-36"><div role="heading" class="note-title marker" id="h-note-36" aria-level="5"><span>注記</span></div><p class="">適合のロゴを使用するとその表明であるとみなされ、上記の適合表明の必須要素を明示しなければならない。</p></div>
-                </section>
-
-                <section id="conformance-optional">
-                    <h4 id="x5-3-2-optional-components-of-a-conformance-claim"><span class="secno">5.3.2 </span>適合表明の任意要素 <span class="permalink"><a href="#conformance-optional" aria-label="Permalink for 5.3.2 Optional Components of a Conformance Claim " title="Permalink for 5.3.2 Optional Components of a Conformance Claim "><span>§</span></a></span></h4>
-                    <p>上記の適合表明の必須要素に加えて、利用者のために追加で情報を提供することを検討する。追加する情報として推奨するものを以下に挙げる:</p>
-                    <ul>
-                        <li>表明した適合レベルよりも上の適合レベルで満たしている達成基準のリスト。この情報は、利用者が使用できる形式で提供すべきで、機械的に読み取れるメタデータが好ましい。</li>
-                        <li><em>使用しているが適合には<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>していない</em>技術のリスト。</li>
-                        <li>コンテンツを試験するのに用いた、支援技術を含むユーザエージェントのリスト。</li>
-                        <li class="new">機械可読メタデータで提供される、コンテンツのアクセシビリティ特性のリスト。</li>
-                        <li>アクセシビリティを向上させるために達成基準を超えて追加で施した措置に関する情報。</li>
-                        <li><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>している技術を示したリストの機械的に読み取れるメタデータ版。</li>
-                        <li>適合表明の機械的に読み取れるメタデータ版。</li>
-                    </ul>
-                    <div class="note" id="issue-container-generatedID-37"><div role="heading" class="note-title marker" id="h-note-37" aria-level="5"><span>注記</span></div><p class="">より多くの情報や適合表明の事例は、<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Conformance Claims</a> を参照。</p></div>
-                    <div class="note" id="issue-container-generatedID-38"><div role="heading" class="note-title marker" id="h-note-38" aria-level="5"><span>注記</span></div><p class="">適合表明内でのメタデータの使用に関する詳細な情報は、<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/appendixC">Understanding Metadata</a> を参照。</p></div>
-                </section>
+            
+            	
+            
+            	
+            <section id="cc2"><div class="header-wrapper"><h4 id="x5-2-2-full-pages"><bdi class="secno">5.2.2 </bdi>ウェブページ全体</h4><a class="self-link" href="#cc2" aria-label="Permalink for Section 5.2.2"></a></div>
+               
+               
+               
+               <p><a href="#dfn-conform" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-conform-2" title="与えられた規格、ガイドライン、又は仕様のすべての要件を満たすこと。">適合</a> (及び適合レベル) は<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-12" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>全体に対するもののみであり、ウェブページの一部が除外されている場合には適合にならない。</p>
+               
+               <div class="note" role="note" id="issue-container-generatedID-31"><div role="heading" class="note-title marker" id="h-note-31" aria-level="5"><span>注記</span></div><p class="">適合の判断をするときに、例えば、詳細な説明又は映像の代替の提示のように、代替となるものがそのページから直接得られる場合は、ページのコンテンツの一部に対する代替コンテンツはそのページの一部であるとみなされる。</p></div>
+               
+               <div class="note" role="note" id="issue-container-generatedID-32"><div role="heading" class="note-title marker" id="h-note-32" aria-level="5"><span>注記</span></div><p class="">コンテンツ制作者が制御できないコンテンツがあるために適合できないウェブページについては、<a href="#conformance-partial">部分適合に関する記述</a>を行うことを検討するとよい。</p></div>
+               
+               <div class="note" role="note" id="issue-container-generatedID-33"><div role="heading" class="note-title marker" id="h-note-33" aria-level="5"><span>注記</span></div><p class="">ウェブページ全体には、様々な画面サイズ向けに自動的に提示される個々のウェブページのバリエーションを含む (例: レスポンジブウェブページのバリエーション)。ウェブページ全体が適合するためには、個々のバリエーションが適合するか、適合する代替版が必要である。</p></div>
+               
             </section>
-
-            <section id="conformance-partial">
-                <h3 id="x5-4-statement-of-partial-conformance-third-party-content"><span class="secno">5.4 </span>部分適合に関する記述 － 第三者によるコンテンツ<span class="permalink"><a href="#conformance-partial" aria-label="Permalink for 5.4 Statement of Partial Conformance - Third Party Content" title="Permalink for 5.4 Statement of Partial Conformance - Third Party Content"><span>§</span></a></span></h3>
-                <p>場合によっては、制作後にコンテンツが追加されるようにウェブページが作成される。例えば、電子メールのプログラム、ブログ、利用者がコメントを追加できる記事、又は利用者がコンテンツを提供できるようなアプリケーションである。その他の例としては、複数の提供者から集めたコンテンツで構成されるポータルやニュースサイトのページや、又は動的に挿入される広告のように、他の情報源からその時々にコンテンツが自動的に挿入されるサイトが挙げられる。</p>
-                <p>これらの場合、最初に掲載した時点では、そのページにおける制御できないコンテンツがどのようなものになっていくか分からない。制御できないコンテンツが、制御できるコンテンツのアクセシビリティにも影響を及ぼす可能性があることに注意することが重要である。そのような場合、次の二つの方法から選択する:</p>
-                <ol>
-                    <li>
-                        <p>適合の判定は、分かる範囲で下すことができる。もしこの種のウェブページが監視されていて 2 営業日以内に修正される (適合していないコンテンツが削除されるか、適合するように修正される) ならば、外部から寄稿されたコンテンツにおける不具合のうち、発見後に修正又は削除できるものを除いて判定又は適合表明ができるので、そのページは適合している。適合していないコンテンツを監視及び修正できない場合は、適合表明を行うことはできない。</p>
-                        <p><strong>又は、</strong></p>
-                    </li>
-                    <li>
-                        <p>適合していないページが特定の部分を除けば適合できる場合、「部分適合に関する記述」ができる。そのような場合の記述は、「このページは適合していないが、制御されていない情報源に起因する以下の部分を除けば、WCAG 2.1 にレベル X で適合していることになる。」というような形式になる。さらに、部分適合の記述に記載される制御できないコンテンツについては、次の条件に当てはまる必要がある。</p>
-                        <ol>
-                            <li>コンテンツ制作者が制御できるコンテンツではない。</li>
-                            <li>利用者が識別できるように、記載されている (例えば、該当箇所が明確に示されない限り、「私たちが制御できない部分すべて」という記載をすることはできない)。</li>
-                        </ol>
-                    </li>
-                </ol>
+            
+            	
+            
+            	
+            <section id="cc3"><div class="header-wrapper"><h4 id="x5-2-3-complete-processes"><bdi class="secno">5.2.3 </bdi>プロセス全体</h4><a class="self-link" href="#cc3" aria-label="Permalink for Section 5.2.3"></a></div>
+               
+               
+               
+               <p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-13" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>が<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-2" title="ある活動を完了させるために必要な利用者の一連の動作。">プロセス</a>を提示する一連の流れのウェブページ群 (つまり、ある目的を達成するために完了させる必要のある一連の手順) に含まれる場合、そのプロセス中のすべてのウェブページが指定したレベル又はそれ以上のレベルで適合している (もし、プロセス中のウェブページが一つでも特定のレベル又はそれ以上のレベルに適合していない場合、そのレベルに適合できない)。</p>
+               
+               <p class="example">あるオンラインストアには、製品を選択して購入するための一連のウェブページがある。このプロセスに含まれるあるウェブページが適合するためには、最初から最後 (支払い) までのすべてのウェブページが適合していなければならない。</p>
+               
             </section>
-
-            <section id="conformance-partial-lang">
-                <h3 id="x5-5-statement-of-partial-conformance-language"><span class="secno">5.5 </span>部分適合に関する記述 － 言語<span class="permalink"><a href="#conformance-partial-lang" aria-label="Permalink for 5.5 Statement of Partial Conformance - Language" title="Permalink for 5.5 Statement of Partial Conformance - Language"><span>§</span></a></span></h3>
-                <p>ページが適合していないが、そのページ上で用いられている (すべての) 言語において<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポート</a>があれば適合するような場合には、「言語による部分適合に関する記述」ができる。そのような場合の記述形式は、「このページは適合していないが、もし以下の言語においてアクセシビリティ サポートがあれば、WCAG 2.1 にレベル X で適合していることになる。」というようになる。</p><!--OddPage-->
+            
+            	
+            
+            	
+            <section id="cc4"><div class="header-wrapper"><h4 id="x5-2-4-only-accessibility-supported-ways-of-using-technologies"><bdi class="secno">5.2.4 </bdi>技術のアクセシビリティ サポーテッドな使用方法だけ</h4><a class="self-link" href="#cc4" aria-label="Permalink for Section 5.2.4"></a></div>
+               
+               
+               
+               
+               <p>達成基準を満たすために、用いる<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-technologies-1" title="ユーザエージェントがどのようにレンダリング、再生、又は実行するかを符号化するメカニズム。">技術</a>の<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-supported-3" title="利用者の支援技術だけでなく、ブラウザ及びその他のユーザエージェントにあるアクセシビリティ機能でサポートされていること。">アクセシビリティ サポーテッド</a>な使用方法だけに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-2" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>している。アクセシビリティ サポーテッドではない方法で提供されている情報又は機能は、アクセシビリティ サポーテッドな方法でも利用できる(<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#accessibility-support">Understanding accessibility support</a> を参照)。</p>
+               
+               
             </section>
-
-        </section>
-        <section id="glossary">
-            <h2 id="x6-glossary"><span class="secno">6. </span>用語集<span class="permalink"><a href="#glossary" aria-label="Permalink for 6. Glossary" title="Permalink for 6. Glossary"><span>§</span></a></span></h2>
-            <dl id="terms">
-
-                <dt><dfn data-lt="abbreviations|abbreviation" data-dfn-type="dfn" id="dfn-abbreviations">略語 (abbreviation)</dfn></dt>
-<dd>
+            
+            	
+            
+            	
+            <section id="cc5"><div class="header-wrapper"><h4 id="x5-2-5-non-interference"><bdi class="secno">5.2.5 </bdi>非干渉</h4><a class="self-link" href="#cc5" aria-label="Permalink for Section 5.2.5"></a></div>
+               
+               
+               
+               <p><a href="#dfn-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-technologies-2" title="ユーザエージェントがどのようにレンダリング、再生、又は実行するかを符号化するメカニズム。">技術</a>が<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-supported-4" title="利用者の支援技術だけでなく、ブラウザ及びその他のユーザエージェントにあるアクセシビリティ機能でサポートされていること。">アクセシビリティ サポーテッド</a>ではない方法で用いられている場合、又は適合しない方法で用いられている場合、利用者がウェブページの他の部分へアクセスすることを妨げていない。加えて、全体として<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-14" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>は、以下のそれぞれの条件の下で適合要件を満たしていること:</p>
+               
+               <ol>
+                  
+                  <li><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-3" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>していない技術がユーザエージェントで有効になっているとき</li>
+                  
+                  <li>依存していない技術がユーザエージェントで無効になっているとき、及び</li>
+                  
+                  <li>依存していない技術がユーザエージェントでサポートされていないとき</li>
+                  
+               </ol>
+               
+               <p>さらに、適合するために依存していないコンテンツも含めて、ページ上のすべてのコンテンツには以下の達成基準が適用される。なぜならば、これらを満たしていないことにより、ページの利用を妨げる可能性があるためである。</p>
+               
+               <ul>
+                  
+                  <li><strong>1.4.2 - 音声の制御</strong>、</li>
+                  
+                  <li><strong>2.1.2 - キーボードトラップなし</strong>、</li>
+                  
+                  <li><strong>2.3.1 - 3 回の閃光、又は閾値以下</strong>、及び</li>
+                  
+                  <li><strong>2.2.2 - 一時停止、停止、非表示</strong></li>
+                  
+               </ul>
+               
+               <div class="note" role="note" id="issue-container-generatedID-34"><div role="heading" class="note-title marker" id="h-note-34" aria-level="5"><span>注記</span></div><p class="">もし、あるページが適合できないならば (例えば、適合のテストページや事例のページの場合)、そのページを適合の範囲、あるいは、適合表明の範囲に含めることはできない。</p></div>
+               
+               	
+               <p>事例を含む、より詳細な情報は、<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#conformance-requirements">Understanding Conformance Requirements</a> を参照。</p>
+               
+               
+            </section>
+            
+         </section>
+         
+         
+         <section id="conformance-claims"><div class="header-wrapper"><h3 id="x5-3-conformance-claims-optional"><bdi class="secno">5.3 </bdi>適合表明 (任意)</h3><a class="self-link" href="#conformance-claims" aria-label="Permalink for Section 5.3"></a></div>
+            
+            
+            
+            <p>適合は、<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-15" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>に対してのみ定義されている。しかし、適合表明は 1 ページ、一連のウェブページ群、又は複数の関連するウェブページに対して行ってもよい。</p>
+            
+            
+            <section id="conformance-required"><div class="header-wrapper"><h4 id="x5-3-1-required-components-of-a-conformance-claim"><bdi class="secno">5.3.1</bdi> 適合表明の必須要素</h4><a class="self-link" href="#conformance-required" aria-label="Permalink for Section 5.3.1"></a></div>
+               
+               
+               
+               <p>適合表明は、<strong>必須ではない</strong>。コンテンツ制作者は、適合表明をしなくても、WCAG 2.1 に適合することができる。しかし、もし適合表明をする場合には、その適合表明には以下の情報が含まれてい<strong>なければならない</strong>:</p>
+               
+               <ol>
+                  
+                  <li>表明<strong>日</strong></li>
+                  
+                  <li><strong>ガイドライン名、バージョン、及び URI</strong> "Web Content Accessibility Guidelines 2.1 (<a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>)"</li>
+                  
+                  <li>満たしている<strong>適合レベル</strong>: (レベル A、AA、又は AAA)</li>
+                  
+                  <li><p>対象となる<strong>ウェブページに関する簡潔な説明</strong>: 例えば、サブドメインも表明の対象に含まれているかどうかも含む、表明の対象となっている URI のリスト。</p>
+                     
+                     <div class="note" role="note" id="issue-container-generatedID-35"><div role="heading" class="note-title marker" id="h-note-35" aria-level="5"><span>注記</span></div><p class="">表明において、ウェブページはリストを用いて表してもよいし、すべての URI を含む表現を用いて表してもよい。</p></div>
+                     
+                     <div class="note" role="note" id="issue-container-generatedID-36"><div role="heading" class="note-title marker" id="h-note-36" aria-level="5"><span>注記</span></div><p class="">顧客がウェブサイト上でインストールするまで URI が存在しないウェブベースの製品がある。その場合、その製品はインストールされると適合した状態になる、といった記述をすることができる。</p></div>
+                     
+                  </li>
+                  
+                  <li><strong><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-4" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>している<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-technologies-3" title="ユーザエージェントがどのようにレンダリング、再生、又は実行するかを符号化するメカニズム。">ウェブコンテンツ技術</a></strong>のリスト</li>
+                  
+               </ol>
+               
+               <div class="note" role="note" id="issue-container-generatedID-37"><div role="heading" class="note-title marker" id="h-note-37" aria-level="5"><span>注記</span></div><p class="">適合のロゴを使用するとその表明であるとみなされ、上記の適合表明の必須要素を明示しなければならない。</p></div>
+               
+            </section>
+            
+            
+            <section id="conformance-optional"><div class="header-wrapper"><h4 id="x5-3-2-optional-components-of-a-conformance-claim"><bdi class="secno">5.3.2 </bdi>適合表明の任意要素</h4><a class="self-link" href="#conformance-optional" aria-label="Permalink for Section 5.3.2"></a></div>
+               
+               
+               
+               <p>上記の適合表明の必須要素に加えて、利用者のために追加で情報を提供することを検討する。追加する情報として推奨するものを以下に挙げる:</p>
+               
+               <ul>
+                  
+                  <li>表明した適合レベルよりも上の適合レベルで満たしている達成基準のリスト。この情報は、利用者が使用できる形式で提供すべきで、機械的に読み取れるメタデータが好ましい。</li>
+                  
+                  <li><em>使用しているが適合には<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-5" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>していない</em> 技術のリスト。</li>
+                  
+                  <li>コンテンツを試験するのに用いた、支援技術を含むユーザエージェントのリスト。</li>
+                  
+                  <li class="new">機械可読メタデータで提供される、コンテンツのアクセシビリティ特性のリスト。</li>
+                  
+                  <li> アクセシビリティを向上させるために達成基準を超えて追加で施した措置に関する情報。</li>
+                  
+                  <li><a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-6" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>している技術を示したリストの機械的に読み取れるメタデータ版。</li>
+                  
+                  <li>適合表明の機械的に読み取れるメタデータ版。</li>
+                  
+               </ul>
+               
+               	
+               <div class="note" role="note" id="issue-container-generatedID-38"><div role="heading" class="note-title marker" id="h-note-38" aria-level="5"><span>注記</span></div><p class="">より多くの情報や適合表明の事例は、<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#conformance-claims">Understanding Conformance Claims</a> を参照。</p></div>
+               	
+               <div class="note" role="note" id="issue-container-generatedID-39"><div role="heading" class="note-title marker" id="h-note-39" aria-level="5"><span>注記</span></div><p class="">適合表明内でのメタデータの使用に関する詳細な情報は、<a href="https://www.w3.org/WAI/WCAG21/Understanding/understanding-metadata">Understanding Metadata</a> を参照。</p></div>
+               
+               
+            </section>
+            
+         </section>
+         
+         
+         <section id="conformance-partial"><div class="header-wrapper"><h3 id="x5-4-statement-of-partial-conformance-third-party-content"><bdi class="secno">5.4</bdi> 部分適合に関する記述 － 第三者によるコンテンツ</h3><a class="self-link" href="#conformance-partial" aria-label="Permalink for Section 5.4"></a></div>
+            
+            
+            
+            <p>場合によっては、制作後にコンテンツが追加されるようにウェブページが作成される。例えば、電子メールのプログラム、ブログ、利用者がコメントを追加できる記事、又は利用者がコンテンツを提供できるようなアプリケーションである。その他の例としては、複数の提供者から集めたコンテンツで構成されるポータルやニュースサイトのページや、又は動的に挿入される広告のように、他の情報源からその時々にコンテンツが自動的に挿入されるサイトが挙げられる。</p>
+            
+            <p>これらの場合、最初に掲載した時点では、そのページにおける制御できないコンテンツがどのようなものになっていくか分からない。制御できないコンテンツが、制御できるコンテンツのアクセシビリティにも影響を及ぼす可能性があることに注意することが重要である。そのような場合、次の二つの方法から選択する:</p>
+            
+            <ol>
+               
+               <li><p>適合の判定は、分かる範囲で下すことができる。もしこの種のウェブページが監視されていて 2 営業日以内に修正される (適合していないコンテンツが削除されるか、適合するように修正される) ならば、外部から寄稿されたコンテンツにおける不具合のうち、発見後に修正又は削除できるものを除いて判定又は適合表明ができるので、そのページは適合している。適合していないコンテンツを監視及び修正できない場合は、適合表明を行うことはできない。</p>
+                  
+                  <p><strong>又は、</strong></p>
+                  
+               </li>
+               
+               <li><p>適合していないページが特定の部分を除けば適合できる場合、「部分適合に関する記述」ができる。そのような場合の記述は、「このページは適合していないが、制御されていない情報源に起因する以下の部分を除けば、WCAG 2.1 にレベル X で適合していることになる。」というような形式になる。さらに、部分適合の記述に記載される制御できないコンテンツについては、次の条件に当てはまる必要がある。</p>
+                  
+                  <ol>
+                     
+                     <li>コンテンツ制作者が制御できるコンテンツではない。</li>
+                     
+                     <li>利用者が識別できるように、記載されている (例えば、該当箇所が明確に示されない限り、「私たちが制御できない部分すべて」という記載をすることはできない)。</li>
+                     
+                  </ol>
+                  
+               </li>
+               
+            </ol>
+            
+         </section>
+         
+         
+         <section id="conformance-partial-lang"><div class="header-wrapper"><h3 id="x5-5-statement-of-partial-conformance-language"><bdi class="secno">5.5 </bdi>部分適合に関する記述 － 言語</h3><a class="self-link" href="#conformance-partial-lang" aria-label="Permalink for Section 5.5"></a></div>
+            
+            
+            
+            <p>ページが適合していないが、そのページ上で用いられている (すべての) 言語において<a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-supported-5" title="利用者の支援技術だけでなく、ブラウザ及びその他のユーザエージェントにあるアクセシビリティ機能でサポートされていること。">アクセシビリティ サポート</a>があれば適合するような場合には、「言語による部分適合に関する記述」ができる。そのような場合の記述形式は、「このページは適合していないが、もし以下の言語においてアクセシビリティ サポートがあれば、WCAG 2.1 にレベル X で適合していることになる。」というようになる。</p>
+            
+         </section>
+         
+         
+      </section>
+      
+      <section id="glossary"><div class="header-wrapper"><h2 id="x6-glossary"><bdi class="secno">6. </bdi>用語集</h2><a class="self-link" href="#glossary" aria-label="Permalink for Section 6."></a></div>
+         
+         
+         
+         <dl id="terms">
+            
+            <dt><dfn data-lt="abbreviations|abbreviation" id="dfn-abbreviations" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">略語 (abbreviation)</dfn></dt>
+<dd><p>単語、語句、又は名称の短縮形で、その略語が言語の一部になっていないもの。</p>
    
-   <p>単語、語句、又は名称の短縮形で、その略語が言語の一部になっていないもの。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-39"><div role="heading" class="note-title marker" id="h-note-39" aria-level="3"><span>注記</span></div><p class="">これは、頭文字語及び頭字語を含む:</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-40"><div role="heading" class="note-title marker" id="h-note-40" aria-level="3"><span>注記</span></div><p class="">これは、頭文字語及び頭字語を含む:</p></div>
    
    <ol>
       
-      <li>
+      <li><p><strong>頭文字語</strong>は、その名称又は語句に含まれる単語又は音節の頭文字による、名称又は語句の短縮形である。</p>
          
-         <p><strong>頭文字語</strong>は、その名称又は語句に含まれる単語又は音節の頭文字による、名称又は語句の短縮形である。
-         </p>
+         <div class="note" role="note" id="issue-container-generatedID-41"><div role="heading" class="note-title marker" id="h-note-41" aria-level="3"><span>注記</span></div><p class="">すべての言語で定義されているわけではない。</p></div>
          
-         <div class="note" id="issue-container-generatedID-40"><div role="heading" class="note-title marker" id="h-note-40" aria-level="3"><span>注記</span></div><p class="">すべての言語で定義されているわけではない。</p></div>
+         <aside class="example" id="example-1"><div class="marker"><a class="self-link" href="#example-1">例<bdi> 1</bdi></a></div><p>SNCF は、フランス国有鉄道である <span lang="fr">Société Nationale des Chemins de Fer</span> の頭文字を含む、フランス語の頭文字語である。</p></aside>
          
-         <p class="example">SNCF は、フランス国有鉄道である <span lang="fr">Societe Nationale des Chemins de Fer</span> の頭文字を含む、フランス語の頭文字語である。
-         </p>
-         
-         <p class="example">ESP は、"extrasensory perception"の頭文字語である。</p>
+         <aside class="example" id="example-2"><div class="marker"><a class="self-link" href="<g1>例<g2> 1</g2></g1>">例<bdi> 2</bdi></a></div><p>ESP は、"extrasensory perception"の頭文字語である。</p></aside>
          
       </li>
       
-      <li>
+      <li><p><strong>頭字語</strong>は、(名称又は語句の中の) 頭文字又は他の単語の一部から作られた省略形で、一つの単語のように発音されるものである。</p>
          
-         <p><strong>頭字語</strong>は、(名称又は語句の中の) 頭文字又は他の単語の一部から作られた省略形で、一つの単語のように発音されるものである。
-         </p>
-         
-         <p class="example">NOAA は、米国の "National Oceanic and Atmospheric Administration" の頭文字から作られた頭字語である。
-         </p>
+         <aside class="example" id="example-3"><div class="marker"><a class="self-link" href="#example-3">例<bdi> 3</bdi></a></div><p>NOAA は、米国の "National Oceanic and Atmospheric Administration" の頭文字から作られた頭字語である。</p></aside>
          
       </li>
       
    </ol>
    
-   <div class="note" id="issue-container-generatedID-41"><div role="heading" class="note-title marker" id="h-note-41" aria-level="3"><span>注記</span></div><p class="">頭文字語だったものを社名として採用している会社がある。そのような場合、その会社の新しい社名はその文字列であるにすぎず (例: Ecma)、その単語はもはや略語とはみなされない。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-42"><div role="heading" class="note-title marker" id="h-note-42" aria-level="3"><span>注記</span></div><p class="">頭文字語だったものを社名として採用している会社がある。そのような場合、その会社の新しい社名はその文字列であるにすぎず (例: Ecma)、その単語はもはや略語とはみなされない。</p></div>
    
 </dd>
 
             	
-                <dt><dfn data-lt="accessibility-supported|accessibility support|accessibility supported" data-dfn-type="dfn" id="dfn-accessibility-supported">アクセシビリティ サポーテッド (accessibility supported)</dfn></dt>
-<dd>
+            <dt><dfn data-lt="accessibility-supported|accessibility support|accessibility supported" id="dfn-accessibility-supported" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">アクセシビリティ サポーテッド (accessibility supported)</dfn></dt>
+<dd><p>利用者の<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-5" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>だけでなく、ブラウザ及びその他の<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-2" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
    
-   <p>利用者の<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>だけでなく、ブラウザ及びその他の<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>にあるアクセシビリティ機能でサポートされていること。</p>
-   
-   <p>あるウェブコンテンツ技術 (又は、ある技術の機能) のアクセシビリティ サポーテッドな使用方法とみなされるためには、そのウェブコンテンツ技術 (又は機能) について、次の 1.と 2.の両方が満たされていなければならない:
-   </p>
+   <p> あるウェブコンテンツ技術 (又は、ある技術の機能) のアクセシビリティ サポーテッドな使用方法とみなされるためには、そのウェブコンテンツ技術 (又は機能) について、次の 1.と 2.の両方が満たされていなければならない:</p>
    
    <ol>
       
-      <li>
-         
-         <p><strong>その<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">ウェブコンテンツ技術</a>の使用方法が、利用者の支援技術によりサポートされていなければならない。</strong>これは、その技術の使用方法が、そのコンテンツの<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">自然言語</a>における利用者の支援技術との相互運用性について検証されていることを意味する。
-         </p>
+      <li><p><strong>その<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-technologies-4" title="ユーザエージェントがどのようにレンダリング、再生、又は実行するかを符号化するメカニズム。">ウェブコンテンツ技術</a>の使用方法が、利用者の支援技術によりサポートされていなければならない。</strong>これは、その技術の使用方法が、そのコンテンツの<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-3" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>における利用者の支援技術との相互運用性について検証されていることを意味する。</p>
          
          <p><strong>かつ</strong></p>
          
       </li>
       
-      <li>
-         
-         <p><strong>そのウェブコンテンツ技術には、利用者が入手できるアクセシビリティ サポーテッドなユーザエージェントがなければならない。</strong>これは、次の四つのうち少なくとも一つを満たしていることを意味する:
-         </p>
+      <li><p><strong>そのウェブコンテンツ技術には、利用者が入手できるアクセシビリティ サポーテッドなユーザエージェントがなければならない。</strong>これは、次の四つのうち少なくとも一つを満たしていることを意味する:</p>
          
          <ol>
             
-            <li>
-               
-               <p>その技術が、広く配布されているアクセシビリティ サポーテッドなユーザエージェントに標準でサポートされている (HTML、CSS など)。
-               </p>
+            <li><p>その技術が、広く配布されているアクセシビリティ サポーテッドなユーザエージェントに標準でサポートされている (HTML、CSS など)。</p>
                
                <p><strong>又は、</strong></p>
             </li>
             
-            <li>
-               <p>その技術が、広く配布されているアクセシビリティ サポーテッドなプラグインでサポートされている。
-               </p>
+            <li><p>その技術が、広く配布されているアクセシビリティ サポーテッドなプラグインでサポートされている。</p>
                
                <p><strong>又は、</strong></p>
             </li>
             
-            <li>
-               <p>そのコンテンツが、大学、企業内ネットワークのような閉じた環境で利用できるものである。この環境で、その技術に必要とされていて、その組織で使用されているユーザエージェントがアクセシビリティ サポーテッドである。
-               </p>
+            <li><p>そのコンテンツが、大学、企業内ネットワークのような閉じた環境で利用できるものである。この環境で、その技術に必要とされていて、その組織で使用されているユーザエージェントがアクセシビリティ サポーテッドである。</p>
                
                <p><strong>又は、</strong></p>
             </li>
             
-            <li>
-               <p>その技術をサポートするユーザエージェントが、アクセシビリティ サポーテッドであって、次の方法でダウンロード又は購入できる:
-               </p>
+            <li><p>その技術をサポートするユーザエージェントが、アクセシビリティ サポーテッドであって、次の方法でダウンロード又は購入できる:</p>
                
                <ul>
                   
                   <li>障害のある人の費用が、障害のない人の費用を上回ることがなく、<strong>かつ</strong>、</li>
                   
-                  <li>障害のある人も、障害のない人と同程度に容易に探して入手できる。
-                  </li>
+                  <li>障害のある人も、障害のない人と同程度に容易に探して入手できる。</li>
                   
                </ul>
                
@@ -2756,260 +2153,189 @@ details.respec-tests-details > li {
       
    </ol>
    
-   <div class="note" id="issue-container-generatedID-42"><div role="heading" class="note-title marker" id="h-note-42" aria-level="3"><span>注記</span></div><p class="">WCAG Working Group 及び <abbr title="World Wide Web Consortium">W3C</abbr> は、あるウェブ技術の特定の使用方法がアクセシビリティ サポーテッドであると分類するために、どの支援技術によるどれだけのサポートが必要なのかを定めない (<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Level of Assistive Technology Support Needed for "Accessibility Support"</a>を参照)。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-43"><div role="heading" class="note-title marker" id="h-note-43" aria-level="3"><span>注記</span></div><p class="">Accessibility Guidelines Working Group 及び <abbr title="World Wide Web Consortium">W3C</abbr> は、あるウェブ技術の特定の使用方法がアクセシビリティ サポーテッドであると分類するために、どの支援技術によるどれだけのサポートが必要なのかを定めない (<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#support-level">Level of Assistive Technology Support Needed for "Accessibility Support"</a> を参照)。</p></div>
    
-   <div class="note" id="issue-container-generatedID-43"><div role="heading" class="note-title marker" id="h-note-43" aria-level="3"><span>注記</span></div><p class="">そのウェブ技術に<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>しておらず、<a href="#cc4">適合要件 4</a> 及び<a href="#cc5">適合要件 5</a> が満たしている場合は、そのウェブ技術をアクセシビリティ サポーテッドではない方法で用いることができる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-44"><div role="heading" class="note-title marker" id="h-note-44" aria-level="3"><span>注記</span></div><p class="">そのウェブ技術に<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-7" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>しておらず、<a href="#cc4">適合要件 4</a> 及び<a href="#cc5">適合要件 5</a> が満たしている場合は、そのウェブ技術をアクセシビリティ サポーテッドではない方法で用いることができる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-44"><div role="heading" class="note-title marker" id="h-note-44" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">ウェブ技術</a>がアクセシビリティ サポーテッドな方法で用いられている場合、その技術全体、又はその技術の使用方法すべてがアクセシビリティ サポーテッドであるということを暗に示すわけではない。ほとんどの技術は、HTML を含めてアクセシビリティ サポーテッドではない機能、又は使用方法が少なくとも一つある。ウェブページが WCAG に適合するのは、依存する技術のアクセシビリティ サポーテッドな使用方法を用いて WCAG の要件を満たしている場合だけである。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-45"><div role="heading" class="note-title marker" id="h-note-45" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-technologies-5" title="ユーザエージェントがどのようにレンダリング、再生、又は実行するかを符号化するメカニズム。">ウェブ技術</a>がアクセシビリティ サポーテッドな方法で用いられている場合、その技術全体、又はその技術の使用方法すべてがアクセシビリティ サポーテッドであるということを暗に示すわけではない。ほとんどの技術は、HTML を含めてアクセシビリティ サポーテッドではない機能、又は使用方法が少なくとも一つある。ウェブページが WCAG に適合するのは、依存する技術のアクセシビリティ サポーテッドな使用方法を用いて WCAG の要件を満たしている場合だけである。</p></div>
    
-   <div class="note" id="issue-container-generatedID-45"><div role="heading" class="note-title marker" id="h-note-45" aria-level="3"><span>注記</span></div><p class="">複数のバージョンを有するウェブコンテンツ技術を挙げる際は、アクセシビリティ サポーテッドなバージョンを特定すべきである。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-46"><div role="heading" class="note-title marker" id="h-note-46" aria-level="3"><span>注記</span></div><p class="">複数のバージョンを有するウェブコンテンツ技術を挙げる際は、アクセシビリティ サポーテッドなバージョンを特定すべきである。</p></div>
    
-   <div class="note" id="issue-container-generatedID-46"><div role="heading" class="note-title marker" id="h-note-46" aria-level="3"><span>注記</span></div><p class="">コンテンツ制作者が技術のアクセシビリティ サポーテッドな使用方法を見つける方法の一つは、アクセシビリティ サポーテッドであることが文書化されている使用方法の資料を参照することである (<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Accessibility-Supported Web Technology Uses</a> を参照)。コンテンツ制作者、企業、技術ベンダー、又はその他の者が、ウェブコンテンツ技術のアクセシビリティ サポーテッドな使用方法を文書化してもよい。しかし、文書中の技術の使用方法はすべて、上記のアクセシビリティ サポーテッドなウェブコンテンツ技術の定義を満たしている必要がある。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-47"><div role="heading" class="note-title marker" id="h-note-47" aria-level="3"><span>注記</span></div><p class="">コンテンツ制作者が技術のアクセシビリティ サポーテッドな使用方法を見つける方法の一つは、アクセシビリティ サポーテッドであることが文書化されている使用方法の資料を参照することである (<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#documented-lists">Understanding Accessibility-Supported Web Technology Uses</a> を参照)。コンテンツ制作者、企業、技術ベンダー、又はその他の者が、ウェブコンテンツ技術のアクセシビリティ サポーテッドな使用方法を文書化してもよい。しかし、文書中の技術の使用方法はすべて、上記のアクセシビリティ サポーテッドなウェブコンテンツ技術の定義を満たしている必要がある。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-alternative-for-time-based-media">時間依存メディアに対する代替コンテンツ (alternative for time-based media)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-alternative-for-time-based-media" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">時間依存メディアに対する代替コンテンツ (alternative for time-based media)</dfn></dt>
+<dd><p>時間依存の視覚的及び聴覚的情報を正しい順序で説明したテキストを含み、あらゆる時間依存のインタラクションによる結果を得る手段を提供している文書。</p>
    
-   <p>時間依存の視覚的及び聴覚的情報を正しい順序で説明したテキストを含み、あらゆる時間依存のインタラクションによる結果を得る手段を提供している文書。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-47"><div role="heading" class="note-title marker" id="h-note-47" aria-level="3"><span>注記</span></div><p class="">同期したメディアのコンテンツを作るために用いられる脚本は、編集が終了した最終版の同期したメディアを正確に描写した脚本に修正されている場合だけ、この定義を満たす。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-48"><div role="heading" class="note-title marker" id="h-note-48" aria-level="3"><span>注記</span></div><p class="">同期したメディアのコンテンツを作るために用いられる脚本は、編集が終了した最終版の同期したメディアを正確に描写した脚本に修正されている場合だけ、この定義を満たす。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-ambiguous-to-users-in-general">ほとんどの利用者にとって曖昧 (ambiguous to users in general)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-ambiguous-to-users-in-general" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ほとんどの利用者にとって曖昧 (ambiguous to users in general)</dfn></dt>
+<dd><p>リンク、及びリンクと同時に利用者に提供されているウェブページのどの情報からも、そのリンクの目的を判断できない (すなわち、障害がない閲覧者でも、そのリンクを動作させるまで、そのリンクが何をするのか分からない)。</p>
    
-   <p>リンク、及びリンクと同時に利用者に提供されているウェブページのどの情報からも、そのリンクの目的を判断できない (すなわち、障害がない閲覧者でも、そのリンクを動作させるまで、そのリンクが何をするのか分からない)。
-   </p>
-   
-   <p class="example">「注目すべき輸出品のひとつはグァバです」という文中にある「グァバ」という単語がリンクになっている。そのリンク先は、グァバの定義、グァバの輸出量を挙げる図表、又はグァバを収穫している人々の写真のいずれにもなり得る。リンクを動作させるまで、すべての利用者が確信を持てないため、障害のある人が不利な立場に置かれることはない。
-   </p>
+   <aside class="example" id="example-4"><div class="marker"><a class="self-link" href="#example-4">例<bdi> 4</bdi></a></div><p> 「注目すべき輸出品のひとつはグァバです」という文中にある「グァバ」という単語がリンクになっている。そのリンク先は、グァバの定義、グァバの輸出量を挙げる図表、又はグァバを収穫している人々の写真のいずれにもなり得る。リンクを動作させるまで、すべての利用者が確信を持てないため、障害のある人が不利な立場に置かれることはない。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-ascii-art">ASCII アート (ASCII art)</dfn></dt>
-<dd>
-   
-   <p>文字又はグリフの空間的配置によって作られた図画 (典型的には、ASCII で定義されている 95 の印字可能文字から作られる)。
-   </p>
+            
+            <dt><dfn id="dfn-ascii-art" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ASCII アート (ASCII art)</dfn></dt>
+<dd><p>文字又はグリフの空間的配置によって作られた図画 (典型的には、ASCII で定義されている 95 の印字可能文字から作られる)。</p>
    
 </dd>
 
-
-                <dt>(この文書で用いられている) <dfn data-lt="assistive technologies|assistive technology" data-dfn-type="dfn" id="dfn-assistive-technologies">支援技術</dfn> (assistive technology (as used in this document))
-</dt>
-<dd>
-   <p>障害のある利用者の要件を満たすために、主流の<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。</p>
+            
+            <dt>(この文書で用いられている) <dfn data-lt="assistive technologies|assistive technology" id="dfn-assistive-technologies" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">支援技術</dfn> (assistive technology (as used in this document))</dt>
+<dd><p>障害のある利用者の要件を満たすために、主流の<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-3" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>が提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。</p>
    
-   <div class="note" id="issue-container-generatedID-48"><div role="heading" class="note-title marker" id="h-note-48" aria-level="3"><span>注記</span></div><p class="">支援技術が提供する機能としては、代替の提示 (例: 合成音声や拡大表示したコンテンツ)、代替入力手法 (例: 音声認識)、付加的なナビゲーション又は位置確認のメカニズム、及びコンテンツ変換 (例: テーブルをよりアクセシブルにするもの) などを挙げることができる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-49"><div role="heading" class="note-title marker" id="h-note-49" aria-level="3"><span>注記</span></div><p class="">支援技術が提供する機能としては、代替の提示 (例: 合成音声や拡大表示したコンテンツ)、代替入力手法 (例: 音声認識)、付加的なナビゲーション又は位置確認のメカニズム、及びコンテンツ変換 (例: テーブルをよりアクセシブルにするもの) などを挙げることができる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-49"><div role="heading" class="note-title marker" id="h-note-49" aria-level="3"><span>注記</span></div><p class="">支援技術は、API を利用、監視することで、主流のユーザエージェントとデータやメッセージのやりとりをすることが多い。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-50"><div role="heading" class="note-title marker" id="h-note-50" aria-level="3"><span>注記</span></div><p class="">支援技術は、API を利用、監視することで、主流のユーザエージェントとデータやメッセージのやりとりをすることが多い。</p></div>
    
-   <div class="note" id="issue-container-generatedID-50"><div role="heading" class="note-title marker" id="h-note-50" aria-level="3"><span>注記</span></div><p class="">主流のユーザエージェントと支援技術との区別は、絶対的なものではない。多くの主流のユーザエージェントは、障害のある個人を支援する機能を提供している。基本的な差異は、主流のユーザエージェントが障害のある人もない人も含めて、広く多様な利用者を対象にしているのに対し、支援技術は、特定の障害のある利用者という、より狭く限られた人たちを対象にしているということである。支援技術により提供される支援は、対象とする利用者に特化した、よりニーズに適したものである。主流のユーザエージェントは、プログラムオブジェクトからのウェブコンテンツの抽出、マークアップの識別可能な構造への解釈といった、重要な機能を支援技術に対して提供する場合がある。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-51"><div role="heading" class="note-title marker" id="h-note-51" aria-level="3"><span>注記</span></div><p class="">主流のユーザエージェントと支援技術との区別は、絶対的なものではない。多くの主流のユーザエージェントは、障害のある個人を支援する機能を提供している。基本的な差異は、主流のユーザエージェントが障害のある人もない人も含めて、広く多様な利用者を対象にしているのに対し、支援技術は、特定の障害のある利用者という、より狭く限られた人たちを対象にしているということである。支援技術により提供される支援は、対象とする利用者に特化した、よりニーズに適したものである。主流のユーザエージェントは、プログラムオブジェクトからのウェブコンテンツの抽出、マークアップの識別可能な構造への解釈といった、重要な機能を支援技術に対して提供する場合がある。</p></div>
    
-   <p class="example">この文書の文脈において重要な支援技術としては、以下のものが挙げられる:
-   </p>
+   <aside class="example" id="example-5"><div class="marker"><a class="self-link" href="#example-5">例<bdi> 5</bdi></a></div><p>この文書の文脈において重要な支援技術としては、以下のものが挙げられる:</p></aside>
    
    <ul>
       
-      <li>画面拡大ソフト及びその他の視覚的な表示に関する支援技術。視覚障害、知覚障害、及び読書困難などの障害のある人が、レンダリング後のテキスト及び画像の視覚的な読みやすさを改善するために、テキストのフォント、サイズ、間隔、色、音声との同期などを変更するのに使用している。
-      </li>
+      <li>画面拡大ソフト及びその他の視覚的な表示に関する支援技術。視覚障害、知覚障害、及び読書困難などの障害のある人が、レンダリング後のテキスト及び画像の視覚的な読みやすさを改善するために、テキストのフォント、サイズ、間隔、色、音声との同期などを変更するのに使用している。</li>
       
-      <li>スクリーンリーダー。全盲の人がテキスト情報を合成音声あるいは点字で読み取るために使用している。
-      </li>
+      <li>スクリーンリーダー。全盲の人がテキスト情報を合成音声あるいは点字で読み取るために使用している。</li>
       
-      <li>音声変換ソフトウェア。認知障害、言語障害、及び学習障害のある人が、テキストを合成音声に変換するために使用している。
-      </li>
+      <li>音声変換ソフトウェア。認知障害、言語障害、及び学習障害のある人が、テキストを合成音声に変換するために使用している。</li>
       
       <li>音声認識ソフトウェア。何らかの身体障害のある利用者が使用することがある。</li>
       
-      <li>代替キーボード。特定の身体障害のある人がキーボード操作をシミュレートするのに使用している (ヘッドポインタ、シングルスイッチ、呼気・吸気スイッチ、及びその他の特別な入力デバイスを使った代替キーボードを含む)。
-      </li>
+      <li>代替キーボード。特定の身体障害のある人がキーボード操作をシミュレートするのに使用している (ヘッドポインタ、シングルスイッチ、呼気・吸気スイッチ、及びその他の特別な入力デバイスを使った代替キーボードを含む)。</li>
       
-      <li>代替ポインティングデバイス。特定の身体障害のある人がマウスポインタとボタンの動きをシミュレートするのに使用している。
-      </li>
+      <li>代替ポインティングデバイス。特定の身体障害のある人がマウスポインタとボタンの動きをシミュレートするのに使用している。</li>
       
    </ul>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-audio">音声 (audio)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-audio" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">音声 (audio)</dfn></dt>
+<dd><p>音の再生技術。</p>
    
-   <p>音の再生技術。</p>
-   
-   <div class="note" id="issue-container-generatedID-51"><div role="heading" class="note-title marker" id="h-note-51" aria-level="3"><span>注記</span></div><p class="">音声には、合成して作られたもの (音声合成を含む)、実世界の音を収録したもの、又はその両方が含まれる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-52"><div role="heading" class="note-title marker" id="h-note-52" aria-level="3"><span>注記</span></div><p class="">音声には、合成して作られたもの (音声合成を含む)、実世界の音を収録したもの、又はその両方が含まれる。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="audio descriptions|audio description" data-dfn-type="dfn" id="dfn-audio-descriptions">音声解説 (audio description)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="audio descriptions|audio description" id="dfn-audio-descriptions" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">音声解説</dfn> (audio description)</dt>
+<dd><p>主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。</p>
    
-   <p>主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。
-   </p>
+   <div class="note" role="note" id="issue-container-generatedID-53"><div role="heading" class="note-title marker" id="h-note-53" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-4" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>の音声解説は、動作、登場人物、場面の変化、画面上のテキスト、及びその他の視覚的なコンテンツに関する情報を提供する。</p></div>
    
-   <div class="note" id="issue-container-generatedID-52"><div role="heading" class="note-title marker" id="h-note-52" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>の音声解説は、動作、登場人物、場面の変化、画面上のテキスト、及びその他の視覚的なコンテンツに関する情報を提供する。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-54"><div role="heading" class="note-title marker" id="h-note-54" aria-level="3"><span>注記</span></div><p class="">標準的な音声解説では、ナレーションが会話の合間に挿入される。(<a href="#dfn-extended-audio-description" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-audio-description-2" title="映像を一時停止することで追加の説明を付加するための時間を確保し、視聴覚提示に付加した音声解説。">拡張音声解説</a>も参照。) </p></div>
    
-   <div class="note" id="issue-container-generatedID-53"><div role="heading" class="note-title marker" id="h-note-53" aria-level="3"><span>注記</span></div><p class="">標準的な音声解説では、ナレーションが会話の合間に挿入される。(<a href="#dfn-extended-audio-description" class="internalDFN" data-link-type="dfn">拡張音声解説</a>も参照。)
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-55"><div role="heading" class="note-title marker" id="h-note-55" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-5" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>情報のすべてが既存の<a href="#dfn-audio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-4" title="音の再生技術。">音声</a>ですでに提供されている場合、補足の音声解説は不要である。</p></div>
    
-   <div class="note" id="issue-container-generatedID-54"><div role="heading" class="note-title marker" id="h-note-54" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>情報のすべてが既存の<a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>ですでに提供されている場合、補足の音声解説は不要である。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-55"><div role="heading" class="note-title marker" id="h-note-55" aria-level="3"><span>注記</span></div><p class="">"video description" や "descriptive narration" とも呼ばれる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-56"><div role="heading" class="note-title marker" id="h-note-56" aria-level="3"><span>注記</span></div><p class=""> "video description" や "descriptive narration" とも呼ばれる。</p></div>
    <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>日本語では「音声ガイド」とも呼ばれる。</p></div>
+
+</dd>
+
+            
+            <dt><dfn id="dfn-audio-only" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">音声しか含まない (audio-only)</dfn></dt>
+<dd><p><a href="#dfn-audio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-5" title="音の再生技術。">音声</a>のみを含んだ、時間に依存する提示 (<a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-6" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>やインタラクションを含まない)。</p>
+   
+</dd>
+            
+            <dt><dfn id="dfn-blinking" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">点滅 (blinking) </dfn></dt>
+<dd><p>注意を引く意図で、二つの視覚的な状態を交互に切り替えること。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-57"><div role="heading" class="note-title marker" id="h-note-57" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-flashes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-flashes-3" title="相対輝度の相反する変化の組合せで、十分な広さを持ち、かつ特定の頻度の場合に、一部の人に発作を誘発する恐れがあるもの。">閃光</a>も参照。ある程度の面積をもち、ある程度の明るさ、特定の頻度で点滅するものは、閃光に分類されることもありうる。</p></div>
    
 </dd>
 
-                
-                <dt><dfn data-dfn-type="dfn" id="dfn-audio-only">音声しか含まない (audio-only)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-blocks-of-text" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">テキストブロック (blocks of text)</dfn></dt>
+<dd><p>一文よりも長いテキスト。</p>
    
-   <p><a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>のみを含んだ、時間に依存する提示 (<a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>やインタラクションを含まない)。
-   </p>
+</dd>
+            
+            <dt><dfn id="dfn-captcha" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">CAPTCHA</dfn></dt>
+<dd><p>コンピュータと人間とを判別する完全自動化されたチューリングテスト (Completely Automated Public Turing test to tell Computers and Humans Apart) の頭文字語。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-58"><div role="heading" class="note-title marker" id="h-note-58" aria-level="3"><span>注記</span></div><p class="">CAPTCHA のテストは多くの場合、利用者に対し、不明瞭な画像又は音声ファイルによって提示されたテキストを入力するよう求める。</p></div>
+   
+   <div class="note" role="note" id="issue-container-generatedID-59"><div role="heading" class="note-title marker" id="h-note-59" aria-level="3"><span>注記</span></div><p class="">チューリングテストは、人間とコンピュータを区別することを目的としたテストの仕組みである。その名は、高名なコンピュータ科学者のアラン チューリングにちなんでいる。この用語は、カーネギーメロン大学の研究者たちによる造語である。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-blinking">点滅 (blinking)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-captions" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">キャプション (captions)</dfn></dt>
+<dd><p>そのメディアのコンテンツを理解するのに必要な、会話及び会話でない音声情報に対する、同期した視覚、及び／又は<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-alternative-2" title="非テキストコンテンツとプログラムで関連付けられるテキスト。又は非テキストコンテンツとプログラムで関連付けられるテキストから参照されるテキスト。プログラムで関連付けられたテキストとは、その場所を、非テキストコンテンツからプログラムによる解釈が可能なテキストである。">テキストによる代替</a>。</p>
    
-   <p>注意を引く意図で、二つの視覚的な状態を交互に切り替えること。</p>
+   <div class="note" role="note" id="issue-container-generatedID-60"><div role="heading" class="note-title marker" id="h-note-60" aria-level="3"><span>注記</span></div><p class="">キャプションは会話のみの字幕と似ているが、会話の内容だけを伝えるのではなく、その番組の内容を理解するために必要な効果音、音楽、笑い声、話者の特定、位置などを含む、会話でない音声情報と同等の内容も伝える点が異なる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-56"><div role="heading" class="note-title marker" id="h-note-56" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">閃光</a>も参照。ある程度の面積をもち、ある程度の明るさ、特定の頻度で点滅するものは、閃光に分類されることもありうる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-61"><div role="heading" class="note-title marker" id="h-note-61" aria-level="3"><span>注記</span></div><p class="">クローズドキャプションは、音声情報と同等の内容で、プレーヤーによっては表示／非表示を切り替えることができるものを指す。</p></div>
    
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-blocks-of-text">テキストブロック (blocks of text)</dfn></dt>
-<dd>
+   <div class="note" role="note" id="issue-container-generatedID-62"><div role="heading" class="note-title marker" id="h-note-62" aria-level="3"><span>注記</span></div><p class="">オープンキャプションは、非表示にできないキャプションである。例えば、キャプションが同等の視覚化された<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-images-of-text-7" title="特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。">文字画像</a>で<a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-7" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>に埋め込まれている場合である。</p></div>
    
-   <p>一文よりも長いテキスト。</p>
-   
-</dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-captcha">CAPTCHA</dfn></dt>
-<dd>
-   
-   <p>コンピュータと人間とを判別する完全自動化されたチューリングテスト (Completely Automated Public Turing test to tell Computers and Humans Apart) の頭文字語。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-57"><div role="heading" class="note-title marker" id="h-note-57" aria-level="3"><span>注記</span></div><p class="">CAPTCHA のテストは多くの場合、利用者に対し、不明瞭な画像又は音声ファイルによって提示されたテキストを入力するよう求める。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-58"><div role="heading" class="note-title marker" id="h-note-58" aria-level="3"><span>注記</span></div><p class="">チューリングテストは、人間とコンピュータを区別することを目的としたテストの仕組みである。その名は、高名なコンピュータ科学者のアラン チューリングにちなんでいる。この用語は、カーネギーメロン大学の研究者たちによる造語である。
-   </p></div>
-   
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-captions">キャプション (captions)</dfn></dt>
-<dd>
-   
-   <p>そのメディアのコンテンツを理解するのに必要な、会話及び会話でない音声情報に対する、同期した視覚、及び／又は<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn">テキストによる代替</a>。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-59"><div role="heading" class="note-title marker" id="h-note-59" aria-level="3"><span>注記</span></div><p class="">キャプションは会話のみの字幕と似ているが、会話の内容だけを伝えるのではなく、その番組の内容を理解するために必要な効果音、音楽、笑い声、話者の特定、位置などを含む、会話でない音声情報と同等の内容も伝える点が異なる。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-60"><div role="heading" class="note-title marker" id="h-note-60" aria-level="3"><span>注記</span></div><p class="">クローズドキャプションは、音声情報と同等の内容で、プレーヤーによっては表示／非表示を切り替えることができるものを指す。</p></div>
-   
-   <div class="note" id="issue-container-generatedID-61"><div role="heading" class="note-title marker" id="h-note-61" aria-level="3"><span>注記</span></div><p class="">オープンキャプションは、非表示にできないキャプションである。例えば、キャプションが同等の視覚化された<a href="#dfn-images-of-text" class="internalDFN" data-link-type="dfn">文字画像</a>で<a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>に埋め込まれている場合である。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-62"><div role="heading" class="note-title marker" id="h-note-62" aria-level="3"><span>注記</span></div><p class="">キャプションは、映像に含まれる情報を分かりにくくしたり遮ったりすべきではない。</p></div>
-   
-   <div class="note" id="issue-container-generatedID-63"><div role="heading" class="note-title marker" id="h-note-63" aria-level="3"><span>注記</span></div><p class="">国によっては、キャプションは "subtitle" と呼ばれている。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-63"><div role="heading" class="note-title marker" id="h-note-63" aria-level="3"><span>注記</span></div><p class="">キャプションは、映像に含まれる情報を分かりにくくしたり遮ったりすべきではない。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-64"><div role="heading" class="note-title marker" id="h-note-64" aria-level="3"><span>注記</span></div><p class="">国によっては、キャプションは "subtitle" と呼ばれている。</p></div>
    <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>subtitle には、「字幕」の意がある。日本では、キャプションのことを一般に字幕と呼ぶことが多い。</p></div>
-   <div class="note" id="issue-container-generatedID-64"><div role="heading" class="note-title marker" id="h-note-64" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>にキャプションをつけることもできるが、つける必要はない。なぜなら、音声解説は既に視覚的に提示されている情報の説明だからである。
-   </p></div>
+
+   <div class="note" role="note" id="issue-container-generatedID-65"><div role="heading" class="note-title marker" id="h-note-65" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-descriptions-4" title="主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。">音声解説</a>にキャプションをつけることもできるが、つける必要はない。なぜなら、音声解説は既に視覚的に提示されている情報の説明だからである。</p></div>
    
 </dd>
 
-                
-                <dt><dfn data-lt="change of context|changes of context" data-dfn-type="dfn" id="dfn-change-of-context">コンテキストの変化 (changes of context)</dfn></dt>
-<dd>
-   
-   <p>大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。
-   </p>
+            
+            <dt><dfn data-lt="change of context|changes of context" id="dfn-change-of-context" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">コンテキストの変化 (changes of context)</dfn></dt>
+<dd><p>大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。</p>
    
    <p>コンテキストの変化には次に挙げるものの変化が含まれる:</p>
    
    <ol>
       
-      <li><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>
-      </li>
+      <li><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-4" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a></li>
       
-      <li><a href="#dfn-viewport" class="internalDFN" data-link-type="dfn">ビューポート</a>
-      </li>
+      <li><a href="#dfn-viewport" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-viewport-1" title="ユーザエージェントがコンテンツを提示するオブジェクト。">ビューポート</a></li>
       
       <li>フォーカス</li>
       
-      <li><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>の意味を変える<a href="#dfn-content" class="internalDFN" data-link-type="dfn">コンテンツ</a>
-      </li>
+      <li><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-16" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>の意味を変える<a href="#dfn-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-content-1" title="コンテンツの構造、提示、及びインタラクションを定義するコード又はマークアップも含めて、ユーザエージェントによって利用者に伝達される情報及び感覚的な体験。">コンテンツ</a></li>
       
    </ol>
    
-   <div class="note" id="issue-container-generatedID-65"><div role="heading" class="note-title marker" id="h-note-65" aria-level="3"><span>注記</span></div><p class="">コンテンツの変化が、必ずコンテキストの変化になるとはかぎらない。アウトラインの展開、動的なメニュー、又はタブの切替などのコンテンツの変化は、それが上記のいずれか (例: フォーカス) を変更しないかぎり、状況を変化させるとは限らない。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-66"><div role="heading" class="note-title marker" id="h-note-66" aria-level="3"><span>注記</span></div><p class="">コンテンツの変化が、必ずコンテキストの変化になるとはかぎらない。アウトラインの展開、動的なメニュー、又はタブの切替などのコンテンツの変化は、それが上記のいずれか (例: フォーカス) を変更しないかぎり、状況を変化させるとは限らない。</p></div>
    
-   <p class="example">新しいウィンドウを開くこと、フォーカスを異なるコンポーネントへ移動させること、新しいウェブページへ移動すること (新しいウェブページへ移動したかのように思わせてしまうことも含む)、又はウェブページの内容を大きく再配置することなどは、コンテキストの変化の事例である。
-   </p>
+   <aside class="example" id="example-6"><div class="marker"><a class="self-link" href="#example-6">例<bdi> 6</bdi></a></div><p> 新しいウィンドウを開くこと、フォーカスを異なるコンポーネントへ移動させること、新しいウェブページへ移動すること (新しいウェブページへ移動したかのように思わせてしまうことも含む)、又はウェブページの内容を大きく再配置することなどは、コンテキストの変化の事例である。</p></aside>
    
 </dd>
 
-                
-                <dt><dfn data-lt="conform|conformance" data-dfn-type="dfn" id="dfn-conform">適合 (conformance)</dfn></dt>
-<dd>
-   
-   <p>与えられた規格、ガイドライン、又は仕様のすべての要件を満たすこと。</p>
+            
+            <dt><dfn data-lt="conform|conformance" id="dfn-conform" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">適合 (conformance)</dfn></dt>
+<dd><p>与えられた規格、ガイドライン、又は仕様のすべての要件を満たすこと。</p>
    
 </dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-conforming-alternate-version">適合している代替版 (conforming alternate version)</dfn></dt>
-<dd>
-   
-   <p>以下の事項を満たす版のことを指す:</p>
+            
+            <dt><dfn data-lt="conforming alternate versions|conforming alternate version" id="dfn-conforming-alternate-versions" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">適合している代替版 (conforming alternate version)</dfn></dt>
+<dd><p>以下の事項を満たす版のことを指す:</p>
    
    <ol>
       
       <li>指定されたレベルで適合しており、かつ</li>
       
-      <li>同じ情報及び<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn">機能</a>のすべてを同一の<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">自然言語</a>で提供しており、かつ
-      </li>
+      <li>同じ情報及び<a href="#dfn-functionality" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-functionality-6" title="利用者の操作により実現可能なプロセス及び結果。">機能</a>のすべてを同一の<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-4" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>で提供しており、かつ</li>
       
       <li>不適合コンテンツと同時に更新されていて、かつ</li>
       
-      <li>
-         <p>以下に挙げる事項のうち少なくとも一つを満たしていること:</p>
+      <li><p>以下に挙げる事項のうち少なくとも一つを満たしていること:</p>
          
          <ol>
             
-            <li><a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn">アクセシビリティ サポーテッド</a>な<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>を用いて、不適合ページから適合版へ到達できる。もしくは、
-            </li>
+            <li><a href="#dfn-accessibility-supported" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-accessibility-supported-6" title="利用者の支援技術だけでなく、ブラウザ及びその他のユーザエージェントにあるアクセシビリティ機能でサポートされていること。">アクセシビリティ サポーテッド</a>な<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-12" title="結果を得るためのプロセス又は手法。">メカニズム</a>を用いて、不適合ページから適合版へ到達できる。もしくは、</li>
             
             <li>不適合版に到達できるのは、適合版からのみである。</li>
             
-            <li>不適合版に到達できるのは、適合版に到達するメカニズムも提供している適合ページからのみである。
-            </li>
+            <li>不適合版に到達できるのは、適合版に到達するメカニズムも提供している適合ページからのみである。</li>
             
          </ol>
          
@@ -3017,179 +2343,124 @@ details.respec-tests-details > li {
       
    </ol>
    
-   <div class="note" id="issue-container-generatedID-66"><div role="heading" class="note-title marker" id="h-note-66" aria-level="3"><span>注記</span></div><p class="">この定義において、「到達できるのは……からのみ」とは、利用者が適合版から来ていない限り、不適合ページに「到達する」 (読み込む) のを防ぐ条件付きリダイレクトのような何らかのメカニズムがある、ということを意味する。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-67"><div role="heading" class="note-title marker" id="h-note-67" aria-level="3"><span>注記</span></div><p class="">この定義において、「到達できるのは……からのみ」とは、利用者が適合版から来ていない限り、不適合ページに「到達する」 (読み込む) のを防ぐ条件付きリダイレクトのような何らかのメカニズムがある、ということを意味する。</p></div>
    
-   <div class="note" id="issue-container-generatedID-67"><div role="heading" class="note-title marker" id="h-note-67" aria-level="3"><span>注記</span></div><p class="">代替版は、元のページと一対一で対応している必要はない (例えば、適合している代替版は複数のページであってもよい)。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-68"><div role="heading" class="note-title marker" id="h-note-68" aria-level="3"><span>注記</span></div><p class="">代替版は、元のページと一対一で対応している必要はない (例えば、適合している代替版は複数のページであってもよい)。</p></div>
    
-   <div class="note" id="issue-container-generatedID-68"><div role="heading" class="note-title marker" id="h-note-68" aria-level="3"><span>注記</span></div><p class="">複数の言語版が利用できる場合、各言語版に対して、適合している代替版を提供する必要がある。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-69"><div role="heading" class="note-title marker" id="h-note-69" aria-level="3"><span>注記</span></div><p class="">複数の言語版が利用できる場合、各言語版に対して、適合している代替版を提供する必要がある。</p></div>
    
-   <div class="note" id="issue-container-generatedID-69"><div role="heading" class="note-title marker" id="h-note-69" aria-level="3"><span>注記</span></div><p class="">異なる技術環境又は利用者層に対応するために、代替版が提供される場合がある。それぞれの版は、可能な限り適合させるべきである。<a href="#cc1">適合要件 1</a> を満たすためには、一つの版が完全に適合している必要がある。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-70"><div role="heading" class="note-title marker" id="h-note-70" aria-level="3"><span>注記</span></div><p class="">異なる技術環境又は利用者層に対応するために、代替版が提供される場合がある。それぞれの版は、可能な限り適合させるべきである。<a href="#cc1">適合要件 1</a> を満たすためには、一つの版が完全に適合している必要がある。</p></div>
    
-   <div class="note" id="issue-container-generatedID-70"><div role="heading" class="note-title marker" id="h-note-70" aria-level="3"><span>注記</span></div><p class="">適合している代替版は、不適合版と同様に自由に利用可能である限り、適合宣言の範囲内に存在する必要はなく、同じウェブサイト上に存在する必要もない。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-71"><div role="heading" class="note-title marker" id="h-note-71" aria-level="3"><span>注記</span></div><p class="">適合している代替版は、不適合版と同様に自由に利用可能である限り、適合宣言の範囲内に存在する必要はなく、同じウェブサイト上に存在する必要もない。</p></div>
    
-   <div class="note" id="issue-container-generatedID-71"><div role="heading" class="note-title marker" id="h-note-71" aria-level="3"><span>注記</span></div><p class="">代替版は、元のページを補助して理解を高める<a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn">補足コンテンツ</a>と混同されないようにすべきである。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-72"><div role="heading" class="note-title marker" id="h-note-72" aria-level="3"><span>注記</span></div><p class="">代替版は、元のページを補助して理解を高める<a href="#dfn-supplementary-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-supplementary-content-2" title="元のコンテンツを説明、又はより明確にするために付加されたコンテンツ。">補足コンテンツ</a>と混同されないようにすべきである。</p></div>
    
-   <div class="note" id="issue-container-generatedID-72"><div role="heading" class="note-title marker" id="h-note-72" aria-level="3"><span>注記</span></div><p class="">コンテンツ内で利用者が設定を行うことで適合版が作り出される仕組みは、その利用者の設定に用いられている手法がアクセシビリティ サポーテッドであるかぎり、代替版への到達メカニズムとして条件を満たしているといえる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-73"><div role="heading" class="note-title marker" id="h-note-73" aria-level="3"><span>注記</span></div><p class="">コンテンツ内で利用者が設定を行うことで適合版が作り出される仕組みは、その利用者の設定に用いられている手法がアクセシビリティ サポーテッドであるかぎり、代替版への到達メカニズムとして条件を満たしているといえる。</p></div>
    
    <p><a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a> を参照。</p>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-content">コンテンツ</dfn> (ウェブコンテンツ) (content (Web content))
-</dt>
-<dd>
+            
+            <dt><dfn id="dfn-content" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">コンテンツ</dfn> (ウェブコンテンツ) (content (Web content))</dt>
+<dd><p>コンテンツの<a href="#dfn-structure" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-structure-2" title="ウェブページの各部を相互の関係性によりまとめる方法論。一連のウェブページをまとめる方法論。">構造</a>、<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-presentation-3" title="rendering of the content in a form to be perceived by users">提示</a>、及びインタラクションを定義するコード又はマークアップも含めて、<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-5" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>によって利用者に伝達される情報及び感覚的な体験。</p>
    
-   <p>コンテンツの<a href="#dfn-structure" class="internalDFN" data-link-type="dfn">構造</a>、<a href="#dfn-presentation" class="internalDFN" data-link-type="dfn">提示</a>、及びインタラクションを定義するコード又はマークアップも含めて、<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>によって利用者に伝達される情報及び感覚的な体験。
-   </p>
+</dd>
+            
+            <dt><dfn id="dfn-context-sensitive-help" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">コンテキストに応じたヘルプ (context-sensitive help)</dfn></dt>
+<dd><p>そのとき実行されている機能に関する情報を提供するヘルプのテキスト。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-74"><div role="heading" class="note-title marker" id="h-note-74" aria-level="3"><span>注記</span></div><p class="">明解なラベルは、コンテキストに応じたヘルプとして機能しうる。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-context-sensitive-help">コンテキストに応じたヘルプ (context-sensitive help)</dfn></dt>
-<dd>
-   
-   <p>そのとき実行されている機能に関する情報を提供するヘルプのテキスト。</p>
-   
-   <div class="note" id="issue-container-generatedID-73"><div role="heading" class="note-title marker" id="h-note-73" aria-level="3"><span>注記</span></div><p class="">明解なラベルは、コンテキストに応じたヘルプとして機能しうる。</p></div>
-   
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-contrast-ratio">コントラスト比 (contrast ratio)</dfn></dt>
-<dd>
-   
-   <p>(L1 + 0.05) / (L2 + 0.05) ここでは、</p>
+            
+            <dt><dfn id="dfn-contrast-ratio" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">コントラスト比 (contrast ratio)</dfn></dt>
+<dd><p>(L1 + 0.05) / (L2 + 0.05) ここでは、</p>
    
    <ul>
       
-      <li>L1 は、明るいほうの色の<a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn">相対輝度</a>である。そして、
-      </li>
+      <li>L1 は、明るいほうの色の<a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relative-luminance-1" title="最も暗い黒を 0 に、最も明るい白を 1 に正規化した色空間内の任意の点の相対的な明るさ。">相対輝度</a>である。そして、 </li>
       
-      <li>L2 は、暗いほうの色の<a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn">相対輝度</a>である。
-      </li>
+      <li>L2 は、暗いほうの色の<a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relative-luminance-2" title="最も暗い黒を 0 に、最も明るい白を 1 に正規化した色空間内の任意の点の相対的な明るさ。">相対輝度</a>である。</li>
       
    </ul>
    
-   <div class="note" id="issue-container-generatedID-74"><div role="heading" class="note-title marker" id="h-note-74" aria-level="3"><span>注記</span></div><p class="">コントラスト比は、1～21 の範囲になりうる (通常は、1:1～21:1 と記述される)。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-75"><div role="heading" class="note-title marker" id="h-note-75" aria-level="3"><span>注記</span></div><p class="">コントラスト比は、1～21 の範囲になりうる (通常は、1:1～21:1 と記述される)。</p></div>
    
-   <div class="note" id="issue-container-generatedID-75"><div role="heading" class="note-title marker" id="h-note-75" aria-level="3"><span>注記</span></div><p class="">コンテンツ制作者は、テキストのレンダリング (例: フォントのスムージングやアンチエイリアス) に関する利用者の設定を制御できないため、アンチエイリアスをオフにした状態でテキストのコントラスト比を評価してもよい。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-76"><div role="heading" class="note-title marker" id="h-note-76" aria-level="3"><span>注記</span></div><p class="">コンテンツ制作者は、テキストのレンダリング (例: フォントのスムージングやアンチエイリアス) に関する利用者の設定を制御できないため、アンチエイリアスをオフにした状態でテキストのコントラスト比を評価してもよい。</p></div>
    
-   <div class="note" id="issue-container-generatedID-76"><div role="heading" class="note-title marker" id="h-note-76" aria-level="3"><span>注記</span></div><p class="">達成基準 1.4.3 及び 1.4.6 の目的上、コントラストは通常の使用においてテキストがレンダリングされるときに指定されている背景色に対して測定する。もし背景色の指定がない場合は、背景色には白を想定する。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-77"><div role="heading" class="note-title marker" id="h-note-77" aria-level="3"><span>注記</span></div><p class="">達成基準 1.4.3 及び 1.4.6 の目的上、コントラストは通常の使用においてテキストがレンダリングされるときに指定されている背景色に対して測定する。もし背景色の指定がない場合は、背景色には白を想定する。</p></div>
    
-   <div class="note" id="issue-container-generatedID-77"><div role="heading" class="note-title marker" id="h-note-77" aria-level="3"><span>注記</span></div><p class="">背景色は、テキストが通常の使用においてレンダリングされるときに背景となるコンテンツの色として指定された色である。テキストの色は指定されているが背景色が指定されていない場合、利用者のデフォルトの背景色は未知であり、コントラストが十分かどうかを評価することができないため、失敗例となる。同じ理由で、背景色が指定されているがテキストの色が指定されていない場合も失敗例となる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-78"><div role="heading" class="note-title marker" id="h-note-78" aria-level="3"><span>注記</span></div><p class="">背景色は、テキストが通常の使用においてレンダリングされるときに背景となるコンテンツの色として指定された色である。テキストの色は指定されているが背景色が指定されていない場合、利用者のデフォルトの背景色は未知であり、コントラストが十分かどうかを評価することができないため、失敗例となる。同じ理由で、背景色が指定されているがテキストの色が指定されていない場合も失敗例となる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-78"><div role="heading" class="note-title marker" id="h-note-78" aria-level="3"><span>注記</span></div><p class="">文字の周囲に縁取りがある場合、その縁取りがコントラストを強めることもあり、文字とその背景色におけるコントラストの計算に用いられる。文字の周囲の細い縁取りは文字として扱われる。文字の周囲の太い縁取りが、光彩のようになって、文字の内側の細部を塗りつぶしていれば、背景色として考慮されることになる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-79"><div role="heading" class="note-title marker" id="h-note-79" aria-level="3"><span>注記</span></div><p class="">文字の周囲に縁取りがある場合、その縁取りがコントラストを強めることもあり、文字とその背景色におけるコントラストの計算に用いられる。文字の周囲の細い縁取りは文字として扱われる。文字の周囲の太い縁取りが、光彩のようになって、文字の内側の細部を塗りつぶしていれば、背景色として考慮されることになる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-79"><div role="heading" class="note-title marker" id="h-note-79" aria-level="3"><span>注記</span></div><p class="">WCAG に適合しているか判断する場合は、典型的な提示において隣接するであろうと制作者が想定するコンテンツで指定された色の組み合わせについて評価しなければならない。制作者は、ユーザエージェントによる色の変更などのように通常とは異なる提示を考慮する必要はない。ただし、それが制作者のコードによって起こる場合は除く。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-80"><div role="heading" class="note-title marker" id="h-note-80" aria-level="3"><span>注記</span></div><p class="">WCAG に適合しているか判断する場合は、典型的な提示において隣接するであろうと制作者が想定するコンテンツで指定された色の組み合わせについて評価しなければならない。制作者は、ユーザエージェントによる色の変更などのように通常とは異なる提示を考慮する必要はない。ただし、それが制作者のコードによって起こる場合は除く。</p></div>
    
 </dd>
 
             	
-                <dt><dfn data-dfn-type="dfn" id="dfn-correct-reading-sequence">正しく読むシーケンス (correct reading sequence)</dfn></dt>
-<dd>
-   
-   <p>コンテンツの意味を変更せずに、単語及び段落が提示されるシーケンス。
-   </p>
+            <dt><dfn id="dfn-correct-reading-sequence" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">正しく読むシーケンス (correct reading sequence)</dfn></dt>
+<dd><p>コンテンツの意味を変更せずに、単語及び段落が提示されるシーケンス。</p>
    
 </dd>
-
-                <dt class="new"><dfn data-lt="css pixels|css pixel" data-dfn-type="dfn" id="dfn-css-pixels">CSS ピクセル (CSS pixel)</dfn></dt>
-<dd class="new">
+            
+            <dt><dfn data-lt="CSS pixels|CSS pixel" data-plurals="css pixels" id="dfn-css-pixels" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">CSS ピクセル (CSS pixel)</dfn></dt>
+<dd><p>約 0.0213 度の視野角。</p>
    					
-   
-   					
-   <p>約 0.0213 度の視野角。</p>
-   					
-   <p>CSS ピクセルは、CSS におけるすべての長さ及び測定のための規範的な測定単位である。この単位は密度非依存で、ディスプレイに存在する実際のハードウェアピクセルとは異なる。ユーザエージェント及びオペレーティングシステムは CSS ピクセルが、ディスプレイの物理的な寸法と予想される視距離 (コンテンツ制作者は決定できない要因) を考慮した <a href="https://www.w3.org/TR/css3-values/#reference-pixel">CSS Values and Units Module Level 3 reference pixel</a> [<cite><a class="bibref" href="#bib-css3-values">css3-values</a></cite>] にできるだけ沿うように設定されていることを確認すべきである。
-   </p>
+   <p>CSS ピクセルは、CSS におけるすべての長さ及び測定のための規範的な測定単位である。この単位は密度非依存で、ディスプレイに存在する実際のハードウェアピクセルとは異なる。ユーザエージェント及びオペレーティングシステムは CSS ピクセルが、ディスプレイの物理的な寸法と予想される視距離 (コンテンツ制作者は決定できない要因) を考慮した <a href="https://www.w3.org/TR/css3-values/#reference-pixel">CSS Values and Units Module Level 3 reference pixel</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-css3-values" title="CSS Values and Units Module Level 3">css3-values</a></cite>] にできるだけ沿うように設定されていることを確認すべきである。</p>
    				
 </dd>
 
-
-                <dt class="new"><dfn data-dfn-type="dfn" id="dfn-down-event">ダウンイベント (down-event)</dfn></dt>
-<dd class="new">
-  
-  <p>トリガ刺激が depressed (押し下げられた) となった時に発生するプラットフォームのイベント。</p>
+            
+            <dt><dfn id="dfn-down-event" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ダウンイベント (down-event)</dfn></dt>
+<dd><p>トリガ刺激が depressed (押し下げられた) となった時に発生するプラットフォームのイベント。</p>
 	<p>ダウンイベントは、「touchstart」「mousedown」など、プラットフォームによって異なる名前を持つ場合がある。</p>
 </dd>
 
-				
-                <dt><dfn data-dfn-type="dfn" id="dfn-emergency">緊急 (emergency)</dfn></dt>
-<dd>
-   
-   <p>健康、安全、又は財産を守るために即座の行動を必要とする、突然で予期しない状況又は出来事。
-   </p>
+            				
+            <dt><dfn id="dfn-emergency" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">緊急 (emergency)</dfn></dt>
+<dd><p>健康、安全、又は財産を守るために即座の行動を必要とする、突然で予期しない状況又は出来事。</p>
    
 </dd>
-
-              	<dt><dfn data-dfn-type="dfn" id="dfn-essential">必要不可欠 (essential)</dfn></dt>
-<dd>
-   					
-   <p>もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、<strong>かつ</strong>、適合する他の方法では情報及び機能を実現できない。
-   </p>
+            
+            	<dt><dfn id="dfn-essential" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">必要不可欠 (essential)</dfn></dt>
+<dd><p>もし取り除いてしまうと、コンテンツの情報又は機能を根本的に変えてしまい、<strong>かつ</strong>、適合する他の方法では情報及び機能を実現できない。</p>
    				
 </dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-extended-audio-description">拡張音声解説 (extended audio description)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-extended-audio-description" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">拡張音声解説 (extended audio description)</dfn></dt>
+<dd><p><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-8" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>を一時停止することで追加の説明を付加するための時間を確保し、視聴覚提示に付加した音声解説。</p>
    
-   <p><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>を一時停止することで追加の説明を付加するための時間を確保し、視聴覚提示に付加した音声解説。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-80"><div role="heading" class="note-title marker" id="h-note-80" aria-level="3"><span>注記</span></div><p class="">この手法は、追加の<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn">音声解説</a>がないと<a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-81"><div role="heading" class="note-title marker" id="h-note-81" aria-level="3"><span>注記</span></div><p class="">この手法は、追加の<a href="#dfn-audio-descriptions" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-descriptions-5" title="主音声のトラックだけでは理解できない重要で視覚的な詳細を説明するために、音声トラックに追加されたナレーション。">音声解説</a>がないと<a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-9" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>の意味が損なわれてしまい、かつ会話又はナレーションの合間が短すぎる場合だけに用いられる。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="flashes|flash" data-dfn-type="dfn" id="dfn-flashes">閃光 (flash)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="flashes|flash" id="dfn-flashes" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">閃光 (flash)</dfn></dt>
+<dd><p><a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relative-luminance-3" title="最も暗い黒を 0 に、最も明るい白を 1 に正規化した色空間内の任意の点の相対的な明るさ。">相対輝度</a>の相反する変化の組合せで、十分な広さを持ち、かつ特定の頻度の場合に、一部の人に発作を誘発する恐れがあるもの。</p>
    
-   <p><a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn">相対輝度</a>の相反する変化の組合せで、十分な広さを持ち、かつ特定の頻度の場合に、一部の人に発作を誘発する恐れがあるもの。
-   </p>
+   <div class="note" role="note" id="issue-container-generatedID-82"><div role="heading" class="note-title marker" id="h-note-82" aria-level="3"><span>注記</span></div><p class="">許容されない閃光の種類に関する情報は、<a href="#dfn-general-flash-and-red-flash-thresholds" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-general-flash-and-red-flash-thresholds-2" title="次のいずれかに該当する場合、閃光、又は急速に変化する映像シーケンスは、閾値を下回っている (すなわち、コンテンツは基準を満たしている) ことになる:">一般閃光閾値及び赤色閃光閾値</a>を参照。</p></div>
    
-   <div class="note" id="issue-container-generatedID-81"><div role="heading" class="note-title marker" id="h-note-81" aria-level="3"><span>注記</span></div><p class="">許容されない閃光の種類に関する情報は、<a href="#dfn-general-flash-and-red-flash-thresholds" class="internalDFN" data-link-type="dfn">一般閃光閾値及び赤色閃光閾値</a>を参照。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-82"><div role="heading" class="note-title marker" id="h-note-82" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-blinking" class="internalDFN" data-link-type="dfn">点滅</a>も参照。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-83"><div role="heading" class="note-title marker" id="h-note-83" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-blinking" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-blinking-2" title="注意を引く意図で、二つの視覚的な状態を交互に切り替えること。">点滅</a>も参照。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-functionality">機能 (functionality)</dfn></dt>
-<dd>
-   
-   <p>利用者の操作により実現可能な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn">プロセス</a>及び結果。
-   </p>
+            	
+            	<dt><dfn id="dfn-functionality" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">機能 (functionality)</dfn></dt>
+<dd><p>利用者の操作により実現可能な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-3" title="ある活動を完了させるために必要な利用者の一連の動作。">プロセス</a>及び結果。</p>
    
 </dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-general-flash-and-red-flash-thresholds">一般閃光閾値及び赤色閃光閾値 (general flash and red flash thresholds)</dfn></dt>
-<dd>
-   
-   <p>次のいずれかに該当する場合、<a href="#dfn-flashes" class="internalDFN" data-link-type="dfn">閃光</a>、又は急速に変化する映像シーケンスは、閾値を下回っている (すなわち、コンテンツは基準を<strong>満たして</strong>いる) ことになる:
-   </p>
+            
+            <dt><dfn id="dfn-general-flash-and-red-flash-thresholds" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">一般閃光閾値及び赤色閃光閾値 (general flash and red flash thresholds)</dfn></dt>
+<dd><p>次のいずれかに該当する場合、<a href="#dfn-flashes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-flashes-4" title="相対輝度の相反する変化の組合せで、十分な広さを持ち、かつ特定の頻度の場合に、一部の人に発作を誘発する恐れがあるもの。">閃光</a>、又は急速に変化する映像シーケンスは、閾値を下回っている (すなわち、コンテンツは基準を<strong>満たして</strong>いる) ことになる:</p>
    
    <ol>
       
-      <li>あらゆる 1 秒間において、<strong>一般閃光</strong>及び／もしくは<strong>赤色閃光</strong>は 3 回以下である。又は、
-      </li>
+      <li>あらゆる 1 秒間において、<strong>一般閃光</strong>及び／もしくは<strong>赤色閃光</strong>は 3 回以下である。又は、</li>
       
-      <li>典型的な閲覧距離で、同時に発生する閃光の領域の合計が、画面上のどの視野 10 度内で、合計 0.006 ステラジアン (画面上の視野 10 度の 25％) よりも多くを占めていない。
-      </li>
+      <li>典型的な閲覧距離で、同時に発生する閃光の領域の合計が、画面上のどの視野 10 度内で、合計 0.006 ステラジアン (画面上の視野 10 度の 25％) よりも多くを占めていない。</li>
       
    </ol>
    
@@ -3197,512 +2468,340 @@ details.respec-tests-details > li {
    
    <ul>
       
-      <li><strong>一般閃光</strong>とは、<a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn">相対輝度</a>の相反する変化が相対輝度の最大値 (1.0) の 10％以上となる組合せであり、暗いほうの映像の相対輝度が 0.80 未満であるもの、として定義される。ここでいう「相反する変化の組合せ」とは、増加した後に減少する、又は減少した後に増加するものである。そして、
-      </li>
+      <li><strong>一般閃光</strong>とは、<a href="#dfn-relative-luminance" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relative-luminance-4" title="最も暗い黒を 0 に、最も明るい白を 1 に正規化した色空間内の任意の点の相対的な明るさ。">相対輝度</a>の相反する変化が相対輝度の最大値 (1.0) の 10％以上となる組合せであり、暗いほうの映像の相対輝度が 0.80 未満であるもの、として定義される。ここでいう「相反する変化の組合せ」とは、増加した後に減少する、又は減少した後に増加するものである。そして、</li>
       
-      <li><strong>赤色閃光</strong>は、彩度の高い赤色を含んだ相反する遷移として定義される。
-      </li>
+      <li><strong>赤色閃光</strong>は、彩度の高い赤色を含んだ相反する遷移として定義される。</li>
       
    </ul>
    
-   <p><em>例外:</em> ホワイトノイズや、1 辺が (典型的な閲覧距離における視野の) 0.1 度未満の市松模様のような細かくバランスの取れた閃光は、閾値を超えることにはならない。
-   </p>
+   <p><em>例外:</em> ホワイトノイズや、1 辺が (典型的な閲覧距離における視野の) 0.1 度未満の市松模様のような細かくバランスの取れた閃光は、閾値を超えることにはならない。</p>
    
-   <div class="note" id="issue-container-generatedID-83"><div role="heading" class="note-title marker" id="h-note-83" aria-level="3"><span>注記</span></div><p class="">一般的なソフトウェア又はウェブコンテンツの場合、コンテンツを 1024 × 768 ピクセルで表示したときに画面上の任意の場所で 341 × 256 ピクセルの矩形を使用すると、標準的な画面サイズ及び視聴距離 (例: 15～17 インチの画面を 22～26 インチの距離で視聴) における視野 10 度の適切な見積もりとなる。この 75～85 ppi という解像度は、CSS 仕様の規定ピクセル解像度である 96 ppi よりも低いことが知られており、したがってより保守的である。高解像度のディスプレイでは、同じコンテンツのレンダリングを表示するとより小さく安全な画像が得られるため、閾値の定義には低めの解像度を使用している。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-84"><div role="heading" class="note-title marker" id="h-note-84" aria-level="3"><span>注記</span></div><p class="">一般的なソフトウェア又はウェブコンテンツの場合、コンテンツを 1024 × 768 ピクセルで表示したときに画面上の任意の場所で 341 × 256 ピクセルの矩形を使用すると、標準的な画面サイズ及び視聴距離 (例: 15～17 インチの画面を 22～26 インチの距離で視聴) における視野 10 度の適切な見積もりとなる。この 75～85 ppi という解像度は、CSS 仕様の規定ピクセル解像度である 96 ppi よりも低いことが知られており、したがってより保守的である。高解像度のディスプレイでは、同じコンテンツのレンダリングを表示するとより小さく安全な画像が得られるため、閾値の定義には低めの解像度を使用している。</p></div>
    
-   <div class="note" id="issue-container-generatedID-84"><div role="heading" class="note-title marker" id="h-note-84" aria-level="3"><span>注記</span></div><p class="">遷移とは、相対輝度 (赤色閃光の相対輝度/色) の計測値を時間軸でプロットしたときの隣接する山と谷の間の相対輝度 (赤色閃光の相対輝度/色) の変化である。閃光は、2 つの相反する遷移で構成される。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-85"><div role="heading" class="note-title marker" id="h-note-85" aria-level="3"><span>注記</span></div><p class="">遷移とは、相対輝度 (赤色閃光の相対輝度/色) の計測値を時間軸でプロットしたときの隣接する山と谷の間の相対輝度 (赤色閃光の相対輝度/色) の変化である。閃光は、2 つの相反する遷移で構成される。</p></div>
+
+   <div class="note" role="note" id="issue-container-generatedID-86"><div role="heading" class="note-title marker" id="h-note-86" aria-level="3"><span>注記</span></div><p class="">この分野における<strong>「彩度の高い赤色を含む相反する遷移の組合せ」</strong>の (2022 年時点での) 実用的定義は、一方の遷移が、R / (R＋G＋B) の値が 0.8 以上の状態への遷移、又はその状態からの遷移であり、かつ、状態間の差が、CIE 1976 UCS 色度図において0.2 (単位なし) 以上である、相反する遷移の組合せである。[<cite><a class="bibref" data-link-type="biblio" href="#bib-iso_9241-391" title="Ergonomics of human-system interaction—Part 391: Requirements, analysis and compliance test methods for the reduction of photosensitive seizures">ISO_9241-391</a></cite>]</p></div>
    
-   <div class="note" id="issue-container-generatedID-85"><div role="heading" class="note-title marker" id="h-note-85" aria-level="3"><span>注記</span></div><p class="">この分野における<strong>「彩度の高い赤色を含む相反する遷移の組合せ」</strong>の (2022 年時点での) 実用的定義は、一方の遷移が、R / (R＋G＋B) の値が 0.8 以上の状態への遷移、又はその状態からの遷移であり、かつ、状態間の差が、CIE 1976 UCS 色度図において0.2 (単位なし) 以上である、相反する遷移の組合せである。[<cite><a class="bibref" href="#bib-iso_9241-391">ISO_9241-391</a></cite>]
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-86"><div role="heading" class="note-title marker" id="h-note-86" aria-level="3"><span>注記</span></div><p class="">ビデオの画面キャプチャから分析を行うツールを利用できる。しかし、閃光があらゆる 1 秒間の間隔において 3 回以下であれば、ツールでこの条件を満たしているかどうかを確認する必要はない。コンテンツは自動的に条件を満たすことになる (上記 1.及び 2.を参照)。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-87"><div role="heading" class="note-title marker" id="h-note-87" aria-level="3"><span>注記</span></div><p class="">ビデオの画面キャプチャから分析を行うツールを利用できる。しかし、閃光があらゆる 1 秒間の間隔において 3 回以下であれば、ツールでこの条件を満たしているかどうかを確認する必要はない。コンテンツは自動的に条件を満たすことになる (上記 1.及び 2.を参照)。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="human language(s)|human language" data-dfn-type="dfn" id="dfn-human-language-s">自然言語 (human language)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="human language(s)|human language" id="dfn-human-language-s" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">自然言語 (human language)</dfn></dt>
+<dd><p>人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。</p>
    
-   <p>人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-87"><div role="heading" class="note-title marker" id="h-note-87" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn">手話</a>も参照。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-88"><div role="heading" class="note-title marker" id="h-note-88" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-sign-language-1" title="意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組み合わせを用いる言語。">手話</a>も参照。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="idioms|idiom" data-dfn-type="dfn" id="dfn-idioms">慣用句 (idiom)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="idioms|idiom" id="dfn-idioms" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">慣用句 (idiom)</dfn></dt>
+<dd><p>個々の単語の意味からはその意味を推測できず、特定の単語を変えると意味が通じなくなる言い回し。</p>
    
-   <p>個々の単語の意味からはその意味を推測できず、特定の単語を変えると意味が通じなくなる言い回し。
-   </p>
+   <div class="note" role="note" id="issue-container-generatedID-89"><div role="heading" class="note-title marker" id="h-note-89" aria-level="3"><span>注記</span></div><p class="">慣用句は、その (文化的又は言語依存の) 意味を失わせることなく、直接に、逐語的に翻訳することはできない。</p></div>
    
-   <div class="note" id="issue-container-generatedID-88"><div role="heading" class="note-title marker" id="h-note-88" aria-level="3"><span>注記</span></div><p class="">慣用句は、その (文化的又は言語依存の) 意味を失わせることなく、直接に、逐語的に翻訳することはできない。
-   </p></div>
-
-
-   <aside class="example" id="example-7"><div class="marker">
-    <a class="self-link" href="#example-7">例<bdi> 7</bdi></a>
-  </div><p>英語では、"spilling the beans" (豆をこぼす) は「秘密を漏らす」という意味である。しかし、"knocking over the beans" (豆をひっくり返す) 又は "spilling the vegetables" (野菜をこぼす) は同じ意味にはならない。
-   </p></aside>
-   <aside class="example" id="example-8"><div class="marker">
-    <a class="self-link" href="#example-8">例<bdi> 8</bdi></a>
-  </div><p>日本語では、「<span lang="ja">さじを投げる</span>」という言い回しは、逐語訳では "he throws a spoon"となるが、「どうすることもできずに諦める」という意味である。
-   </p></aside>
-  <aside class="example" id="example-9"><div class="marker">
-    <a class="self-link" href="#example-9">例<bdi> 9</bdi></a>
-  </div><p>オランダ語では、"<span lang="nl">Hij ging met de kippen op stok</span>"は、逐語訳すれば「彼はニワトリとねぐらについた」となるが、「彼は早く寝た」という意味である。
-   </p></aside> 
-
+   <aside class="example" id="example-7"><div class="marker"><a class="self-link" href="#example-7">例<bdi> 7</bdi></a></div><p>英語では、"spilling the beans" (豆をこぼす) は「秘密を漏らす」という意味である。しかし、"knocking over the beans" (豆をひっくり返す) 又は "spilling the vegetables" (野菜をこぼす) は同じ意味にはならない。</p></aside>
+   
+   <aside class="example" id="example-8"><div class="marker"><a class="self-link" href="#example-8">例<bdi> 8</bdi></a></div><p>日本語では、「<span lang="ja">さじを投げる</span>」という言い回しは、逐語訳では "he throws a spoon"となるが、「どうすることもできずに諦める」という意味である。</p></aside>
+   
+   <aside class="example" id="example-9"><div class="marker"><a class="self-link" href="#example-9">例<bdi> 9</bdi></a></div><p>オランダ語では、"<span lang="nl">Hij ging met de kippen op stok</span>"は、逐語訳すれば「彼はニワトリとねぐらについた」となるが、「彼は早く寝た」という意味である。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-lt="images of text|image of text" data-dfn-type="dfn" id="dfn-images-of-text">文字画像 (image of text)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="images of text|image of text" id="dfn-images-of-text" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">文字画像 (image of text)</dfn></dt>
+<dd><p>特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。</p>
    
-   <p>特定の視覚的効果を得るために非テキスト形式 (例えば画像) でレンダリングされたテキスト。
-   </p>
+   <div class="note" role="note" id="issue-container-generatedID-90"><div role="heading" class="note-title marker" id="h-note-90" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-9" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>以外の部分が重要な視覚的コンテンツである場合、画像に含まれるテキストは該当しない。</p></div>
    
-   <div class="note" id="issue-container-generatedID-89"><div role="heading" class="note-title marker" id="h-note-89" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>以外の部分が重要な視覚的コンテンツである場合、画像に含まれるテキストは該当しない。
-   </p></div>
-   <aside class="example" id="example-10"><div class="marker">
-    <a class="self-link" href="#example-10">例<bdi> 10</bdi></a>
-  </div><p>写真に写っている人の名札にある人名。</p></aside>
+   <aside class="example" id="example-10"><div class="marker"><a class="self-link" href="#example-10">例<bdi> 10</bdi></a></div><p>写真に写っている人の名札にある人名。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-informative">参考情報 (informative)</dfn></dt>
-<dd>
-   
-   <p>情報提供を目的としており、適合するために必須ではないもの。</p>
+            
+            <dt><dfn id="dfn-informative" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">参考情報 (informative)</dfn></dt>
+<dd><p>情報提供を目的としており、適合するために必須ではないもの。</p>
   
-  <div class="note" id="issue-container-generatedID-90"><div role="heading" class="note-title marker" id="h-note-90" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-conform" class="internalDFN" data-link-type="dfn">適合</a>に必須の内容は、「<a href="#dfn-normative" class="internalDFN" data-link-type="dfn">規定</a>」と呼ばれる。</p></div>
+  <div class="note" role="note" id="issue-container-generatedID-91"><div role="heading" class="note-title marker" id="h-note-91" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-conform" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-conform-3" title="与えられた規格、ガイドライン、又は仕様のすべての要件を満たすこと。">適合</a>に必須の内容は、「<a href="#dfn-normative" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-normative-2" title="適合に必須なもの。">規定</a>」と呼ばれる。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-input-error">入力エラー (input error)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-input-error" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">入力エラー (input error)</dfn></dt>
+<dd><p>利用者が入力した情報で、受け付けられないもの。</p>
    
-   <p>利用者が入力した情報で、受け付けられないもの。</p>
-   
-   <div class="note" id="issue-container-generatedID-91"><div role="heading" class="note-title marker" id="h-note-91" aria-level="3"><span>注記</span></div><div class="">
-     <p>以下のものが含まれる:</p>
+   <div class="note" role="note" id="issue-container-generatedID-92"><div role="heading" class="note-title marker" id="h-note-92" aria-level="3"><span>注記</span></div><div class=""><p>以下のものが含まれる:</p>
    
      <ol>
       
-      <li>その<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>では必須であるが、利用者が入力しなかった情報
-      </li>
+      <li>その<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-17" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>では必須であるが、利用者が入力しなかった情報</li>
       
-      <li>利用者が入力したが、要求されたデータ形式あるいは値ではない情報
-      </li>
+      <li>利用者が入力したが、要求されたデータ形式あるいは値ではない情報</li>
       
      </ol>
   </div></div>
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-jargon">業界用語 (jargon)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-jargon" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">業界用語 (jargon)</dfn></dt>
+<dd><p>特定の分野の人々が特定の用法で用いる単語。</p>
    
-   <p>特定の分野の人々が特定の用法で用いる単語。</p>
-					
-   <aside class="example" id="example-11"><div class="marker">
-    <a class="self-link" href="#example-11">例<bdi> 11</bdi></a>
-  </div><p>固定キーという用語は、支援技術やアクセシビリティの分野における業界用語である。</p></aside>
+   <aside class="example" id="example-11"><div class="marker"><a class="self-link" href="#example-11">例<bdi> 11</bdi></a></div><p>固定キーという用語は、支援技術やアクセシビリティの分野における業界用語である。</p></aside>
    
 </dd>
 
+            
+            <dt><dfn id="dfn-keyboard-interface" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">キーボードインタフェース (keyboard interface)</dfn></dt>
+<dd><p>キーストローク入力を取得するためにソフトウェアが用いるインタフェース。</p>
+   
+    <div class="note" role="note" id="issue-container-generatedID-93"><div role="heading" class="note-title marker" id="h-note-93" aria-level="3"><span>注記</span></div><div class=""><p>標準ではキーボードが存在しない技術であっても、キーボードインタフェースによって、利用者がキーストローク入力をプログラムに提供できる。</p>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-keyboard-interface">キーボードインタフェース (keyboard interface)</dfn></dt>
-<dd>
+       <aside class="example" id="example-12"><div class="marker"><a class="self-link" href="#example-12">例<bdi> 12</bdi></a></div><p>タッチスクリーンを搭載している PDA には、外部キーボードへのコネクタとあわせて、そのオペレーティングシステムに組み込まれたキーボードインタフェースがある。PDA 上のアプリケーションはそのインタフェースを用いて、外部キーボード、あるいは手書き解釈プログラムや「キーボードエミュレーション」機能付きの音声テキスト変換アプリケーションのような擬似キーボード出力を提供する他のアプリケーションのいずれかからキーボード入力を取得することができる。</p></aside>
+    </div></div>
    
-   <p>キーストローク入力を取得するためにソフトウェアが用いるインタフェース。</p>
-   
-   <div class="note" id="issue-container-generatedID-92"><div role="heading" class="note-title marker" id="h-note-92" aria-level="3"><span>注記</span></div><p class="">標準ではキーボードが存在しない技術であっても、キーボードインタフェースによって、利用者がキーストローク入力をプログラムに提供できる。
-   </p>
-   <aside class="example" id="example-12"><div class="marker">
-    <a class="self-link" href="#example-12">例<bdi> 12</bdi></a>
-    </div><p>タッチスクリーンを搭載している PDA には、外部キーボードへのコネクタとあわせて、そのオペレーティングシステムに組み込まれたキーボードインタフェースがある。PDA 上のアプリケーションはそのインタフェースを用いて、外部キーボード、あるいは手書き解釈プログラムや「キーボードエミュレーション」機能付きの音声テキスト変換アプリケーションのような擬似キーボード出力を提供する他のアプリケーションのいずれかからキーボード入力を取得することができる。</p></aside>
-   </div>
-   
-   <div class="note" id="issue-container-generatedID-94"><div role="heading" class="note-title marker" id="h-note-94" aria-level="3"><span>注記</span></div><p class="">マウスキーのようなキーボード操作によるマウスエミュレータによるアプリケーション (又は、そのアプリケーションの一部) の操作は、キーボードインタフェースからの操作とは見なさない。なぜならば、この場合、プログラムの操作は、キーボードインタフェースからではなく、そのポインティングデバイス インタフェースからの入力によって行われるからである。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-94"><div role="heading" class="note-title marker" id="h-note-94" aria-level="3"><span>注記</span></div><p class="">マウスキーのようなキーボード操作によるマウスエミュレータによるアプリケーション (又は、そのアプリケーションの一部) の操作は、キーボードインタフェースからの操作とは見なさない。なぜならば、この場合、プログラムの操作は、キーボードインタフェースからではなく、そのポインティングデバイス インタフェースからの入力によって行われるからである。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="keyboard shortcuts|keyboard shortcut" data-dfn-type="dfn" id="dfn-keyboard-shortcuts">キーボードショートカット (keyboard shortcut)</dfn></dt>
-<dd>
-   					
-   
-   					
-   <p>一つ以上のキーを押すことによる、動作のトリガーの代替手段</p>
+            
+            <dt><dfn data-lt="keyboard shortcuts|keyboard shortcut" id="dfn-keyboard-shortcuts" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">キーボードショートカット (keyboard shortcut)</dfn></dt>
+<dd><p>一つ以上のキーを押すことによる、動作のトリガーの代替手段</p>
    				
 </dd>
 
-                
-                <dt><dfn data-lt="labels|label" data-dfn-type="dfn" id="dfn-labels">ラベル (label)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="labels|label" id="dfn-labels" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ラベル (label)</dfn></dt>
+<dd><p><a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-10" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>、又は<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-alternative-3" title="非テキストコンテンツとプログラムで関連付けられるテキスト。又は非テキストコンテンツとプログラムで関連付けられるテキストから参照されるテキスト。プログラムで関連付けられたテキストとは、その場所を、非テキストコンテンツからプログラムによる解釈が可能なテキストである。">テキストによる代替</a>を伴うコンポーネントで、ウェブ<a href="#dfn-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-content-2" title="コンテンツの構造、提示、及びインタラクションを定義するコード又はマークアップも含めて、ユーザエージェントによって利用者に伝達される情報及び感覚的な体験。">コンテンツ</a>内のコンポーネントを識別するために利用者に提示されているもの。</p>
    
-   <p><a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>、又は<a href="#dfn-text-alternative" class="internalDFN" data-link-type="dfn">テキストによる代替</a>を伴うコンポーネントで、ウェブ<a href="#dfn-content" class="internalDFN" data-link-type="dfn">コンテンツ</a>内のコンポーネントを識別するために利用者に提示されているもの。</p>
+   <div class="note" role="note" id="issue-container-generatedID-95"><div role="heading" class="note-title marker" id="h-note-95" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-name" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-name-4" title="ソフトウェアが、ウェブコンテンツのコンポーネントを利用者に識別させることができるテキスト。">名前 (name)</a> は隠されていて、支援技術に対してだけ公開される場合がある一方で、ラベルはすべての利用者に提示される。多くの場合 (すべてではないが)、名前 (name) とラベルは同じである。</p></div>
    
-   <div class="note" id="issue-container-generatedID-95"><div role="heading" class="note-title marker" id="h-note-95" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-name" class="internalDFN" data-link-type="dfn">名前 (name)</a> は隠されていて、支援技術に対してだけ公開される場合がある一方で、ラベルはすべての利用者に提示される。多くの場合 (すべてではないが)、名前 (name) とラベルは同じである。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-96"><div role="heading" class="note-title marker" id="h-note-96" aria-level="3"><span>注記</span></div><p class="">ラベルという用語は、HTML における label 要素だけに限定されない。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-96"><div role="heading" class="note-title marker" id="h-note-96" aria-level="3"><span>注記</span></div><p class="">ラベルという用語は、HTML における label 要素だけに限定されない。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="large-scale|large scale" data-dfn-type="dfn" id="dfn-large-scale">サイズの大きな</dfn> (テキスト) (large scale (text))
-</dt>
-<dd>
+            
+            <dt><dfn data-lt="large-scale|large scale" id="dfn-large-scale" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">サイズの大きな</dfn> (テキスト) (large scale (text))</dt>
+<dd><p>少なくとも 18 ポイント、又は 14 ポイントの太字。あるいは、中国語、日本語、及び韓国語 (CJK) のフォントは、それと同等の文字サイズ。</p>
    
-   <p>少なくとも 18 ポイント、又は 14 ポイントの太字。あるいは、中国語、日本語、及び韓国語 (CJK) のフォントは、それと同等の文字サイズ。
-   </p>
+   <div class="note" role="note" id="issue-container-generatedID-97"><div role="heading" class="note-title marker" id="h-note-97" aria-level="3"><span>注記</span></div><p class="">特別に細い線のフォント、又は文字の形が分かりにくくなるような独特の見た目や特徴のあるフォントは、コントラストが低い場合に特に読みづらい。</p></div>
    
-   <div class="note" id="issue-container-generatedID-97"><div role="heading" class="note-title marker" id="h-note-97" aria-level="3"><span>注記</span></div><p class="">特別に細い線のフォント、又は文字の形が分かりにくくなるような独特の見た目や特徴のあるフォントは、コントラストが低い場合に特に読みづらい。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-98"><div role="heading" class="note-title marker" id="h-note-98" aria-level="3"><span>注記</span></div><p class="">ここでいう文字サイズは、コンテンツが提供される際のサイズであり、利用者によるサイズ変更は含まれない。</p></div>
    
-   <div class="note" id="issue-container-generatedID-98"><div role="heading" class="note-title marker" id="h-note-98" aria-level="3"><span>注記</span></div><p class=""> ここでいう文字サイズは、コンテンツが提供される際のサイズであり、利用者によるサイズ変更は含まれない。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-99"><div role="heading" class="note-title marker" id="h-note-99" aria-level="3"><span>注記</span></div><p class="">利用者が目にする文字の実際のサイズは、コンテンツ制作者が指定したサイズと利用者のディスプレイあるいはユーザエージェントの設定の両方に依存している。多くの主流となっている本文テキストで用いられるフォントにおいて、14 ポイントと 18 ポイントは、1.2em と 1.5em、又は、 (本文フォントが 100％であると仮定して) デフォルトサイズの 120%と 150%に、おおよそ同等である。しかし、制作者は、使用する特定のフォントについて、このことをチェックしておく必要がある。フォントが相対単位で定義されている時、実際に表示される文字サイズのポイント数は、ユーザエージェントによって計算される。この達成基準について評価する時には、文字サイズのポイント数は、ユーザエージェントから取得されるべきであり、又はユーザエージェントが行うフォントの計算基準に基づいて計算するべきである。ロービジョンの利用者については、自分で適切な設定を選択することを想定している。</p></div>
    
-   <div class="note" id="issue-container-generatedID-99"><div role="heading" class="note-title marker" id="h-note-99" aria-level="3"><span>注記</span></div><p class="">利用者が目にする文字の実際のサイズは、コンテンツ制作者が指定したサイズと利用者のディスプレイあるいはユーザエージェントの設定の両方に依存している。多くの主流となっている本文テキストで用いられるフォントにおいて、14 ポイントと 18 ポイントは、1.2em と 1.5em、又は、 (本文フォントが 100％であると仮定して) デフォルトサイズの 120%と 150%に、おおよそ同等である。しかし、制作者は、使用する特定のフォントについて、このことをチェックしておく必要がある。フォントが相対単位で定義されている時、実際に表示される文字サイズのポイント数は、ユーザエージェントによって計算される。この達成基準について評価する時には、文字サイズのポイント数は、ユーザエージェントから取得されるべきであり、又はユーザエージェントが行うフォントの計算基準に基づいて計算するべきである。ロービジョンの利用者については、自分で適切な設定を選択することを想定している。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-100"><div role="heading" class="note-title marker" id="h-note-100" aria-level="3"><span>注記</span></div><p class="">フォントサイズを指定せずにテキストを用いる際は、サイズを指定していないテキストに対して主要ブラウザで用いられる最小のフォントサイズをそのテキストのサイズとみなすのが妥当であろう。もし、レベル 1 の見出しが、主要なブラウザで 14 ポイントの太字あるいはそれ以上のサイズでレンダリングされるならば、それは「サイズの大きな」テキストであると考えてよい。相対的な拡大縮小は、同様の方法でそのデフォルトのサイズから算出することが可能である。</p></div>
    
-   <div class="note" id="issue-container-generatedID-100"><div role="heading" class="note-title marker" id="h-note-100" aria-level="3"><span>注記</span></div><p class="">フォントサイズを指定せずにテキストを用いる際は、サイズを指定していないテキストに対して主要ブラウザで用いられる最小のフォントサイズをそのテキストのサイズとみなすのが妥当であろう。もし、レベル 1 の見出しが、主要なブラウザで 14 ポイントの太字あるいはそれ以上のサイズでレンダリングされるならば、それは「サイズの大きな」テキストであると考えてよい。相対的な拡大縮小は、同様の方法でそのデフォルトのサイズから算出することが可能である。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-101"><div role="heading" class="note-title marker" id="h-note-101" aria-level="3"><span>注記</span></div><p class="">半角の英数字のテキストにおける 18 ポイント及び 14 ポイントのサイズは、拡大印刷の最小サイズ (14 ポイント) と標準的な大きい文字サイズ (18 ポイント) に基づいている。例えば、CJK 言語のようなその他の文字については、「同等な」サイズはその言語での拡大印刷の最小サイズと拡大印刷でその次に大きな標準のサイズとなる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-101"><div role="heading" class="note-title marker" id="h-note-101" aria-level="3"><span>注記</span></div><p class="">半角の英数字のテキストにおける 18 ポイント及び 14 ポイントのサイズは、拡大印刷の最小サイズ (14 ポイント) と標準的な大きい文字サイズ (18 ポイント) に基づいている。例えば、CJK 言語のようなその他の文字については、「同等な」サイズはその言語での拡大印刷の最小サイズと拡大印刷でその次に大きな標準のサイズとなる。</p></div>
    <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>日本語の全角文字の場合は、拡大教科書普及推進会議 第一次報告「第2章 拡大教科書の標準的な規格について」に基づき、22 ポイント又は 18 ポイントの太字を「同等な」サイズとみなすのが妥当である。</p></div>
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-legal-commitments">法律行為 (legal commitments)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-legal-commitments" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">法律行為 (legal commitments)</dfn></dt>
+<dd><p>法的に拘束力のある義務あるいは利益が発生する取引。</p>
    
-   <p>法的に拘束力のある義務あるいは利益が発生する取引。</p>
-					
-   <aside class="example" id="example-13"><div class="marker">
-    <a class="self-link" href="#example-13">例<bdi> 13</bdi></a>
-  </div><p>結婚許可証、株取引 (金銭上及び法的)、遺言、ローン、採用、軍隊への入隊登録、あらゆる契約、など。
-   </p></aside>
+   <aside class="example" id="example-13"><div class="marker"><a class="self-link" href="#example-13">例<bdi> 13</bdi></a></div><p>結婚許可証、株取引 (金銭上及び法的)、遺言、ローン、採用、軍隊への入隊登録、あらゆる契約、など。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-lt="purpose of each link|link purpose" data-dfn-type="dfn" id="dfn-purpose-of-each-link">リンクの目的 (link purpose)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="purpose of each link|link purpose" id="dfn-purpose-of-each-link" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">リンクの目的 (link purpose)</dfn></dt>
+<dd><p>ハイパーリンクを動作させたときに得られる結果の本質。</p>
    
-   <p>ハイパーリンクを動作させたときに得られる結果の本質。</p>
+</dd>
+            
+            <dt><dfn id="dfn-live" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ライブ (live)</dfn></dt>
+<dd><p>現実の出来事から取り込まれ、放送遅延以上の遅延なく受け手に送信される情報。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-102"><div role="heading" class="note-title marker" id="h-note-102" aria-level="3"><span>注記</span></div><p class="">放送遅延は、短時間の (通常は自動的な) 遅れで、例えば放送局に放送のタイミング[queue→cue]の調整や音声 (又は映像) の検閲のための時間を与えるものだが、意味のある編集ができるほどのものではない。</p></div>
+   
+   <div class="note" role="note" id="issue-container-generatedID-103"><div role="heading" class="note-title marker" id="h-note-103" aria-level="3"><span>注記</span></div><p class="">もし情報が完全にコンピュータで生成されたものならば、それはライブではない。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-live">ライブ (live)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-lower-secondary-education-level" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">前期中等教育レベル (lower secondary education level)</dfn></dt>
+<dd><p>6 年間の学校教育卒業の後に始まり、<a href="#dfn-primary-education" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-primary-education-1" title="5～7 歳の間に始まる 6 年間の教育で、その前には教育を受けた期間がない場合もある。">初等教育</a>の開始から 9 年後に終わる、2 年、又は 3 年の教育期間。</p>
    
-   <p>現実の出来事から取り込まれ、放送遅延以上の遅延なく受け手に送信される情報。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-102"><div role="heading" class="note-title marker" id="h-note-102" aria-level="3"><span>注記</span></div><p class="">放送遅延は、短時間の (通常は自動的な) 遅れで、例えば放送局に放送のタイミング[queue→cue]の調整や音声 (又は映像) の検閲のための時間を与えるものだが、意味のある編集ができるほどのものではない。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-103"><div role="heading" class="note-title marker" id="h-note-103" aria-level="3"><span>注記</span></div><p class="">もし情報が完全にコンピュータで生成されたものならば、それはライブではない。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-104"><div role="heading" class="note-title marker" id="h-note-104" aria-level="3"><span>注記</span></div><p class="">この定義は、"International Standard Classification of Education" [<cite><a class="bibref" data-link-type="biblio" href="#bib-unesco" title="International Standard Classification of Education">UNESCO</a></cite>] に基づいている。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-lower-secondary-education-level">前期中等教育レベル (lower secondary education level)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-mechanism" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">メカニズム (mechanism)</dfn></dt>
+<dd><p>結果を得るための<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-4" title="ある活動を完了させるために必要な利用者の一連の動作。">プロセス</a>又は手法。</p>
    
-   <p>6 年間の学校教育卒業の後に始まり、<a href="#dfn-primary-education" class="internalDFN" data-link-type="dfn">初等教育</a>の開始から 9 年後に終わる、2 年、又は 3 年の教育期間。</p>
+   <div class="note" role="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class="">メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-6" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-6" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>で提供されるものに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relied-upon-8" title="その技術が無効になっている場合、又はサポートされていない場合に、コンテンツが適合できないこと。">依存</a>することもある。</p></div>
    
-   <div class="note" id="issue-container-generatedID-104"><div role="heading" class="note-title marker" id="h-note-104" aria-level="3"><span>注記</span></div><p class="">この定義は、"International Standard Classification of Education" [<cite><a class="bibref" href="#bib-unesco">UNESCO</a></cite>]に基づいている。
-   </p></div>
-   
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-mechanism">メカニズム (mechanism)</dfn></dt>
-<dd>
-   
-   <p>結果を得るための<a href="#dfn-processes" class="internalDFN" data-link-type="dfn">プロセス</a>又は手法。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-105"><div role="heading" class="note-title marker" id="h-note-105" aria-level="3"><span>注記</span></div><p class="">メカニズムは、コンテンツ内で明示的に提供されることもあれば、プラットフォーム又は<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>で提供されるものに<a href="#dfn-relied-upon" class="internalDFN" data-link-type="dfn">依存</a>することもある。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-106"><div role="heading" class="note-title marker" id="h-note-106" aria-level="3"><span>注記</span></div><p class="">メカニズムは、宣言する適合レベルのすべての達成基準を満たしている必要がある。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-106"><div role="heading" class="note-title marker" id="h-note-106" aria-level="3"><span>注記</span></div><p class="">メカニズムは、宣言する適合レベルのすべての達成基準を満たしている必要がある。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-media-alternative-for-text">メディアによるテキストの代替 (media alternative for text)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-media-alternative-for-text" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">メディアによるテキストの代替 (media alternative for text)</dfn></dt>
+<dd><p>テキストで (直接又はテキストによる代替によって) 既に提示されている情報以上のものを提示していないメディア。</p>
    
-   <p>テキストで (直接又はテキストによる代替によって) 既に提示されている情報以上のものを提示していないメディア。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-107"><div role="heading" class="note-title marker" id="h-note-107" aria-level="3"><span>注記</span></div><p class="">メディアによるテキストの代替は、テキストを代替する提示の恩恵を受ける人たちのために提供される。テキストの代替メディアになりうるのは、音声しか含まないメディア、映像しか含まない (手話の映像を含む) メディア、又は音声付映像メディアである。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-107"><div role="heading" class="note-title marker" id="h-note-107" aria-level="3"><span>注記</span></div><p class="">メディアによるテキストの代替は、テキストを代替する提示の恩恵を受ける人たちのために提供される。テキストの代替メディアになりうるのは、音声しか含まないメディア、映像しか含まない (手話の映像を含む) メディア、又は音声付映像メディアである。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-motion-animation">モーションアニメーション (motion animation)</dfn></dt>
-<dd>
-   					
-   
-   					
-   <p>動いているような錯覚を作り出す、又は滑らかに遷移しているような感覚を与えるための、状態間へのステップの追加。</p>
-<aside class="example" id="example-14"><div class="marker">
-    <a class="self-link" href="#example-14">例<bdi> 14</bdi></a>
-  </div><p>例えば、出現する間に特定の位置に移動する、又はサイズが変化する要素は、アニメーションであるとみなされる。遷移せずに即座に出現する要素は、アニメーションが使用されていない。要素の見た目のサイズ、形状、又は位置の変化が生じない、色、ぼかし、又は不透明度の変化は、モーションアニメーションには含まれない。</p></aside>
+            
+            <dt><dfn id="dfn-motion-animation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">モーションアニメーション (motion animation)</dfn></dt>
+<dd><p>動いているような錯覚を作り出す、又は滑らかに遷移しているような感覚を与えるための、状態間へのステップの追加。</p>
+	<aside class="example" id="example-14"><div class="marker"><a class="self-link" href="#example-14">例<bdi> 14</bdi></a></div><p>例えば、出現する間に特定の位置に移動する、又はサイズが変化する要素は、アニメーションであるとみなされる。遷移せずに即座に出現する要素は、アニメーションが使用されていない。要素の見た目のサイズ、形状、又は位置の変化が生じない、色、ぼかし、又は不透明度の変化は、モーションアニメーションには含まれない。</p></aside>
    				
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-name">名前 (name)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-name" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">名前 (name)</dfn></dt>
+<dd><p>ソフトウェアが、ウェブコンテンツのコンポーネントを利用者に識別させることができるテキスト。</p>
    
-   <p>ソフトウェアが、ウェブコンテンツのコンポーネントを利用者に識別させることができるテキスト。</p>
+   <div class="note" role="note" id="issue-container-generatedID-108"><div role="heading" class="note-title marker" id="h-note-108" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-labels" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-labels-4" title="テキスト、又はテキストによる代替を伴うコンポーネントで、ウェブコンテンツ内のコンポーネントを識別するために利用者に提示されているもの。">ラベル</a>はすべての利用者に提示される一方で、名前 (name) は隠されていて、支援技術に対してだけ明らかにされる場合もある。多くの場合 (すべてではないが)、ラベルと名前 (name) は同じである。</p></div>
    
-   <div class="note" id="issue-container-generatedID-108"><div role="heading" class="note-title marker" id="h-note-108" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-labels" class="internalDFN" data-link-type="dfn">ラベル</a>はすべての利用者に提示される一方で、名前 (name) は隠されていて、支援技術に対してだけ明らかにされる場合もある。多くの場合 (すべてではないが)、ラベルと名前 (name) は同じである。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-109"><div role="heading" class="note-title marker" id="h-note-109" aria-level="3"><span>注記</span></div><p class="">これは、HTML の name 属性とは関係がない。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-109"><div role="heading" class="note-title marker" id="h-note-109" aria-level="3"><span>注記</span></div><p class="">これは、HTML の name 属性とは関係がない。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-navigated-sequentially">順を追ってナビゲート (navigated sequentially)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-navigated-sequentially" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">順を追ってナビゲート (navigated sequentially)</dfn></dt>
+<dd><p><a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-keyboard-interface-4" title="キーストローク入力を取得するためにソフトウェアが用いるインタフェース。">キーボードインタフェース</a>を用いて (一つの要素から次へ) フォーカスを移動するために、定義された順序でナビゲートすること。</p>
    
-   <p><a href="#dfn-keyboard-interface" class="internalDFN" data-link-type="dfn">キーボードインタフェース</a>を用いて (一つの要素から次へ) フォーカスを移動するために、定義された順序でナビゲートすること。</p>
+</dd>
+            
+            <dt><dfn id="dfn-non-text-content" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">非テキストコンテンツ (non-text content)</dfn></dt>
+<dd><p><a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-9" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈が可能</a>な文字の並びではないコンテンツ、又は文字の並びが<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-5" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>においても何をも表現していないコンテンツ。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-110"><div role="heading" class="note-title marker" id="h-note-110" aria-level="3"><span>注記</span></div><p class="">これには、 (文字による図画である) <a href="#dfn-ascii-art" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-ascii-art-1" title="文字又はグリフの空間的配置によって作られた図画 (典型的には、ASCII で定義されている 95 の印字可能文字から作られる)。">ASCII アート</a>、顔文字、 (文字を置き換える) リートスピーク、文字を表現している画像が含まれる。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-non-text-content">非テキストコンテンツ (non-text content)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-normative" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">規定 (normative)</dfn></dt>
+<dd><p>適合に必須なもの。</p>
    
-   <p><a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈が可能</a>な文字の並びではないコンテンツ、又は文字の並びが<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">自然言語</a>においても何をも表現していないコンテンツ。</p>
-   
-   <div class="note" id="issue-container-generatedID-110"><div role="heading" class="note-title marker" id="h-note-110" aria-level="3"><span>注記</span></div><p class="">これには、 (文字による図画である) <a href="#dfn-ascii-art" class="internalDFN" data-link-type="dfn">ASCII アート</a>、顔文字、 (文字を置き換える) リートスピーク、文字を表現している画像が含まれる。
-   </p></div>
-   
-</dd>
-
-                
-                <dt><dfn data-dfn-type="dfn" id="dfn-normative">規定 (normative)</dfn></dt>
-<dd>
-   
-   <p>適合に必須なもの。</p>
-   
-   <div class="note" id="issue-container-generatedID-111"><div role="heading" class="note-title marker" id="h-note-111" aria-level="3"><span>注記</span></div><p class="">この文書には、様々な明確な方法で適合することができる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-111"><div role="heading" class="note-title marker" id="h-note-111" aria-level="3"><span>注記</span></div><p class="">この文書には、様々な明確な方法で適合することができる。</p></div>
   
-  <div class="note" id="issue-container-generatedID-112"><div role="heading" class="note-title marker" id="h-note-112" aria-level="3"><span>注記</span></div><p class="">「<a href="#dfn-informative" class="internalDFN" data-link-type="dfn">参考情報</a>」又は「規定ではない」とされている内容は、<a href="#dfn-conform" class="internalDFN" data-link-type="dfn">適合</a>のために必須ではない内容である。</p></div>
+  <div class="note" role="note" id="issue-container-generatedID-112"><div role="heading" class="note-title marker" id="h-note-112" aria-level="3"><span>注記</span></div><p class="">「<a href="#dfn-informative" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-informative-2" title="情報提供を目的としており、適合するために必須ではないもの。">参考情報</a>」又は「規定ではない」とされている内容は、<a href="#dfn-conform" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-conform-4" title="与えられた規格、ガイドライン、又は仕様のすべての要件を満たすこと。">適合</a>のために必須ではない内容である。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-on-a-full-screen-window">全画面表示のウィンドウで (on a full-screen window)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-on-a-full-screen-window" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">全画面表示のウィンドウで (on a full-screen window)</dfn></dt>
+<dd><p>最も普及したサイズのデスクトップやラップトップのディスプレイで、ビューポートを最大化した状態。</p>
    
-   <p>最も普及したサイズのデスクトップやラップトップのディスプレイで、ビューポートを最大化した状態。</p>
-   
-   <div class="note" id="issue-container-generatedID-113"><div role="heading" class="note-title marker" id="h-note-113" aria-level="3"><span>注記</span></div><p class="">利用者は一般的にコンピュータを数年間使い続けるので、評価の際は、最新のデスクトップやラップトップの画面解像度を基準にするのではなく、数年間にわたって普及したデスクトップやラップトップの画面解像度を考慮するのが望ましい。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-113"><div role="heading" class="note-title marker" id="h-note-113" aria-level="3"><span>注記</span></div><p class="">利用者は一般的にコンピュータを数年間使い続けるので、評価の際は、最新のデスクトップやラップトップの画面解像度を基準にするのではなく、数年間にわたって普及したデスクトップやラップトップの画面解像度を考慮するのが望ましい。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="pause|paused" data-dfn-type="dfn" id="dfn-pause">一時停止 (paused)</dfn></dt>
-<dd>
-   
-   <p>利用者の要求により停止し、利用者の要求があるまで再開しない。</p>
+            
+            <dt><dfn data-lt="pause|paused" id="dfn-pause" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">一時停止 (paused)</dfn></dt>
+<dd><p>利用者の要求により停止し、利用者の要求があるまで再開しない。</p>
    
 </dd>
-
-                <dt><dfn data-lt="pointer inputs|pointer input" data-dfn-type="dfn" id="dfn-pointer-inputs">ポインタ入力 (pointer input)</dfn></dt>
-<dd>
-   <p>マウス、ペン、タッチ接触のように、画面上の特定の座標 (又は複数の座標群) をターゲットにできるデバイスからの入力。
-   </p>
-   					
-   <div class="note" role="note" id="issue-container-generatedID-114"><div role="heading" class="note-title marker" id="h-note-114" aria-level="3"><span>注記</span></div><p class=""><a href="https://www.w3.org/TR/pointerevents/#dfn-pointer">Pointer Events の「pointer」の定義</a>を参照 [<cite><a class="bibref" href="#bib-pointerevents">pointerevents</a></cite>]。</p></div>
+            
+            <dt><dfn data-lt="pointer inputs|pointer input" id="dfn-pointer-inputs" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ポインタ入力 (pointer input)</dfn></dt>
+<dd><p>マウス、ペン、タッチ接触のように、画面上の特定の座標 (又は複数の座標群) をターゲットにできるデバイスからの入力。</p>
+   <div class="note" role="note" id="issue-container-generatedID-114"><div role="heading" class="note-title marker" id="h-note-114" aria-level="3"><span>注記</span></div><p class=""><a href="https://www.w3.org/TR/pointerevents/#dfn-pointer">Pointer Events の「pointer」の定義</a>を参照 [<cite><a class="bibref" data-link-type="biblio" href="#bib-pointerevents" title="Pointer Events">pointerevents</a></cite>]。</p></div>
    				
 </dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-prerecorded">収録済 (prerecorded)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-prerecorded" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">収録済 (prerecorded)</dfn></dt>
+<dd><p><a href="#dfn-live" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-live-3" title="現実の出来事から取り込まれ、放送遅延以上の遅延なく受け手に送信される情報。">ライブ</a>ではない情報。</p>
    
-   <p><a href="#dfn-live" class="internalDFN" data-link-type="dfn">ライブ</a>ではない情報。</p>
+</dd>
+            
+            <dt><dfn id="dfn-presentation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">提示 (presentation)</dfn></dt>
+<dd><p>利用者が知覚できる形式で<a href="#dfn-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-content-3" title="コンテンツの構造、提示、及びインタラクションを定義するコード又はマークアップも含めて、ユーザエージェントによって利用者に伝達される情報及び感覚的な体験。">コンテンツ</a>をレンダリングすること。</p>
+   
+</dd>
+            
+            <dt><dfn data-lt="primary education|primary education level" id="dfn-primary-education" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">初等教育レベル (primary education level)</dfn></dt>
+<dd><p>5～7 歳の間に始まる 6 年間の教育で、その前には教育を受けた期間がない場合もある。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-115"><div role="heading" class="note-title marker" id="h-note-115" aria-level="3"><span>注記</span></div><p class="">この定義は、"International Standard Classification of Education" [<cite><a class="bibref" data-link-type="biblio" href="#bib-unesco" title="International Standard Classification of Education">UNESCO</a></cite>] に基づいている。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-presentation">提示 (presentation)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="processes|process" id="dfn-processes" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">プロセス (process)</dfn></dt>
+<dd><p>ある活動を完了させるために必要な利用者の一連の動作。</p>
    
-   <p>利用者が知覚できる形式で<a href="#dfn-content" class="internalDFN" data-link-type="dfn">コンテンツ</a>をレンダリングすること。
-   </p>
+   <aside class="example" id="example-15"><div class="marker"><a class="self-link" href="#example-15">例<bdi> 15</bdi></a></div><p>ショッピングサイト上の一連のウェブページで目的を果たすためには、利用者が選択肢となりうる製品、価格及び内容を閲覧した後、製品を選択して発注し、配送先情報及び支払情報を提供する必要がある。</p></aside>
    
-</dd>
-
-                <dt><dfn data-lt="primary education|primary education level" data-dfn-type="dfn" id="dfn-primary-education">初等教育レベル (primary education level)</dfn></dt>
-<dd>
-   
-   <p>5～7 歳の間に始まる 6 年間の教育で、その前には教育を受けた期間がない場合もある。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-114"><div role="heading" class="note-title marker" id="h-note-114" aria-level="3"><span>注記</span></div><p class="">この定義は、"International Standard Classification of Education" [<cite><a class="bibref" href="#bib-unesco">UNESCO</a></cite>]に基づいている。
-   </p></div>
+   <aside class="example" id="example-16"><div class="marker"><a class="self-link" href="#example-16">例<bdi> 16</bdi></a></div><p>アカウント登録ページでは、登録フォームにアクセスする前に<a href="https://www.w3.org/TR/turingtest/">チューリングテスト</a>に成功する必要がある。</p></aside>
    
 </dd>
 
-                
-                <dt><dfn data-lt="processes|process" data-dfn-type="dfn" id="dfn-processes">プロセス (process)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="programmatically determinable|programmatically determined" id="dfn-programmatically-determinable" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">プログラムによる解釈 (プログラムによる解釈が可能) (programmatically determined (programmatically determinable))</dfn></dt>
+<dd><p><a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-7" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>を含む様々な<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-7" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。</p>
    
-   <p>ある活動を完了させるために必要な利用者の一連の動作。</p>
+   <aside class="example" id="example-17"><div class="marker"><a class="self-link" href="#example-17">例<bdi> 17</bdi></a></div><p>マークアップ言語で、一般に入手可能な支援技術が直接アクセスできる要素と属性から解釈される。</p></aside>
    
-   <aside class="example" id="example-15"><div class="marker">
-    <a class="self-link" href="#example-15">例<bdi> 15</bdi></a>
-    </div><p>ショッピングサイト上の一連のウェブページで目的を果たすためには、利用者が選択肢となりうる製品、価格及び内容を閲覧した後、製品を選択して発注し、配送先情報及び支払情報を提供する必要がある。
-   </p></aside>
-   
-   <aside class="example" id="example-16"><div class="marker">
-    <a class="self-link" href="#example-16">例<bdi> 16</bdi></a>
-    </div><p>アカウント登録ページでは、登録フォームにアクセスする前に<a href="https://www.w3.org/TR/turingtest/">チューリングテスト</a>に成功する必要がある。
-   </p></aside>
+      <aside class="example" id="example-18"><div class="marker"><a class="self-link" href="#example-18">例<bdi> 18</bdi></a></div><p>非マークアップ言語の技術特有のデータ構造から解釈され、一般に入手可能な支援技術がサポートするアクセシビリティ API を通じて支援技術に提供される。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-lt="programmatically determinable|programmatically determined" data-dfn-type="dfn" id="dfn-programmatically-determinable">プログラムによる解釈</dfn> (プログラムによる解釈が可能) (programmatically determined (programmatically determinable))
-</dt>
-<dd>
+            
+            <dt><dfn id="dfn-programmatically-determined-link-context" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">プログラムによる解釈が可能なリンクのコンテキスト (programmatically determined link context)</dfn></dt>
+<dd><p>リンクとの<a href="#dfn-relationships" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-relationships-2" title="コンテンツの異なる部分間における意味のあるつながり。">関係性</a>から<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-10" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈</a>が可能であり、リンクテキストと結びつけることができ、様々な感覚モダリティで利用者に提示することができる付加的情報。</p>
    
-   <p><a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>を含む様々な<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>が抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。
-   </p>
+   <aside class="example" id="example-19"><div class="marker"><a class="self-link" href="#example-19">例<bdi> 19</bdi></a></div><p>HTML において、英語で書かれたリンクからプログラムによる解釈が可能な情報には、そのリンクと同じ段落、リスト、もしくはテーブルのセル内にあるテキスト、又はテーブル内のリンクを含むセルに関連付けられたヘッダーセル内のテキストが挙げられる。</p></aside>
    
-   <aside class="example" id="example-17"><div class="marker">
-    <a class="self-link" href="#example-17">例<bdi> 17</bdi></a>
-  </div><p>マークアップ言語で、一般に入手可能な支援技術が直接アクセスできる要素と属性から解釈される。
-   </p></aside>
-   
-   <aside class="example" id="example-18"><div class="marker">
-    <a class="self-link" href="#example-18">例<bdi> 18</bdi></a>
-  </div><p>非マークアップ言語の技術特有のデータ構造から解釈され、一般に入手可能な支援技術がサポートするアクセシビリティ API を通じて支援技術に提供される。
-      </p></aside>
+   <div class="note" role="note" id="issue-container-generatedID-116"><div role="heading" class="note-title marker" id="h-note-116" aria-level="3"><span>注記</span></div><p class="">スクリーンリーダーは句読点を解釈するので、フォーカスが文中のリンクにある場合は、その文からコンテキストを提供することも可能である。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-programmatically-determined-link-context">プログラムによる解釈が可能なリンクのコンテキスト (programmatically determined link context)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-programmatically-set" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">プログラムによる設定 (programmatically set)</dfn></dt>
+<dd><p>支援技術を含むユーザエージェントがサポートしている手法を用いて、ソフトウェアによって設定されること。</p>
    
-   <p>リンクとの<a href="#dfn-relationships" class="internalDFN" data-link-type="dfn">関係性</a>から<a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈</a>が可能であり、リンクテキストと結びつけることができ、様々な感覚モダリティで利用者に提示することができる付加的情報。
-   </p>
+</dd>
+            
+            <dt><dfn id="dfn-pure-decoration" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">純粋な装飾 (pure decoration)</dfn></dt>
+<dd><p>見栄えのためだけのもので、情報は提供せず、機能性も備えていないもの。</p>
    
-   <aside class="example" id="example-19"><div class="marker">
-    <a class="self-link" href="#example-19">例<bdi> 19</bdi></a>
-  </div><p>HTML において、英語で書かれたリンクからプログラムによる解釈が可能な情報には、そのリンクと同じ段落、リスト、もしくはテーブルのセル内にあるテキスト、又はテーブル内のリンクを含むセルに関連付けられたヘッダーセル内のテキストが挙げられる。
-   </p></aside>
+   <div class="note" role="note" id="issue-container-generatedID-117"><div role="heading" class="note-title marker" id="h-note-117" aria-level="3"><span>注記</span></div><p class="">テキストが純粋な装飾といえるのは、単語を並べ替え、又は置き換えても意図が変わらないときだけである。</p></div>
    
-   <div class="note" id="issue-container-generatedID-117"><div role="heading" class="note-title marker" id="h-note-117" aria-level="3"><span>注記</span></div><p class="">スクリーンリーダーは句読点を解釈するので、フォーカスが文中のリンクにある場合は、その文からコンテキストを提供することも可能である。
-   </p></div>
+   <aside class="example" id="example-20"><div class="marker"><a class="self-link" href="#example-20">例<bdi> 20</bdi></a></div><p>背景にとても淡い文字で単語がランダムに並んでいる辞書の表紙。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-programmatically-set">プログラムによる設定 (programmatically set)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="real-time events|real-time event" id="dfn-real-time-events" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">リアルタイムのイベント (real-time event)</dfn></dt>
+<dd><p>a) 閲覧と同時に発生し、かつ b) コンテンツによる生成だけでは完結しないイベント。</p>
    
-   <p>支援技術を含むユーザエージェントがサポートしている手法を用いて、ソフトウェアによって設定されること。
-   </p>
+   <aside class="example" id="example-21"><div class="marker"><a class="self-link" href="#example-21">例<bdi> 21</bdi></a></div><p>ライブパフォーマンスのウェブ放送 (閲覧と同時に発生していて、収録済ではない)。</p></aside>
    
-</dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-pure-decoration">純粋な装飾 (pure decoration)</dfn></dt>
-<dd>
+   <aside class="example" id="example-22"><div class="marker"><a class="self-link" href="#example-22">例<bdi> 22</bdi></a></div><p>人々が入札するオンラインのオークション (閲覧と同時に発生している)。</p></aside>
    
-   <p>見栄えのためだけのもので、情報は提供せず、機能性も備えていないもの。</p>
-   
-   <div class="note" id="issue-container-generatedID-118"><div role="heading" class="note-title marker" id="h-note-118" aria-level="3"><span>注記</span></div><p class="">テキストが純粋な装飾といえるのは、単語を並べ替え、又は置き換えても意図が変わらないときだけである。
-   </p></div>
-   
-   <aside class="example" id="example-20"><div class="marker">
-    <a class="self-link" href="#example-20">例<bdi> 20</bdi></a>
-  </div><p>背景にとても淡い文字で単語がランダムに並んでいる辞書の表紙。</p></aside>
+   <aside class="example" id="example-23"><div class="marker"><a class="self-link" href="#example-23">例<bdi> 23</bdi></a></div><p>アバターを用いたバーチャルな世界での、生身の人間のやりとり (コンテンツによる生成だけで完結するものではなく、閲覧と同時に発生する)。</p></aside>
    
 </dd>
 
-                
-                <dt><dfn data-lt="real-time events|real-time event" data-dfn-type="dfn" id="dfn-real-time-events">リアルタイムのイベント (real-time event)</dfn></dt>
-<dd>
-   
-   <p>a) 閲覧と同時に発生し、かつ b) コンテンツによる生成だけでは完結しないイベント。
-   </p>
-   
-   <aside class="example" id="example-21"><div class="marker">
-    <a class="self-link" href="#example-21">例<bdi> 21</bdi></a>
-  </div><p>ライブパフォーマンスのウェブ放送 (閲覧と同時に発生していて、収録済ではない)。
-   </p></aside>
-   
-   <aside class="example" id="example-22"><div class="marker">
-    <a class="self-link" href="#example-22">例<bdi> 22</bdi></a>
-  </div><p>人々が入札するオンラインのオークション (閲覧と同時に発生している)。</p></aside>
-   
-   <aside class="example" id="example-23"><div class="marker">
-    <a class="self-link" href="#example-23">例<bdi> 23</bdi></a>
-  </div><p>アバターを用いたバーチャルな世界での、生身の人間のやりとり (コンテンツによる生成だけで完結するものではなく、閲覧と同時に発生する)。
-   </p></aside>
-   
+            
+            <dt><dfn data-lt="regions|region" id="dfn-regions" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">領域 (region)</dfn></dt>
+<dd><p>コンテンツの知覚可能、プログラムによる解釈が可能なセクション</p>
+  <div class="note" role="note" id="issue-container-generatedID-118"><div role="heading" class="note-title marker" id="h-note-118" aria-level="3"><span>注記</span></div><p class="">HTML では、landmark ロールが指定されたあらゆるエリアは領域になる。</p></div>
 </dd>
 
-
-                <dt><dfn data-lt="regions|region" data-dfn-type="dfn" id="dfn-regions">領域 (region)</dfn></dt>
-<dd>
-  
-  <p>コンテンツの知覚可能、プログラムによる解釈が可能なセクション</p>
-  <div class="note" id="issue-container-generatedID-119"><div role="heading" class="note-title marker" id="h-note-119" aria-level="3"><span>注記</span></div><p class="">HTML では、landmark ロールが指定されたあらゆるエリアは領域になる。</p></div>
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-relationships">関係性 (relationships)</dfn></dt>
-<dd>
-   
-   <p>コンテンツの異なる部分間における意味のあるつながり。</p>
+            
+            <dt><dfn id="dfn-relationships" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">関係性 (relationships)</dfn></dt>
+<dd><p>コンテンツの異なる部分間における意味のあるつながり。</p>
    
 </dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-relative-luminance">相対輝度 (relative luminance)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-relative-luminance" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">相対輝度 (relative luminance)</dfn></dt>
+<dd><p>最も暗い黒を 0 に、最も明るい白を 1 に正規化した色空間内の任意の点の相対的な明るさ。</p>
    
-   <p>最も暗い黒を 0 に、最も明るい白を 1 に正規化した色空間内の任意の点の相対的な明るさ。
-   </p>
-   
-  <div class="note" id="issue-container-generatedID-120"><div role="heading" class="note-title marker" id="h-note-120" aria-level="3"><span>注記</span></div><div class="">
-   <p>sRGB 色空間においては、色の相対輝度は、L = 0.2126 * <strong>R</strong> + 0.7152 * <strong>G</strong> + 0.0722 * <strong>B</strong> と定義されており、<strong>R</strong>、<strong>G</strong> 及び <strong>B</strong> は以下のように定義される:
-   </p>
+  <div class="note" role="note" id="issue-container-generatedID-119"><div role="heading" class="note-title marker" id="h-note-119" aria-level="3"><span>注記</span></div><div class=""><p>sRGB 色空間においては、色の相対輝度は、L = 0.2126 * <strong>R</strong> + 0.7152 * <strong>G</strong> + 0.0722 * <strong>B</strong> と定義されており、<strong>R</strong>、<strong>G</strong> 及び <strong>B</strong> は以下のように定義される:</p>
    
    <ul>
       
-      <li>RsRGB <= 0.04045 の場合 <strong>R</strong> = RsRGB/12.92 、そうでない場合 <strong>R</strong> = ((RsRGB+0.055)/1.055) ^ 2.4
-      </li>
+      <li>RsRGB &lt;= 0.04045 の場合 <strong>R</strong> = RsRGB/12.92、そうでない場合 <strong>R</strong> = ((RsRGB+0.055)/1.055) ^ 2.4</li>
       
-      <li>GsRGB <= 0.04045 の場合 <strong>G</strong> = GsRGB/12.92 、そうでない場合 <strong>G</strong> = ((GsRGB+0.055)/1.055) ^ 2.4
-      </li>
+      <li>GsRGB &lt;= 0.04045 の場合 <strong>G</strong> = GsRGB/12.92、そうでない場合 <strong>G</strong> = ((GsRGB+0.055)/1.055) ^ 2.4</li>
       
-      <li>BsRGB <= 0.04045 の場合 <strong>B</strong> = BsRGB/12.92 、そうでない場合 <strong>B</strong> = ((BsRGB+0.055)/1.055) ^ 2.4
-      </li>
+      <li>BsRGB &lt;= 0.04045 の場合 <strong>B</strong> = BsRGB/12.92、そうでない場合 <strong>B</strong> = ((BsRGB+0.055)/1.055) ^ 2.4</li>
       
    </ul>
    
@@ -3718,196 +2817,133 @@ details.respec-tests-details > li {
       
    </ul>
    
-   <p>^ という記号は、指数演算子である (計算式は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-srgb" title="Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB">SRGB</a></cite>] を参考にしている)。
-   </p>
+   <p>^ という記号は、指数演算子である (計算式は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-srgb" title="Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB">SRGB</a></cite>] を参考にしている)。</p>
 
   </div></div>
 
   <div class="note" role="note" id="issue-container-generatedID-120"><div role="heading" class="note-title marker" id="h-note-120" aria-level="3"><span>注記</span></div><p class="">2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、古いバージョンの仕様から取り込んだものであり、現在は更新されている。本ガイドラインの文脈における計算には、実質的な影響はない。</p></div>
-		
-   <div class="note" id="issue-container-generatedID-121"><div role="heading" class="note-title marker" id="h-note-121" aria-level="3"><span>注記</span></div><p class="">ウェブコンテンツを閲覧するのに今日用いられているほとんどすべてのシステムは、sRGB 符号化を前提としている。コンテンツを処理して表示するのに別の色空間が用いられている事が分かっているのでない限り、コンテンツ制作者は sRGB 色空間を用いて検証するべきである。もしその他の色空間を用いるのであれば、<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast">Understanding Success Criterion 1.4.3</a> を参照。
-   </p></div>
+  
+   <div class="note" role="note" id="issue-container-generatedID-121"><div role="heading" class="note-title marker" id="h-note-121" aria-level="3"><span>注記</span></div><p class="">ウェブコンテンツを閲覧するのに今日用いられているほとんどすべてのシステムは、sRGB 符号化を前提としている。コンテンツを処理して表示するのに別の色空間が用いられている事が分かっているのでない限り、コンテンツ制作者は sRGB 色空間を用いて検証するべきである。もしその他の色空間を用いるのであれば、<a href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum">Understanding Success Criterion 1.4.3</a> を参照。</p></div>
    
-   <div class="note" id="issue-container-generatedID-122"><div role="heading" class="note-title marker" id="h-note-122" aria-level="3"><span>注記</span></div><p class="">表示時にディザリングが発生する場合は、元の色の値が用いられる。元々ディザリングがかけられている色については、用いられている色の平均値を用いるべきである (R の平均値、G の平均値、及び B の平均値)。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-122"><div role="heading" class="note-title marker" id="h-note-122" aria-level="3"><span>注記</span></div><p class="">表示時にディザリングが発生する場合は、元の色の値が用いられる。元々ディザリングがかけられている色については、用いられている色の平均値を用いるべきである (R の平均値、G の平均値、及び B の平均値)。</p></div>
    
-   <div class="note" id="issue-container-generatedID-123"><div role="heading" class="note-title marker" id="h-note-123" aria-level="3"><span>注記</span></div><p class="">コントラストと閃光を検証する際に、この計算を自動で行うツールが利用できる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-123"><div role="heading" class="note-title marker" id="h-note-123" aria-level="3"><span>注記</span></div><p class="">コントラストと閃光を検証する際に、この計算を自動で行うツールが利用できる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-124"><div role="heading" class="note-title marker" id="h-note-124" aria-level="3"><span>注記</span></div><p class=""><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-124"><div role="heading" class="note-title marker" id="h-note-124" aria-level="3"><span>注記</span></div><p class=""><a href="relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-relied-upon">依存されている</dfn> (技術) (relied upon (technologies that are))
-</dt>
-<dd>
+            
+            <dt><dfn id="dfn-relied-upon" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">依存されている (技術) (relied upon (technologies that are))</dfn></dt>
+<dd><p>その<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-technologies-6" title="ユーザエージェントがどのようにレンダリング、再生、又は実行するかを符号化するメカニズム。">技術</a>が無効になっている場合、又はサポートされていない場合に、コンテンツが<a href="#dfn-conform" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-conform-5" title="与えられた規格、ガイドライン、又は仕様のすべての要件を満たすこと。">適合</a>できないこと。</p>
    
-   <p>その<a href="#dfn-technologies" class="internalDFN" data-link-type="dfn">技術</a>が無効になっている場合、又はサポートされていない場合に、コンテンツが<a href="#dfn-conform" class="internalDFN" data-link-type="dfn">適合</a>できないこと。
-   </p>
+</dd>
+            
+            <dt><dfn id="dfn-role" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">役割 (role)</dfn></dt>
+<dd><p>ソフトウェアがウェブコンテンツ内のコンポーネントの機能の識別を可能にするためのテキスト又は番号。</p>
+   
+   <aside class="example" id="example-24"><div class="marker"><a class="self-link" href="#example-24">例<bdi> 24</bdi></a></div><p>画像がハイパーリンク、コマンドボタン、又はチェックボックスとしての機能を果たすかどうかを示す番号。</p></aside>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-role">役割 (role)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-same-functionality" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">同じ機能 (same functionality)</dfn></dt>
+<dd><p>使うと同じ結果が得られること。</p>
    
-   <p>ソフトウェアがウェブコンテンツ内のコンポーネントの機能の識別を可能にするためのテキスト又は番号。
-   </p>
-   
-   <aside class="example" id="example-24"><div class="marker">
-    <a class="self-link" href="#example-24">例<bdi> 24</bdi></a>
-  </div><p>画像がハイパーリンク、コマンドボタン、又はチェックボックスとしての機能を果たすかどうかを示す番号。
-   </p></aside>
+   <aside class="example" id="example-25"><div class="marker"><a class="self-link" href="#example-25">例<bdi> 25</bdi></a></div><p>あるウェブページ上にある "search" ボタンと他のウェブページ上にある "find" ボタンは、どちらもキーワードを入力するテキストフィールドがあり、そのウェブサイトにある入力されたキーワードに関係のあるコンテンツをリスト表示する。この場合、同じ機能を有しながらも、ラベルは一貫していないことになる。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-same-functionality">同じ機能 (same functionality)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-same-relative-order" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">相対的に同じ順序 (same relative order)</dfn></dt>
+<dd><p>他の項目との相対位置が同じ。</p>
    
-   <p>使うと同じ結果が得られること。</p>
-   
-   <aside class="example" id="example-25"><div class="marker">
-    <a class="self-link" href="#example-25">例<bdi> 25</bdi></a>
-  </div><p>あるウェブページ上にある "search" ボタンと他のウェブページ上にある "find" ボタンは、どちらもキーワードを入力するテキストフィールドがあり、そのウェブサイトにある入力されたキーワードに関係のあるコンテンツをリスト表示する。この場合、同じ機能を有しながらも、ラベルは一貫していないことになる。
-   </p></aside>
+   <div class="note" role="note" id="issue-container-generatedID-125"><div role="heading" class="note-title marker" id="h-note-125" aria-level="3"><span>注記</span></div><p class="">当初の順序に対して、別の項目が挿入、又は削除されていたとしても、項目は相対的に同じ順序になっていると考えられる。例えば、展開するナビゲーションメニューに詳細な追加階層が挿入される、又は、読みの順序の途中に副次的なナビゲーション部分が挿入されることがある。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-same-relative-order">相対的に同じ順序 (same relative order)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="satisfies|satisfies a success criterion" id="dfn-satisfies" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">達成基準を満たす (satisfies a success criterion)</dfn></dt>
+<dd><p>ページに適用した際、その達成基準が 'false' と判定されないこと。</p>
    
-   <p>他の項目との相対位置が同じ。</p>
+</dd>
+            
+            <dt><dfn id="dfn-section" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">セクション (section)</dfn></dt>
+<dd><p>一つ以上の関連する話題、又は考えについて書かれたコンテンツの自己完結している部分。</p>
    
-   <div class="note" id="issue-container-generatedID-125"><div role="heading" class="note-title marker" id="h-note-125" aria-level="3"><span>注記</span></div><p class="">当初の順序に対して、別の項目が挿入、又は削除されていたとしても、項目は相対的に同じ順序になっていると考えられる。例えば、展開するナビゲーションメニューに詳細な追加階層が挿入される、又は、読みの順序の途中に副次的なナビゲーション部分が挿入されることがある。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-126"><div role="heading" class="note-title marker" id="h-note-126" aria-level="3"><span>注記</span></div><p class="">セクションは一つ以上の段落から成ることがあり、画像、表、リスト、及びサブセクションを含むこともある。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-lt="satisfies|satisfies a success criterion" data-dfn-type="dfn" id="dfn-satisfies">達成基準を満たす (satisfies a success criterion)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-set-of-web-pages" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ウェブページ一式 (set of Web pages)</dfn></dt>
+<dd><p>共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作された<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-18" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>の集合。</p>
    
-   <p>ページに適用した際、その達成基準が 'false' と判定されないこと。</p>
-   
-</dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-section">セクション (section)</dfn></dt>
-<dd>
-   
-   <p>一つ以上の関連する話題、又は考えについて書かれたコンテンツの自己完結している部分。
-   </p>
-   
-   <div class="note" id="issue-container-generatedID-126"><div role="heading" class="note-title marker" id="h-note-126" aria-level="3"><span>注記</span></div><p class="">セクションは一つ以上の段落から成ることがあり、画像、表、リスト、及びサブセクションを含むこともある。
-   </p></div>
-   
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-set-of-web-pages">ウェブページ一式 (set of Web pages)</dfn></dt>
-<dd>
-   
-   <p>共通の目的を共有し、同じコンテンツ制作者、グループ、又は組織により制作された<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>の集合。
-   </p>
-   
-   <aside class="example" id="example-26"><div class="marker">
-    <a class="self-link" href="#example-26">例<bdi> 26</bdi></a>
-  </div><p>以下の例がある:</p>
+   <aside class="example" id="example-26"><div class="marker"><a class="self-link" href="#example-26">例<bdi> 26</bdi></a></div><p>以下の例がある:</p>
       <ul>
       <li>複数のウェブページにまたがる発行物で、各ページには一つの章又はその他の重要なセクションが含まれる。その発行物は論理的には一つの連続した集合体であり、ページ一式全体へのアクセスを可能にするナビゲーション機能を有する。</li>
       <li>e コマースのウェブサイトで、同じナビゲーション及び識別を共有するウェブページ一式に、商品が表示されている。しかし、精算プロセスに進むと、テンプレートが変更される。ナビゲーション及び他の要素が削除され、それによって、そのプロセスのページは機能的にも視覚的にも異なったものとなる。その精算ページは商品のページ一式の一部ではない。</li>
       <li>サブドメイン (例えば blog.example.com) 上のブログで、プライマリドメイン (example.com) 上のページとは異なるナビゲーションを持ち、かつ異なる人々によって制作されている。</li>
    </ul></aside>
 
-  <div class="note" id="issue-container-generatedID-127"><div role="heading" class="note-title marker" id="h-note-127" aria-level="3"><span>注記</span></div><p class="">他言語版は、異なるウェブページ一式と見なされることもある。</p></div>
+  <div class="note" role="note" id="issue-container-generatedID-127"><div role="heading" class="note-title marker" id="h-note-127" aria-level="3"><span>注記</span></div><p class="">他言語版は、異なるウェブページ一式と見なされることもある。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-sign-language">手話 (sign language)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-sign-language" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">手話 (sign language)</dfn></dt>
+<dd><p>意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組み合わせを用いる言語。</p>
    
-   <p>意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組み合わせを用いる言語。
-   </p>
+</dd>
+            
+            <dt><dfn id="dfn-sign-language-interpretation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">手話通訳 (sign language interpretation)</dfn></dt>
+<dd><p>ある言語、通常は話されている言語を、<a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-sign-language-2" title="意味を伝えるために、手と腕の動き、顔の表情又は身体の姿勢の組み合わせを用いる言語。">手話</a>に訳すこと。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-128"><div role="heading" class="note-title marker" id="h-note-128" aria-level="3"><span>注記</span></div><p class="">純粋な手話は、同じ国又は地域の話されている言語とは関係がない独立したものである。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-sign-language-interpretation">手話通訳 (sign language interpretation)</dfn></dt>
-<dd>
-   
-   <p>ある言語、通常は話されている言語を、<a href="#dfn-sign-language" class="internalDFN" data-link-type="dfn">手話</a>に訳すこと。</p>
-   
-   <div class="note" id="issue-container-generatedID-128"><div role="heading" class="note-title marker" id="h-note-128" aria-level="3"><span>注記</span></div><p class="">純粋な手話は、同じ国又は地域の話されている言語とは関係がない独立したものである。
-   </p></div>
-   
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-single-pointer">シングルポインタ (single pointer)</dfn></dt>
-<dd>
-   					
-   
-   	
-   <p>シングルタップ・クリック、ダブルタップ・クリック、長押し、軌跡ベースのジェスチャなど、画面と一つの接点で動作するポインタ入力。</p>
+            
+            <dt><dfn id="dfn-single-pointer" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">シングルポインタ (single pointer)</dfn></dt>
+<dd><p>シングルタップ・クリック、ダブルタップ・クリック、長押し、軌跡ベースのジェスチャなど、画面と一つの接点で動作するポインタ入力。</p>
   				
 </dd>
 
 
-                
-                <dt><dfn data-dfn-type="dfn" id="dfn-specific-sensory-experience">特定の感覚的な体験 (specific sensory experience)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-specific-sensory-experience" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">特定の感覚的な体験 (specific sensory experience)</dfn></dt>
+<dd><p>純粋な装飾ではなく、かつ、重要な情報を伝える、又は機能を果たすことを主としない、感覚的な体験。</p>
    
-   <p>純粋な装飾ではなく、かつ、重要な情報を伝える、又は機能を果たすことを主としない、感覚的な体験。
-   </p>
-   
-   <aside class="example" id="example-27"><div class="marker">
-    <a class="self-link" href="#example-27">例<bdi> 27</bdi></a>
-  </div><p>フルートのソロ演奏、視覚芸術の作品などが例として挙げられる。</p></aside>
+   <aside class="example" id="example-27"><div class="marker"><a class="self-link" href="#example-27">例<bdi> 27</bdi></a></div><p>フルートのソロ演奏、視覚芸術の作品などが例として挙げられる。</p></aside>
    
 </dd>
 
-                
-                <dt><dfn data-lt="states|state" data-dfn-type="dfn" id="dfn-states">状態 (state)</dfn></dt>
-<dd>
-   					
-   
-   					
-   <p>利用者のアクション又は自動プロセスに応答して変化し得るユーザインタフェースコンポーネントの特性を表現する動的プロパティ。</p>
+            
+            <dt><dfn data-lt="states|state" id="dfn-states" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">状態 (state)</dfn></dt>
+<dd><p>利用者のアクション又は自動プロセスに応答して変化し得るユーザインタフェースコンポーネントの特性を表現する動的プロパティ。</p>
 	<p>状態はコンポーネントの本質に影響を与えないが、コンポーネント又はインタラクションの変化の候補に関連付けられているデータを表す。例えば、フォーカス、ホバー、選択、プレス、チェック、訪問済・未訪問、展開・折りたたみが挙げられる。</p>
 </dd>
 
-
-                <dt><dfn data-lt="status messages|status message" data-dfn-type="dfn" id="dfn-status-messages">ステータスメッセージ (status message)</dfn></dt>
-<dd>
-   					
-   
-   					
-   <p>コンテンツ内の変化であって、<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn">コンテキストの変化</a>ではなく、かつ、アクションの成否もしくは結果、アプリケーションの処理待ち状態、プロセスの進捗、又はエラーの存在に関する情報を利用者に提供するもの。</p>
+            
+            <dt><dfn data-lt="status messages|status message" id="dfn-status-messages" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ステータスメッセージ (status message)</dfn></dt>
+<dd><p>コンテンツ内の変化であって、<a href="#dfn-change-of-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-change-of-context-4" title="大きな変化で、利用者が気づかないと、ウェブページ全体を一度に見ることのできない利用者を混乱させる恐れのあるもの。">コンテキストの変化</a>ではなく、かつ、アクションの成否もしくは結果、アプリケーションの処理待ち状態、プロセスの進捗、又はエラーの存在に関する情報を利用者に提供するもの。</p>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-structure">構造 (structure)</dfn></dt>
-<dd>
-   
-   <ol>
+            
+            <dt><dfn id="dfn-structure" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">構造 (structure)</dfn></dt>
+<dd><ol>
       
-      <li><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>の各部を相互の関係性によりまとめる方法論。及び、
-      </li>
+      <li><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-19" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>の各部を相互の関係性によりまとめる方法論。及び、</li>
       
-      <li>一連の<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>をまとめる方法論。
-      </li>
+      <li>一連の<a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-20" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>をまとめる方法論。</li>
       
    </ol>
    
 </dd>
-
-                <dt><dfn data-lt="style properties|style property" data-dfn-type="dfn" id="dfn-style-properties">スタイルプロパティ (style properties) </dfn></dt>
-  <dd>
-  
-  <p>ユーザエージェントによってコンテンツ要素が (画面、音声スピーカー、点字ディスプレイなどを介して) レンダリングされるとき、その値の提示 (フォント、色、サイズ、位置、パディング、音量、合成音声の韻律など) を定義するプロパティ。</p>
+            
+            <dt><dfn data-lt="style properties|style property" id="dfn-style-properties" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">スタイルプロパティ (style properties)</dfn></dt>
+  <dd><p>ユーザエージェントによってコンテンツ要素が (画面、音声スピーカー、点字ディスプレイなどを介して) レンダリングされるとき、その値の提示 (フォント、色、サイズ、位置、パディング、音量、合成音声の韻律など) を定義するプロパティ。</p>
  	<p>スタイルプロパティには、オリジンがいくつか考えられる。</p>
     <ul>
       <li>ユーザエージェントのデフォルトのスタイル: コンテンツ制作者又は利用者のスタイルがない場合は、ユーザエージェントのデフォルトのスタイルプロパティが適用される。ウェブコンテンツ技術には、デフォルトのレンダリングを規定しているものと、規定していないものがある。</li>
@@ -3916,256 +2952,168 @@ details.respec-tests-details > li {
     </ul>
 </dd>
 
-              
-                <dt><dfn data-lt="supplementary content|supplemental content" data-dfn-type="dfn" id="dfn-supplementary-content">補足コンテンツ (supplemental content)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="supplementary content|supplemental content" id="dfn-supplementary-content" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">補足コンテンツ (supplemental content)</dfn></dt>
+<dd><p>元のコンテンツを説明、又はより明確にするために付加された<a href="#dfn-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-content-4" title="コンテンツの構造、提示、及びインタラクションを定義するコード又はマークアップも含めて、ユーザエージェントによって利用者に伝達される情報及び感覚的な体験。">コンテンツ</a>。</p>
    
-   <p>元のコンテンツを説明、又はより明確にするために付加された<a href="#dfn-content" class="internalDFN" data-link-type="dfn">コンテンツ</a>。
-   </p>
+   <aside class="example" id="example-28"><div class="marker"><a class="self-link" href="#example-28">例<bdi> 28</bdi></a></div><p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-web-page-s-21" title="単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又はユーザエージェントがこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。">ウェブページ</a>の音声版。</p></aside>
    
-   <aside class="example" id="example-28"><div class="marker">
-    <a class="self-link" href="#example-28">例<bdi> 28</bdi></a>
-  </div><p><a href="#dfn-web-page-s" class="internalDFN" data-link-type="dfn">ウェブページ</a>の音声版。
-   </p></aside>
+   <aside class="example" id="example-29"><div class="marker"><a class="self-link" href="#example-29">例<bdi> 29</bdi></a></div><p>複雑な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-processes-5" title="ある活動を完了させるために必要な利用者の一連の動作。">プロセス</a>を示したイラスト。</p></aside>
    
-   <aside class="example" id="example-29"><div class="marker">
-    <a class="self-link" href="#example-29">例<bdi> 29</bdi></a>
-  </div><p>複雑な<a href="#dfn-processes" class="internalDFN" data-link-type="dfn">プロセス</a>を示したイラスト。</a>.
-   </p></aside>
-   
-   <aside class="example" id="example-30"><div class="marker">
-    <a class="self-link" href="#example-30">例<bdi> 30</bdi></a>
-  </div><p>調査研究でなされた主要な成果及び提言を要約する段落。
-   </p></aside>
+   <aside class="example" id="example-30"><div class="marker"><a class="self-link" href="#example-30">例<bdi> 30</bdi></a></div><p>調査研究でなされた主要な成果及び提言を要約する段落。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-synchronized-media">同期したメディア (synchronized media)</dfn></dt>
-<dd>
-   
-   <p>情報を提示するために、他のフォーマットと同期した<a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>もしくは<a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアが<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn">メディアによるテキストの代替</a>であって、そのように明確にラベル付けされているものは除く。
-   </p>
+            
+            <dt><dfn id="dfn-synchronized-media" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">同期したメディア (synchronized media)</dfn></dt>
+<dd><p>情報を提示するために、他のフォーマットと同期した<a href="#dfn-audio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-6" title="音の再生技術。">音声</a>もしくは<a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-10" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>、及び／又は時間に依存するインタラクティブな構成要素と同期した音声もしくは映像。ただし、そのメディアが<a href="#dfn-media-alternative-for-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-media-alternative-for-text-4" title="テキストで (直接又はテキストによる代替によって) 既に提示されている情報以上のものを提示していないメディア。">メディアによるテキストの代替</a>であって、そのように明確にラベル付けされているものは除く。</p>
    
 </dd>
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-target">ターゲット (target)</dfn></dt>
-<dd>
-   					
-   
-   					
-     <p>ユーザインタフェース コンポーネントのインタラクティブな領域のような、ポインタアクションを受け入れるディスプレイの領域</p> 
-    <div class="note" id="issue-container-generatedID-129"><div role="heading" class="note-title marker" id="h-note-129" aria-level="3"><span>注記</span></div><p class="">二つ以上のターゲットが重なっている場合、重なっているターゲットが同じアクションを実行する、又は同じページを開く場合を除いて、重なっている領域をターゲットサイズの計算に含めるべきではない。</p></div>
+            
+            <dt><dfn data-lt="targets|target" id="dfn-targets" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ターゲット (target)</dfn></dt>
+<dd><p>ユーザインタフェース コンポーネントのインタラクティブな領域のような、ポインタアクションを受け入れるディスプレイの領域</p> 
+    <div class="note" role="note" id="issue-container-generatedID-129"><div role="heading" class="note-title marker" id="h-note-129" aria-level="3"><span>注記</span></div><p class="">二つ以上のターゲットが重なっている場合、重なっているターゲットが同じアクションを実行する、又は同じページを開く場合を除いて、重なっている領域をターゲットサイズの計算に含めるべきではない。</p></div>
   
 </dd>
 
-
-                <dt>(ウェブコンテンツ) <dfn data-lt="technologies|web technology|web content technology|web content technologies|technology" data-dfn-type="dfn" id="dfn-technologies">技術</dfn> (technology (Web content))
-</dt>
-<dd>
+            
+            <dt><dfn data-lt="technologies|web technology|web content technology|web content technologies|technology" id="dfn-technologies" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">(ウェブコンテンツ) 技術 (technology (Web content))</dfn></dt>
+<dd><p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-8" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-mechanism-13" title="結果を得るためのプロセス又は手法。">メカニズム</a>。</p>
    
-   <p><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がどのようにレンダリング、再生、又は実行するかを符号化する<a href="#dfn-mechanism" class="internalDFN" data-link-type="dfn">メカニズム</a>。</p>
+   <div class="note" role="note" id="issue-container-generatedID-130"><div role="heading" class="note-title marker" id="h-note-130" aria-level="3"><span>注記</span></div><p class="">このガイドラインで用いられている「ウェブ技術」及び (単独で用いられている) 「技術」という用語は、どちらもウェブコンテンツ技術を指す。</p></div>
    
-   <div class="note" id="issue-container-generatedID-130"><div role="heading" class="note-title marker" id="h-note-130" aria-level="3"><span>注記</span></div><p class="">このガイドラインで用いられている「ウェブ技術」及び (単独で用いられている) 「技術」という用語は、どちらもウェブコンテンツ技術を指す。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-131"><div role="heading" class="note-title marker" id="h-note-131" aria-level="3"><span>注記</span></div><p class="">ウェブコンテンツ技術には、マークアップ言語、データ形式、及びプログラム言語などがあり、これらをコンテンツ制作者が単独で、又は組み合わせて用いることによって、静的なウェブページや同期したメディアによる提示、さらには動的なウェブアプリケーションに至るまでの様々なエンドユーザ体験を作ることができる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-131"><div role="heading" class="note-title marker" id="h-note-131" aria-level="3"><span>注記</span></div><p class="">ウェブコンテンツ技術には、マークアップ言語、データ形式、及びプログラム言語などがあり、これらをコンテンツ制作者が単独で、又は組み合わせて用いることによって、静的なウェブページや同期したメディアによる提示、さらには動的なウェブアプリケーションに至るまでの様々なエンドユーザ体験を作ることができる。
-   </p></div>
-   
-   <aside class="example" id="example-31"><div class="marker">
-    <a class="self-link" href="#example-31">例<bdi> 31</bdi></a>
-  </div><p>ウェブコンテンツ技術のよくある事例としては、HTML、CSS、SVG、PNG、PDF、Flash、 JavaScript などがある。
-   </p></aside>
+   <aside class="example" id="example-31"><div class="marker"><a class="self-link" href="#example-31">例<bdi> 31</bdi></a></div><p>ウェブコンテンツ技術のよくある事例としては、HTML、CSS、SVG、PNG、PDF、Flash、 JavaScript などがある。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-text">テキスト (text)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-text" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">テキスト (text)</dfn></dt>
+<dd><p><a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-programmatically-determinable-11" title="支援技術を含む様々なユーザエージェントが抽出でき、利用者に様々な感覚モダリティで提示できるような形のデータがコンテンツ制作者によって提供されたとき、そのデータがソフトウェアによって解釈されること。">プログラムによる解釈</a>が可能な文字の並びで、<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-human-language-s-6" title="人間とコミュニケーションをとるために話される、書かれる、又は (視覚的もしくは触覚的な手段で) 手話にされる言語。">自然言語</a>で何かを表現しているもの。</p>
    
-   <p><a href="#dfn-programmatically-determinable" class="internalDFN" data-link-type="dfn">プログラムによる解釈</a>が可能な文字の並びで、<a href="#dfn-human-language-s" class="internalDFN" data-link-type="dfn">自然言語</a>で何かを表現しているもの。</p>
+</dd>
+            
+            <dt><dfn id="dfn-text-alternative" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">テキストによる代替 (text alternative)</dfn></dt>
+<dd><p>非テキストコンテンツとプログラムで関連付けられる<a href="#dfn-text" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-text-11" title="プログラムによる解釈が可能な文字の並びで、自然言語で何かを表現しているもの。">テキスト</a>。又は<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-non-text-content-2" title="プログラムによる解釈が可能な文字の並びではないコンテンツ、又は文字の並びが自然言語においても何をも表現していないコンテンツ。">非テキストコンテンツ</a>とプログラムで関連付けられるテキストから参照されるテキスト。プログラムで関連付けられたテキストとは、その場所を、非テキストコンテンツからプログラムによる解釈が可能なテキストである。</p>
+   
+   <aside class="example" id="example-32"><div class="marker"><a class="self-link" href="#example-32">例<bdi> 32</bdi></a></div><p>チャートの画像があり、その直後の段落にテキストによる説明がある。チャートに対する短いテキストによる代替で後に説明があることを示している。</p></aside>
+   
+   <div class="note" role="note" id="issue-container-generatedID-132"><div role="heading" class="note-title marker" id="h-note-132" aria-level="3"><span>注記</span></div><p class="">より詳細な情報は、<a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#text-alternatives">Understanding Text Alternatives</a> を参照。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-text-alternative">テキストによる代替 (text alternative)</dfn></dt>
-<dd>
-   
-   <p>非テキストコンテンツとプログラムで関連付けられる<a href="#dfn-text" class="internalDFN" data-link-type="dfn">テキスト</a>。又は<a href="#dfn-non-text-content" class="internalDFN" data-link-type="dfn">非テキストコンテンツ</a>とプログラムで関連付けられるテキストから参照されるテキスト。プログラムで関連付けられたテキストとは、その場所を、非テキストコンテンツからプログラムによる解釈が可能なテキストである。
-   </p>
-   
-   <aside class="example" id="example-32"><div class="marker">
-    <a class="self-link" href="#example-32">例<bdi> 32</bdi></a>
-  </div><p>チャートの画像があり、その直後の段落にテキストによる説明がある。チャートに対する短いテキストによる代替で後に説明があることを示している。
-   </p></aside>
-   
-   <div class="note" id="issue-container-generatedID-133"><div role="heading" class="note-title marker" id="h-note-133" aria-level="3"><span>注記</span></div><p class="">より詳細な情報は、<a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Text Alternatives</a> を参照。
-   </p></div>
-   
-</dd>
-
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-up-event">アップイベント (up-event)</dfn></dt>
-<dd>
-  
-  <p>ポインタのトリガが解除されたときに生じるプラットフォームイベント。</p>
+            
+            <dt><dfn id="dfn-up-event" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">アップイベント (up-event)</dfn></dt>
+<dd><p>ポインタのトリガが解除されたときに生じるプラットフォームイベント。</p>
 	<p>アップイベントは、プラットフォームによっては「タッチエンド」や「マウスアップ」などの異なる名称で呼ばれている場合がある。</p>
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-used-in-an-unusual-or-restricted-way">一般的ではない、又は限定された用法で使われている (used in an unusual or restricted way)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-used-in-an-unusual-or-restricted-way" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">一般的ではない、又は限定された用法で使われている (used in an unusual or restricted way)</dfn></dt>
+<dd><p>そのコンテンツを正しく理解するために、どの定義で使われているのかを利用者が正確に知る必要があるような使われ方をしている言葉。</p>
    
-   <p>そのコンテンツを正しく理解するために、どの定義で使われているのかを利用者が正確に知る必要があるような使われ方をしている言葉。
-   </p>
-   
-   <aside class="example" id="example-33"><div class="marker">
-    <a class="self-link" href="#example-33">例<bdi> 33</bdi></a>
-  </div><p>"gig" という用語は、音楽コンサートの話の中で使われている場合、コンピュータのハードディスクドライブの容量に関する記事とは違うことを意味するが、適切な定義は文脈から判断できる。それに対して、「テキスト」という言葉は、WCAG 2.1 では非常に特定された意味で使われており、その定義が用語集で提供されている。
-   </p></aside>
+   <aside class="example" id="example-33"><div class="marker"><a class="self-link" href="#example-33">例<bdi> 33</bdi></a></div><p> "gig" という用語は、音楽コンサートの話の中で使われている場合、コンピュータのハードディスクドライブの容量に関する記事とは違うことを意味するが、適切な定義は文脈から判断できる。それに対して、「テキスト」という言葉は、WCAG 2.1 では非常に特定された意味で使われており、その定義が用語集で提供されている。</p></aside>
    
 </dd>
 
-                
-                <dt><dfn data-lt="user agents|user agent" data-dfn-type="dfn" id="dfn-user-agents">ユーザエージェント (user agent)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="user agents|user agent" id="dfn-user-agents" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ユーザエージェント (user agent)</dfn></dt>
+<dd><p>ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。</p>
    
-   <p>ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。</p>
-   
-   <aside class="example" id="example-34"><div class="marker">
-    <a class="self-link" href="#example-34">例<bdi> 34</bdi></a>
-  </div><p>ウェブコンテンツの取得、レンダリング及びインタラクションを支援する、ウェブブラウザ、メディアプレーヤ、プラグイン、及びその他のプログラム (<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn">支援技術</a>も含む)。
-   </p></aside>
+   <aside class="example" id="example-34"><div class="marker"><a class="self-link" href="#example-34">例<bdi> 34</bdi></a></div><p>ウェブコンテンツの取得、レンダリング及びインタラクションを支援する、ウェブブラウザ、メディアプレーヤ、プラグイン、及びその他のプログラム (<a href="#dfn-assistive-technologies" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-assistive-technologies-8" title="障害のある利用者の要件を満たすために、主流のユーザエージェントが提供する機能を超えた機能を提供するような、ユーザエージェントとして動作する、又は主流のユーザエージェントと共に動作するハードウェア及び／又はソフトウェア。">支援技術</a>も含む)。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-user-controllable">利用者が制御可能 (user-controllable)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-user-controllable" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">利用者が制御可能 (user-controllable)</dfn></dt>
+<dd><p>利用者によってアクセスされることを意図したデータ。</p>
    
-   <p>利用者によってアクセスされることを意図したデータ。</p>
+   <div class="note" role="note" id="issue-container-generatedID-133"><div role="heading" class="note-title marker" id="h-note-133" aria-level="3"><span>注記</span></div><p class="">これは、インターネットのログ、検索エンジンの監視データなどを指すものではない。</p></div>
    
-   <div class="note" id="issue-container-generatedID-134"><div role="heading" class="note-title marker" id="h-note-134" aria-level="3"><span>注記</span></div><p class="">これは、インターネットのログ、検索エンジンの監視データなどを指すものではない。</p></div>
-   
-   <aside class="example" id="example-35"><div class="marker">
-    <a class="self-link" href="#example-35">例<bdi> 35</bdi></a>
-  </div><p>利用者のアカウントのための氏名及び住所のフィールド。</p></aside>
+   <aside class="example" id="example-35"><div class="marker"><a class="self-link" href="#example-35">例<bdi> 35</bdi></a></div><p>利用者のアカウントのための氏名及び住所のフィールド。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-lt="user interface components|user interface component" data-dfn-type="dfn" id="dfn-user-interface-components">ユーザインタフェース コンポーネント (user interface component)</dfn></dt>
-<dd>
+            
+            <dt><dfn data-lt="user interface components|user interface component" id="dfn-user-interface-components" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ユーザインタフェース コンポーネント (user interface component)</dfn></dt>
+<dd><p>コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。</p>
    
-   <p>コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。
-   </p>
+   <div class="note" role="note" id="issue-container-generatedID-134"><div role="heading" class="note-title marker" id="h-note-134" aria-level="3"><span>注記</span></div><p class="">複数のユーザインタフェース コンポーネントが、単一のプログラム要素で実装されることもある。ここでいう「コンポーネント」は、プログラムの手法と結びついたものではなく、利用者が別々のコントロールとして知覚するものを指す。</p></div>
    
-   <div class="note" id="issue-container-generatedID-135"><div role="heading" class="note-title marker" id="h-note-135" aria-level="3"><span>注記</span></div><p class="">複数のユーザインタフェース コンポーネントが、単一のプログラム要素で実装されることもある。ここでいう「コンポーネント」は、プログラムの手法と結びついたものではなく、利用者が別々のコントロールとして知覚するものを指す。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-135"><div role="heading" class="note-title marker" id="h-note-135" aria-level="3"><span>注記</span></div><p class="">ユーザインタフェース コンポーネントには、フォーム要素、リンクだけでなく、スクリプトで生成されるコンポーネントが含まれる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-136"><div role="heading" class="note-title marker" id="h-note-136" aria-level="3"><span>注記</span></div><p class="">ユーザインタフェース コンポーネントには、フォーム要素、リンクだけでなく、スクリプトで生成されるコンポーネントが含まれる。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-136"><div role="heading" class="note-title marker" id="h-note-136" aria-level="3"><span>注記</span></div><p class="">ここでの「コンポーネント」又は「ユーザインタフェース コンポーネント」は、「ユーザインターフェース要素」とも呼ばれる。</p></div>
    
-   <div class="note" id="issue-container-generatedID-137"><div role="heading" class="note-title marker" id="h-note-137" aria-level="3"><span>注記</span></div><p class="">ここでの「コンポーネント」又は「ユーザインタフェース コンポーネント」は、「ユーザインターフェース要素」とも呼ばれる。
-   </p></div>
-   
-   <aside class="example" id="example-36"><div class="marker">
-    <a class="self-link" href="#example-36">例<bdi> 36</bdi></a>
-  </div><p>アプレットには、コンテンツ内を行単位、ページ単位、又はランダムアクセスで移動するために用いられる「コントロール」がある。これらには、いずれも名前 (name) を割り当て、個別に設定できるようにする必要があるため、それぞれが「ユーザインタフェース コンポーネント」となる。
-   </p></aside>
+   <aside class="example" id="example-36"><div class="marker"><a class="self-link" href="#example-36">例<bdi> 36</bdi></a></div><p>アプレットには、コンテンツ内を行単位、ページ単位、又はランダムアクセスで移動するために用いられる「コントロール」がある。これらには、いずれも名前 (name) を割り当て、個別に設定できるようにする必要があるため、それぞれが「ユーザインタフェース コンポーネント」となる。</p></aside>
    
 </dd>
 
             	
-            	<dt><dfn data-dfn-type="dfn" id="dfn-user-inactivity">利用者の無操作 (user inactivity)</dfn></dt>
-<dd>
-  
-  <p>利用者がいかなる操作も行わない時間が続くこと。</p>
+            	<dt><dfn id="dfn-user-inactivity" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">利用者の無操作 (user inactivity)</dfn></dt>
+<dd><p>利用者がいかなる操作も行わない時間が続くこと。</p>
 	<p>そのトラッキングの方法は、ウェブサイトやアプリケーションによって決定される。</p>
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-video">映像 (video)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-video" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">映像 (video)</dfn></dt>
+<dd><p>写真又は画像を動かす、又はシーケンス化する技術。</p>
    
-   <p>写真又は画像を動かす、又はシーケンス化する技術。</p>
-   
-   <div class="note" id="issue-container-generatedID-138"><div role="heading" class="note-title marker" id="h-note-138" aria-level="3"><span>注記</span></div><p class="">映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-137"><div role="heading" class="note-title marker" id="h-note-137" aria-level="3"><span>注記</span></div><p class="">映像は、アニメーション画像もしく実写画像、又はその両方で構成され得る。</p></div>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-video-only">映像しか含まない (video-only)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-video-only" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">映像しか含まない (video-only)</dfn></dt>
+<dd><p><a href="#dfn-video" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-video-11" title="写真又は画像を動かす、又はシーケンス化する技術。">映像</a>のみを含んだ (<a href="#dfn-audio" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-audio-7" title="音の再生技術。">音声</a>もインタラクションも含まない)、時間に依存する提示。</p>
    
-   <p><a href="#dfn-video" class="internalDFN" data-link-type="dfn">映像</a>のみを含んだ (<a href="#dfn-audio" class="internalDFN" data-link-type="dfn">音声</a>もインタラクションも含まない)、時間に依存する提示。
-   </p>
+</dd>
+            
+            <dt><dfn id="dfn-viewport" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ビューポート (viewport)</dfn></dt>
+<dd><p>ユーザエージェントがコンテンツを提示するオブジェクト。</p>
+   
+   <div class="note" role="note" id="issue-container-generatedID-138"><div role="heading" class="note-title marker" id="h-note-138" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-9" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>は、一つ以上のビューポートでコンテンツを提示する。ビューポートには、ウィンドウ、フレーム、スピーカー、拡大鏡ソフトなどがある。ビューポートは、他のビューポートを含んでいることがある (例えば、入れ子のフレーム)。プロンプト、メニュー、アラートのように、ユーザエージェントが作成するインタフェース コンポーネントは、ビューポートではない。</p></div>
+   
+   <div class="note" role="note" id="issue-container-generatedID-139"><div role="heading" class="note-title marker" id="h-note-139" aria-level="3"><span>注記</span></div><p class="">この定義は、<a href="https://www.w3.org/TR/WAI-USERAGENT/glossary.html">User Agent Accessibility Guidelines 1.0 Glossary</a>  [<cite><a class="bibref" data-link-type="biblio" href="#bib-uaag10" title="User Agent Accessibility Guidelines 1.0">UAAG10</a></cite>] をもとにしている。</p></div>
    
 </dd>
 
-                <dt><dfn data-dfn-type="dfn" id="dfn-viewport">ビューポート (viewport)</dfn></dt>
-<dd>
+            
+            <dt><dfn id="dfn-visually-customized" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">視覚的なカスタマイズ (visually customized)</dfn></dt>
+<dd><p>フォント、サイズ、色、及び背景を設定できること。</p>
    
-   <p>ユーザエージェントがコンテンツを提示するオブジェクト。</p>
+</dd>
+            
+            <dt><dfn data-lt="web page(s)|web pages|Web page" id="dfn-web-page-s" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">ウェブページ (Web page)</dfn></dt>
+<dd><p>単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-agents-10" title="ウェブコンテンツを取得して利用者に提示するあらゆるソフトウェア。">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
    
-   <div class="note" id="issue-container-generatedID-139"><div role="heading" class="note-title marker" id="h-note-139" aria-level="3"><span>注記</span></div><p class=""><a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>は、一つ以上のビューポートでコンテンツを提示する。ビューポートには、ウィンドウ、フレーム、スピーカー、拡大鏡ソフトなどがある。ビューポートは、他のビューポートを含んでいることがある (例えば、入れ子のフレーム)。プロンプト、メニュー、アラートのように、ユーザエージェントが作成するインタフェース コンポーネントは、ビューポートではない。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-140"><div role="heading" class="note-title marker" id="h-note-140" aria-level="3"><span>注記</span></div><p class="">どのような「その他のリソース」も主たるリソースと一緒にレンダリングされるであろうが、これらのリソースが同時にレンダリングされるとは限らない。</p></div>
    
-   <div class="note" id="issue-container-generatedID-140"><div role="heading" class="note-title marker" id="h-note-140" aria-level="3"><span>注記</span></div><p class="">この定義は、<a href="https://www.w3.org/TR/WAI-USERAGENT/glossary.html">User Agent Accessibility Guidelines 1.0 Glossary</a> [<cite><a class="bibref" href="#bib-uaag10">UAAG10</a></cite>]をもとにしている。
-   </p></div>
+   <div class="note" role="note" id="issue-container-generatedID-141"><div role="heading" class="note-title marker" id="h-note-141" aria-level="3"><span>注記</span></div><p class="">このガイドラインの適合範囲に含まれる対象となるウェブページとみなされるためには、リソースが「埋め込まれていない」リソースでなければならない。</p></div>
+   
+   <aside class="example" id="example-37"><div class="marker"><a class="self-link" href="#example-37">例<bdi> 37</bdi></a></div><p>単体のウェブリソースであり、埋め込まれている画像及びメディアのすべてを含んだもの。</p></aside>
+   
+   <aside class="example" id="example-38"><div class="marker"><a class="self-link" href="#example-38">例<bdi> 38</bdi></a></div><p>Asynchronous JavaScript and XML (AJAX) を用いたウェブメールのプログラム。そのプログラム全体は http://example.com/mail に存在しているが、受信トレイ、連絡先、カレンダーがある。受信トレイ、連絡先、又はカレンダーを表示するリンク又はボタンが提供されているが、全体としてページの URI は変更されない。</p></aside>
+   
+   <aside class="example" id="example-39"><div class="marker"><a class="self-link" href="#example-39">例<bdi> 39</bdi></a></div><p>カスタマイズ可能なポータルサイトで、利用者が様々なコンテンツモジュールのセットから表示させるコンテンツを選択できるようなもの。</p></aside>
+   
+   <aside class="example" id="example-40"><div class="marker"><a class="self-link" href="#example-40">例<bdi> 40</bdi></a></div><p>ブラウザで "http://shopping.example.com/" へ行くと、映画のようなインタラクティブなショッピング環境になる。そこでは、視覚的に店内を移動して、店内の棚から商品をドラッグして、目の前にある視覚的な買物カゴに商品を入れる。商品をクリックすると、同時に仕様書が浮き上がるように表示される。これは 1 ページだけのウェブサイトかもしれないし、ウェブサイトの中のほんの 1 ページなのかもしれない。</p></aside>
    
 </dd>
 
-
-                <dt><dfn data-dfn-type="dfn" id="dfn-visually-customized">視覚的なカスタマイズ (visually customized)</dfn></dt>
-<dd>
-   
-   <p>フォント、サイズ、色、及び背景を設定できること。</p>
-   
-</dd>
-
-                <dt><dfn data-lt="web page(s)|web pages|web page" data-dfn-type="dfn" id="dfn-web-page-s">ウェブページ (Web page)</dfn></dt>
-<dd>
-   
-   <p>単一の URI から HTTP で得た埋め込まれていないリソースに加え、レンダリングに使われる、又は<a href="#dfn-user-agents" class="internalDFN" data-link-type="dfn">ユーザエージェント</a>がこのリソースと一緒にレンダリングすることを意図しているその他のあらゆるリソースを合わせたもの。</p>
-   
-   <div class="note" id="issue-container-generatedID-141"><div role="heading" class="note-title marker" id="h-note-141" aria-level="3"><span>注記</span></div><p class="">どのような「その他のリソース」も主たるリソースと一緒にレンダリングされるであろうが、これらのリソースが同時にレンダリングされるとは限らない。
-   </p></div>
-   
-   <div class="note" id="issue-container-generatedID-142"><div role="heading" class="note-title marker" id="h-note-142" aria-level="3"><span>注記</span></div><p class="">このガイドラインの適合範囲に含まれる対象となるウェブページとみなされるためには、リソースが「埋め込まれていない」リソースでなければならない。
-   </p></div>
-   
-   <aside class="example" id="example-37"><div class="marker">
-    <a class="self-link" href="#example-37">例<bdi> 37</bdi></a>
-  </div><p>単体のウェブリソースであり、埋め込まれている画像及びメディアのすべてを含んだもの。</p></aside>
-   
-   <aside class="example" id="example-38"><div class="marker">
-    <a class="self-link" href="#example-38">例<bdi> 38</bdi></a>
-  </div><p>Asynchronous JavaScript and XML (AJAX) を用いたウェブメールのプログラム。そのプログラム全体は http://example.com/mail に存在しているが、受信トレイ、連絡先、カレンダーがある。受信トレイ、連絡先、又はカレンダーを表示するリンク又はボタンが提供されているが、全体としてページの URI は変更されない。
-   </p></aside>
-   
-   <aside class="example" id="example-39"><div class="marker">
-    <a class="self-link" href="#example-39">例<bdi> 39</bdi></a>
-  </div><p>カスタマイズ可能なポータルサイトで、利用者が様々なコンテンツモジュールのセットから表示させるコンテンツを選択できるようなもの。
-   </p></aside>
-   
-   <aside class="example" id="example-40"><div class="marker">
-    <a class="self-link" href="#example-40">例<bdi> 40</bdi></a>
-  </div><p>ブラウザで "http://shopping.example.com/" へ行くと、映画のようなインタラクティブなショッピング環境になる。そこでは、視覚的に店内を移動して、店内の棚から商品をドラッグして、目の前にある視覚的な買物カゴに商品を入れる。商品をクリックすると、同時に仕様書が浮き上がるように表示される。これは 1 ページだけのウェブサイトかもしれないし、ウェブサイトの中のほんの 1 ページなのかもしれない。
-   </p></aside>
-
-</dd>
-
-
-            </dl><!--OddPage-->
-        </section>
-    	    	
-      <section id="input-purposes">
-	<h2 id="x7-input-purposes-for-user-interface-components"><span class="secno">7. </span>ユーザインタフェース コンポーネントの入力目的<span class="permalink"><a href="#input-purposes" aria-label="Permalink for 7. Input Purposes for User Interface Components" title="Permalink for 7. Input Purposes for User Interface Components"><span>§</span></a></span></h2>
-	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は、使わなければならないキーワードというわけではない。そのかわり、これらのキーワードは目的を表現するものとなり、ウェブページに適用されている分類法の観点でとらえなければならないことになる。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
+            
+            
+         </dl>
+         
+      </section>
+      	    	
+      <section id="input-purposes"><div class="header-wrapper"><h2 id="x7-input-purposes-for-user-interface-components"><bdi class="secno">7. </bdi>ユーザインタフェース コンポーネントの入力目的</h2><a class="self-link" href="#input-purposes" aria-label="Permalink for Section 7."></a></div>
+	
+	<p>この節には一般的な<a href="#dfn-user-interface-components" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-user-interface-components-12" title="コンテンツの一部分で、特定の機能を実現するための単一のコントロールとして利用者が知覚するもの。">ユーザインタフェース コンポーネント</a>の入力目的の一覧が含まれる。以下の用語は、使わなければならないキーワードというわけではない。そのかわり、これらのキーワードは目的を表現するものとなり、ウェブページに適用されている分類法の観点でとらえなければならないことになる。コンテンツ制作者は、できれば、セマンティック上の目的を示すよう選ばれた分類法でコントロールをマークアップする。これはユーザエージェントと支援技術に、より多くの人々がコンテンツを理解し使用できるようにする個別化された提示を適用する可能性を提供する。</p>
   
-  <div class="note" id="issue-container-generatedID-143"><div role="heading" class="note-title marker" id="h-note-143" aria-level="3"><span>注記</span></div><p class="">入力タイプの目的の一覧は、<a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 Autofill field のセクション</a> で定義されているコントロールの目的に基づいている。しかし、異なるウェブコンテンツ技術は、HTML 仕様で定義されているものと同じ概念の一部又は全部を持ってもよく、以下で示される意味に対応付けられているその概念のみが要求されることを理解することが重要である。</p></div>
+  <div class="note" role="note" id="issue-container-generatedID-142"><div role="heading" class="note-title marker" id="h-note-142" aria-level="3"><span>注記</span></div><p class="">入力タイプの目的の一覧は、<a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">HTML 5.2 Autofill field のセクション</a>で定義されているコントロールの目的に基づいている。しかし、異なるウェブコンテンツ技術は、HTML 仕様で定義されているものと同じ概念の一部又は全部を持ってもよく、以下で示される意味に対応付けられているその概念のみが要求されることを理解することが重要である。</p></div>
   <div class="note"><div role="heading" class="note-title marker" aria-level="5"><span>訳注</span></div><p>この節での「セマンティック上の」という記載の趣旨は、ウェブを構成するシステムが意味的に正確に解釈できるような、というものである。</p></div>
-	    
+
   <p>以下に示す入力コントロールの目的は、コンテンツの利用者に関連づけること、その個人に関連する情報にのみ適用することを意図している。</p>
 
 	<ul>
@@ -4173,7 +3121,7 @@ details.respec-tests-details > li {
 		<li><strong>honorific-prefix</strong> - 敬称又は称号 (例えば、"Mr."、"Ms."、"Dr."、"M<sup>lle</sup>")</li>
 		<li><strong>given-name</strong> - Given name (一部の西洋文化において、<i>first name</i> として知られる)</li>
 		<li><strong>additional-name</strong> - Additional names (一部の西洋文化において、<i>middle names</i> として知られる、姓の前にあるファーストネームではない名前)</li>
-		<li><strong>family-name</strong> - Family name (一部の西洋文化において、<i>last  name</i> 又は <i>surname</i> として知られる)</li>
+		<li><strong>family-name</strong> - Family name (一部の西洋文化において、<i>last name</i> 又は <i>surname</i> として知られる)</li>
 		<li><strong>honorific-suffix</strong> - 接尾語 (例えば、"Jr."、"B.Sc."、"MBASW"、"II")</li>
 		<li><strong>nickname</strong> - ニックネーム、スクリーンネーム、ハンドル: フルネームの代わりに使用する一般的に短い名前</li>
 		<li><strong>organization-title</strong> - 職種 (例えば"Software Engineer"、"Senior Vice President"、"Deputy Managing Director")</li>
@@ -4194,8 +3142,8 @@ details.respec-tests-details > li {
 		<li><strong>postal-code</strong> - 郵便番号、ZIP コード、CEDEX コード (CEDEX の場合、"CEDEX"を、関連する場合<i lang="fr">郡</i>を、<strong>address-level2</strong> フィールドに追加する)</li>
 		<li><strong>cc-name</strong> - 決済手段に与えられるようなフルネーム</li>
 		<li><strong>cc-given-name</strong> - 決済手段に与えられるような Given name (一部の西洋文化において、<i>first name</i> として知られる)</li>
-		<li><strong>cc-additional-name</strong> - 決済手段に与えられるような Additional names (一部の西洋文化において、<i>middle names</i> として知られる)</li>
-		<li><strong>cc-family-name</strong> - 決済手段に与えられるような Family name (一部の西洋文化において、<i>last  name</i> 又は <i>surname</i> として知られる)</li>
+		<li><strong>cc-additional-name</strong> - 決済手段に与えられるような Additional names (一部の西洋文化において、 <i>middle names</i> として知られる)</li>
+		<li><strong>cc-family-name</strong> - 決済手段に与えられるような Family name (一部の西洋文化において、<i>last name</i> 又は <i>surname</i> として知られる)</li>
 		<li><strong>cc-number</strong> - 決済手段 (例えばクレジットカード番号) を識別するコード</li>
 		<li><strong>cc-exp</strong> - 決済手段の有効期限</li>
 		<li><strong>cc-exp-month</strong> - 決済手段の有効期限の月コンポーネント</li>
@@ -4221,231 +3169,894 @@ details.respec-tests-details > li {
 		<li><strong>tel-local-suffix</strong> - コンポーネントが二つのコンポーネントに分割される場合の、市外局番に続く電話番号のコンポーネントの 2 番目の部分</li>
 		<li><strong>tel-extension</strong> - 電話番号の内部拡張コード</li>
 		<li><strong>email</strong> - 電子メールアドレス</li>
-		<li><strong>impp</strong> - インスタントメッセージングプロトコルのエンドポイントを表す URL (例えば、"<strong>aim:goim?screenname=example</strong>"又は <strong>xmpp:fred@example.net</strong>")</li>
-	</ul><!--OddPage-->
+		<li><strong>impp</strong> - インスタントメッセージングプロトコルのエンドポイントを表す URL (例えば、"<strong>aim:goim?screenname=example</strong>" 又は "<strong>xmpp:fred@example.net</strong>")</li>
+	</ul>
 	
-      </section>
+</section>
 
-      <section class="appendix" id="changelog">
-	<h2 id="a-change-log"><bdi class="secno">A. </bdi>変更点<span class="permalink"><a class="self-link" href="#changelog" aria-label="Permalink for Appendix A."><span>§</span></a></span></h2>
-	
-         <p>このセクションでは、WCAG 2.1 が <abbr title="World Wide Web Consortium">W3C</abbr> 勧告として発行されてからの変更点を示す。これらの変更点は、<a href="https://www.w3.org/WAI/WCAG21/errata/">Errata</a>としても記録されている。
-         </p>
+      
+      	
+      <section class="appendix" id="changelog"><div class="header-wrapper"><h2 id="a-change-log"><bdi class="secno">A. </bdi>変更点</h2><a class="self-link" href="#changelog" aria-label="Permalink for Appendix A."></a></div>
+         		
          
-	<p><a href="https://www.w3.org/TR/2018/REC-WCAG21-20180605/">2018 年 6 月 5 日の <abbr title="World Wide Web Consortium">W3C</abbr> 勧告</a>以降の変更点:
-         </p>
+         		
+         <p>このセクションでは、WCAG 2.1 が <abbr title="World Wide Web Consortium">>W3C</abbr> 勧告として発行されてからの変更点を示す。これらの変更点は、<a href="https://www.w3.org/WAI/WCAG21/errata/">errata</a> としても記録されている。</p>
+         
+         <p>2018 年 6 月 5 日の <a href="https://www.w3.org/TR/2018/REC-WCAG21-20180605/"><abbr title="World Wide Web Consortium">W3C</abbr> 勧告</a>以降の変更点:</p>
          
          <ul>
             					
-            <li>In the <a href="https://www.w3.org/TR/WCAG21/#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by <abbr title="World Wide Web Consortium">W3C</abbr> Members..." appears
-               twice. The first instance of this paragraph has been removed.
-            </li>
+            <li>In the <a href="https://www.w3.org/TR/WCAG21/#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by <abbr title="World Wide Web Consortium">W3C</abbr> Members..." appears twice. The first instance of this paragraph has been removed.</li>
             					
-            <li>In the <a href="https://www.w3.org/TR/WCAG21/#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" has been changed to "WCAG 2.1".
-            </li>
+            <li>In the <a href="https://www.w3.org/TR/WCAG21/#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" has been changed to "WCAG 2.1".</li>
             					
-            <li>In the <a href="https://www.w3.org/TR/WCAG21/#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" have been changed to "criteria".
-            </li>
+            <li>In the <a href="https://www.w3.org/TR/WCAG21/#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" have been changed to "criteria".</li>
             					
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which has been removed.
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which has been removed.</li>
             					
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" has been changed to "dismissible".
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" has been changed to "dismissible".</li>
             					
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#robust">4. Robust</a>, repetition of the word "by" has been removed.
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#robust">4. Robust</a>, repetition of the word "by" has been removed.</li>
             					
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#cc2">5.2.2 Full pages</a>, the third note began with "New" which has been removed.
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#cc2">5.2.2 Full pages</a>, the third note began with "New" which has been removed.</li>
             					
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted
-               when this becomes a Rec." has been removed.
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." has been removed.</li>
             					
-            <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note has been changed to be an example of the first note,
-               leaving only two actual notes.
-            </li>
+            <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note has been changed to be an example of the first note, leaving only two actual notes.</li>
             					
-            <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-technologies">technology</a>, the third note has been changed to be an example.
-            </li>
+            <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-technologies">technology</a>, the third note has been changed to be an example.</li>
             					
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" has been changed to "country".
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" has been changed to "country".</li>
             					
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content
-               is not necessarily restricted to landscape or portrait display orientation".
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
             			
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".
-            </li>
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
             					
-            <li>In the <a href="https://www.w3.org/TR/WCAG21/#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.
-            </li>
+            <li>In the <a href="https://www.w3.org/TR/WCAG21/#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
             
-            <li>In <a href="https://www.w3.org/TR/WCAG21/#parsing">4.1.1 Parsing</a> one note was deleted, and two notes were added, including: "This Success Criterion
-               should be considered as always satisfied for any content using HTML or XML."
-            </li> 
+            <li>In <a href="https://www.w3.org/TR/WCAG21/#parsing">4.1.1 Parsing</a> one note was deleted, and two notes were added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li> 
             				
          </ul>
          		
-	<p>完全な<a href="https://github.com/w3c/wcag/commits/WCAG-2.1/guidelines/index.html">WCAG 2.1 に対するコミット履歴</a>も参照可能である。</p>
+         <p>完全な <a href="https://github.com/w3c/wcag/commits/WCAG-2.1/guidelines/index.html">WCAG 2.1 に対するコミット履歴</a>も参照可能である。</p>
          	
       </section>
-
-      <section class="appendix" id="acknowledgments">
-    <h2 id="b-acknowledgments"><span class="secno">B. </span>謝辞<span class="permalink"><a href="#acknowledgments" aria-label="Permalink for A. Acknowledgments" title="Permalink for A. Acknowledgments"><span>§</span></a></span></h2><p><em>この節は規定ではない。</em></p>
-    <p>Accessibility Guidelines Working Group (AG WG) への参加に関する詳細な情報は、<a href="https://www.w3.org/WAI/GL/">ワーキンググループのホームページ</a>を参照。</p>
-
-    <section id="ack_participants-active">
-        <h3 id="b-1-participants-of-the-ag-wg-active-in-the-development-of-this-document"><span class="secno">B.1 </span>この文書の作成時にアクティブだった AG WG 参加者:<span class="permalink"><a href="#ack_participants-active" aria-label="Permalink for A.1 Participants of the AG WG active in the development of this document:" title="Permalink for A.1 Participants of the AG WG active in the development of this document:"><span>§</span></a></span></h3>
-        <ul>
-          	<li>Jake Abma (Invited Expert)</li>
-            <li>Shadi Abou-Zahra (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
-        	<li>Chuck Adams (Oracle Corporation)</li>
-        	<li>Amani Ali (Nomensa)</li>
-            <li>Jim Allan (Invited Expert)</li>
-            <li>Paul Adam (Deque Systems, Inc.)</li>
-        	<li>Christopher Auclair (VitalSource | Ingram Content Group)</li>
-            <li>Jon Avila (Level Access)</li>
-            <li>Tom Babinszki (IBM Corporation)</li>
-            <li>Bruce Bailey (U.S. Access Board)</li>
-            <li>Renaldo Bernard (University of Southampton)</li>
-        	<li>Chris Blouch (Level Access)</li>
-        	<li>Denis Boudreau (Deque Systems, Inc.)</li>
-            <li>Judy Brewer (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
-            <li>Shari Butler (Pearson plc)</li>
-            <li>Thaddeus Cambron (Invited Expert)</li>
-            <li>Alastair Campbell (Nomensa)</li>
-            <li>Laura Carlson (Invited Expert)</li>
-            <li>Louis Cheng (Google)</li>
-            <li>Pietro Cirrincione (Invited Expert)</li>
-            <li>Vivienne Conway (Web Key IT Pty Ltd)</li>
-            <li>Michael Cooper (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
-            <li>Jennifer Delisi (Invited Expert)</li>
-            <li>Romain Deltour (DAISY Consortium)</li>
-            <li>Wayne Dick (Knowbility, Inc)</li>
-            <li>Chaohai Ding (University of Southampton)</li>
-            <li>Kim Dirks (Thomson Reuters)</li>
-            <li>Shwetank Dixit (BarrierBreak Technologies)</li>
-            <li>Anthony Doran (TextHelp)</li>
-            <li>E.A. Draffan (University of Southampton)</li>
-            <li>Eric Eggert (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
-            <li>Michael Elledge (Invited Expert)</li>
-            <li>David Fazio (Invited Expert)</li>
-            <li>Wilco Fiers (Deque Systems, Inc.)</li>
-            <li>Detlev Fischer (Invited Expert)</li>
-            <li>John Foliot (Deque Systems, Inc.)</li>
-            <li>Matt Garrish (DAISY Consortium)</li>
-            <li>Alistair Garrison (Level Access)</li>
-            <li>Michael Gower (IBM Corporation)</li>
-            <li>Jon Gunderson</li>
-            <li>Markku Hakkinen (Educational Testing Service)</li>
-            <li>Katie Haritos-Shea (Knowbility, Inc)</li>
-           	<li>Andy Heath (Invited Expert)</li>
-            <li>Shawn Henry (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
-            <li>Thomas Hoffman (Educational Testing Service)</li>
-            <li>Sarah Horton (The Paciello Group, LLC)</li>
-            <li>Stefan Johansson (Invited Expert)</li>
-            <li>Marc Johlic (IBM Corporation)</li>
-            <li>Rick Johnson (VitalSource | Ingram Content Group)</li>
-          	<li>Crystal Jones (Microsoft Corporation)</li>
-            <li>Andrew Kirkpatrick (Adobe)</li>
-            <li>John Kirkwood (Invited Expert)</li>
-            <li>Jason Kiss (Department of Internal Affairs, New Zealand Government)</li>
-            <li>Maureen Kraft (IBM Corporation)</li>
-            <li>JaEun Ku (University of Illinois at Urbana-Champaign)</li>
-            <li>Patrick Lauke (The Paciello Group, LLC)</li>
-            <li>Shawn Lauriat (Google, Inc.)</li>
-            <li>Steve Lee (Invited Expert)</li>
-          	<li>Alex Li (Microsoft Corporation)</li>
-          	<li>Chris Loiselle (Invited Expert)</li>
-            <li>Greg Lowney (Invited Expert)</li>
-            <li>Adam Lund (Thomson Reuters)</li>
-            <li>David MacDonald (Invited Expert)</li>
-            <li>Erich Manser (IBM Corporation)</li>
-        	<li>Kurt Mattes (Deque Systems, Inc.)</li>
-            <li>Scott McCormack (Level Access)</li>
-            <li>Chris McMeeking (Deque Systems, Inc.)</li>
-            <li>Jan McSorley (Pearson plc)</li>
-            <li>Neil Milliken (Unify Software and Solutions)</li>
-            <li>Rachael Montgomery (Invited Expert)</li>
-            <li>Mary Jo Mueller (IBM Corporation)</li>
-          	<li>Brooks Newton (Thomson Reuters)</li>
-            <li>James Nurthen (Oracle Corporation)</li>
-            <li>Joshue O Connor (Invited Expert)</li>
-            <li>Sailesh Panchang (Deque Systems, Inc.)</li>
-            <li>Charu Pandhi (IBM Corporation)</li>
-            <li>Kim Patch (Invited Expert)</li>
-        	<li>Melanie Philipp (Deque Systems, Inc.)</li>
-            <li>Mike Pluke (Invited Expert)</li>
-            <li>Ian Pouncey (The Paciello Group, LLC)</li>
-          	<li>Ruoxi Ran (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
-            <li>Stephen Repsher (Invited Expert)</li>
-            <li>Jan Richards (Invited Expert)</li>
-            <li>John Rochford (Invited Expert)</li>
-            <li>Marla Runyan (Invited Expert)</li>
-        	<li>Stefan Schnabel (SAP SE)</li>
-            <li>Ayelet Seeman (Invited Expert)</li>
-            <li>Lisa Seeman-Kestenbaum (Invited Expert)</li>
-            <li>Glenda Sims (Deque Systems, Inc.)</li>
-          	<li>Avneesh Singh (DAISY Consortium)</li>
-            <li>David Sloan (The Paciello Group, LLC)</li>
-            <li>Alan Smith (Invited Expert)</li>
-            <li>Jim Smith (Unify Software and Solutions)</li>
-            <li>Andrew Somers (Invited Expert)</li>
-            <li>Adam Solomon (Invited Expert)</li>
-            <li>Jaeil Song (National Information Society Agency (NIA))</li>
-            <li>Jeanne Spellman (The Paciello Group, LLC)</li>
-            <li>Makoto Ueki (Invited Expert)</li>
-        	<li>Jatin Vaishnav (Deque Systems, Inc.)</li>
-            <li>Gregg Vanderheiden (Raising the Floor)</li>
-            <li>Evangelos Vlachogiannis (Fraunhofer Gesellschaft)</li>
-            <li>Kathleen Wahlbin (Invited Expert)</li>
-            <li>Can Wang (Zhejiang University)</li>
-            <li>Léonie Watson (The Paciello Group, LLC)</li>
-            <li>Jason White (Educational Testing Service)</li>
-        	<li>Mark Wilcock (Unify Software and Solutions)</li>
-        </ul>
-    </section>
-
-    <section id="ack_participants-previous">
-        <h3 id="b-2-other-previously-active-wcag-wg-participants-and-other-contributors-to-wcag-2-0-wcag-2-1-or-supporting-resources"><span class="secno">B.2 </span>以前に活動していた他の WCAG WG 参加者及び WCAG 2.0、WCAG 2.1、又は関連文書への他の貢献者<span class="permalink"><a href="#ack_participants-previous" aria-label="Permalink for A.2 Other previously active WCAG WG participants and other contributors to WCAG 2.0, WCAG 2.1, or supporting resources " title="Permalink for A.2 Other previously active WCAG WG participants and other contributors to WCAG 2.0, WCAG 2.1, or supporting resources "><span>§</span></a></span></h3>
-    	<p>Paul Adam, Jenae Andershonis, Wilhelm Joys Andersen, Andrew Arch, Avi Arditti, Aries Arditi, Mark Barratt, Mike Barta, Sandy Bartell, Kynn Bartlett, Chris Beer, Charles Belov, Marco Bertoni, Harvey Bingham, Chris Blouch, Paul Bohman, Frederick Boland, Denis Boudreau, Patrice Bourlon, Andy Brown, Dick Brown, Doyle Burnett, Raven Calais, Ben Caldwell, Tomas Caspers, Roberto Castaldo, Sofia Celic-Li, Sambhavi Chandrashekar, Mike Cherim, Jonathan Chetwynd, Wendy Chisholm, Alan Chuter, David M Clark, Joe Clark, Darcy Clarke, James Coltham, Earl Cousins, James Craig, Tom Croucher, Pierce Crowell, Nir Dagan, Daniel Dardailler, Geoff Deering, Sébastien Delorme, Pete DeVasto, Iyad Abu Doush, Sylvie Duchateau, Cherie Eckholm, Roberto Ellero, Don Evans, Gavin Evans, Neal Ewers, Steve Faulkner, Bengt Farre, Lainey Feingold, Wilco Fiers, Michel Fitos, Alan J. Flavell, Nikolaos Floratos, Kentarou Fukuda, Miguel Garcia, P.J. Gardner, Alistair Garrison, Greg Gay, Becky Gibson, Al Gilman, Kerstin Goldsmith, Michael Grade, Karl Groves, Loretta Guarino Reid, Jon Gunderson, Emmanuelle Gutiérrez y Restrepo, Brian Hardy, Eric Hansen, Benjamin Hawkes-Lewis, Sean Hayes, Shawn Henry, Hans Hillen, Donovan Hipke, Bjoern Hoehrmann, Allen Hoffman, Chris Hofstader, Yvette Hoitink, Martijn Houtepen, Carlos Iglesias, Richard Ishida, Jonas Jacek, Ian Jacobs, Phill Jenkins, Barry Johnson, Duff Johnson, Jyotsna Kaki, Shilpi Kapoor, Leonard R. Kasday, Kazuhito Kidachi, Ken Kipness, Johannes Koch, Marja-Riitta Koivunen, Preety Kumar, Kristjan Kure, Andrew LaHart, Gez Lemon, Chuck Letourneau, Aurélien Levy, Harry Loots, Scott Luebking, Tim Lacy, Jim Ley, Alex Li, William Loughborough, N Maffeo, Mark Magennis, Kapsi Maria, Luca Mascaro, Matt May, Sheena McCullagh, Liam McGee, Jens Oliver Meiert, Niqui Merret, Jonathan Metz, Alessandro Miele, Steven Miller, Mathew J Mirabella, Matt May, Marti McCuller, Sorcha Moore, Charles F. Munat, Robert Neff, Charles Nevile, Liddy Nevile, Dylan Nicholson, Bruno von Niman, Tim Noonan, Sebastiano Nutarelli, Graham Oliver, Sean B. Palmer, Devarshi Pant, Nigel Peck, Anne Pemberton, David Poehlman, Ian Pouncey, Charles Pritchard, Kerstin Probiesch, W Reagan, Adam Victor Reed, Chris Reeve, Chris Ridpath, Lee Roberts, Mark Rogers, Raph de Rooij, Gregory J. Rosmaita, Matthew Ross, Sharron Rush, Joel Sanda, Janina Sajka, Roberto Scano, Gordon Schantz, Tim van Schie, Wolf Schmidt, Stefan Schnabel, Cynthia Shelly, Glenda Sims, John Slatin, Becky Smith, Jared Smith, Andi Snow-Weaver, Neil Soiffer, Mike Squillace, Michael Stenitzer, Diane Stottlemyer, Christophe Strobbe, Sarah J Swierenga, Jim Thatcher, Terry Thompson, Justin Thorp, David Todd, Mary Utt, Jean Vanderdonckt, Carlos A Velasco, Eric Velleman, Gijs Veyfeyken, Dena Wainwright, Paul Walsch, Daman Wandke, Richard Warren, Elle Waters, Takayuki Watanabe, Gian Wild, David Wooley, Wu Wei, Kenny Zhang, Leona Zumbo.</p>
-    </section>
-
-    <section id="enabling-funders">
-        <h3 id="b-3-enabling-funders"><span class="secno">B.3</span> 有効な資金提供者<span class="permalink"><a href="#enabling-funders" aria-label="Permalink for A.3 Enabling funders" title="Permalink for A.3 Enabling funders"><span>§</span></a></span></h3>
-        <p> この出版物は、当初は契約番号 ED-OSE-10-C-0067 のもとで、現在は契約番号 HHSP23301500054C のもとで米国保健福祉省・障害者自立生活リハビリテーション研究所 (NIDILRR) の政府資金によって一部賄われている。この出版物の内容は、必ずしも米国保健福祉省又は米国教育省の見解や政策を反映するものではなく、また商品名、商用製品、組織の言及は米国政府による支持を意味するものではない。</p><!--OddPage-->
-    </section>
+      	
+      <section class="appendix informative section" id="acknowledgements"><div class="header-wrapper"><h2 id="b-acknowledgments"><bdi class="secno">B. </bdi>謝辞</h2><a class="self-link" href="#acknowledgements" aria-label="Permalink for Appendix B."></a></div><p><em>この節は規定ではない。</em></p>
+         		
+         
+         		
+         <p>Accessibility Guidelines Working Group (AG WG) への参加に関する詳細な情報は、<a href="https://www.w3.org/WAI/GL/">ワーキンググループのホームページ</a>を参照。</p>
+         		<section id="ack_participants-active"><div class="header-wrapper"><h3 id="b-1-participants-of-the-ag-wg-active-in-the-development-of-this-document"><bdi class="secno">B.1 </bdi>この文書の作成時にアクティブだった AG WG 参加者:</h3><a class="self-link" href="#ack_participants-active" aria-label="Permalink for Appendix B.1"></a></div>
+	
+	<ul>
+		<li>Jake Abma (Invited Expert)</li>
+		<li>Shadi Abou-Zahra (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
+		<li>Chuck Adams (Oracle Corporation)</li>
+		<li>Amani Ali (Nomensa)</li>
+		<li>Jim Allan (Invited Expert)</li>
+		<li>Paul Adam (Deque Systems, Inc.)</li>
+		<li>Christopher Auclair (VitalSource | Ingram Content Group)</li>
+		<li>Jon Avila (Level Access)</li>
+		<li>Tom Babinszki (IBM Corporation)</li>
+		<li>Bruce Bailey (U.S. Access Board)</li>
+		<li>Renaldo Bernard (University of Southampton)</li>
+		<li>Chris Blouch (Level Access)</li>
+		<li>Denis Boudreau (Deque Systems, Inc.)</li>
+		<li>Judy Brewer (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
+		<li>Shari Butler (Pearson plc)</li>
+		<li>Thaddeus Cambron (Invited Expert)</li>
+		<li>Alastair Campbell (Nomensa)</li>
+		<li>Laura Carlson (Invited Expert)</li>
+		<li>Louis Cheng (Google)</li>
+		<li>Pietro Cirrincione (Invited Expert)</li>
+		<li>Vivienne Conway (Web Key IT Pty Ltd)</li>
+		<li>Michael Cooper (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
+		<li>Jennifer Delisi (Invited Expert)</li>
+		<li>Romain Deltour (DAISY Consortium)</li>
+		<li>Wayne Dick (Knowbility, Inc)</li>
+		<li>Chaohai Ding (University of Southampton)</li>
+		<li>Kim Dirks (Thomson Reuters)</li>
+		<li>Shwetank Dixit (BarrierBreak Technologies)</li>
+		<li>Anthony Doran (TextHelp)</li>
+		<li>E.A. Draffan (University of Southampton)</li>
+		<li>Eric Eggert (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
+		<li>Michael Elledge (Invited Expert)</li>
+		<li>David Fazio (Invited Expert)</li>
+		<li>Wilco Fiers (Deque Systems, Inc.)</li>
+		<li>Detlev Fischer (Invited Expert)</li>
+		<li>John Foliot (Deque Systems, Inc.)</li>
+		<li>Matt Garrish (DAISY Consortium)</li>
+		<li>Alistair Garrison (Level Access)</li>
+		<li>Michael Gower (IBM Corporation)</li>
+		<li>Jon Gunderson</li>
+		<li>Markku Hakkinen (Educational Testing Service)</li>
+		<li>Katie Haritos-Shea (Knowbility, Inc)</li>
+		<li>Andy Heath (Invited Expert)</li>
+		<li>Shawn Henry (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
+		<li>Thomas Hoffman (Educational Testing Service)</li>
+		<li>Sarah Horton (The Paciello Group, LLC)</li>
+		<li>Stefan Johansson (Invited Expert)</li>
+		<li>Marc Johlic (IBM Corporation)</li>
+		<li>Rick Johnson (VitalSource | Ingram Content Group)</li>
+		<li>Crystal Jones (Microsoft Corporation)</li>
+		<li>Andrew Kirkpatrick (Adobe)</li>
+		<li>John Kirkwood (Invited Expert)</li>
+		<li>Jason Kiss (Department of Internal Affairs, New Zealand Government)</li>
+		<li>Maureen Kraft (IBM Corporation)</li>
+		<li>JaEun Ku (University of Illinois at Urbana-Champaign)</li>
+		<li>Patrick Lauke (The Paciello Group, LLC)</li>
+		<li>Shawn Lauriat (Google, Inc.)</li>
+		<li>Steve Lee (Invited Expert)</li>
+		<li>Alex Li (Microsoft Corporation)</li>
+		<li>Chris Loiselle (Invited Expert)</li>
+		<li>Greg Lowney (Invited Expert)</li>
+		<li>Adam Lund (Thomson Reuters)</li>
+		<li>David MacDonald (Invited Expert)</li>
+		<li>Erich Manser (IBM Corporation)</li>
+		<li>Kurt Mattes (Deque Systems, Inc.)</li>
+		<li>Scott McCormack (Level Access)</li>
+		<li>Chris McMeeking (Deque Systems, Inc.)</li>
+		<li>Jan McSorley (Pearson plc)</li>
+		<li>Neil Milliken (Unify Software and Solutions)</li>
+		<li>Rachael Montgomery (Invited Expert)</li>
+		<li>Mary Jo Mueller (IBM Corporation)</li>
+		<li>Brooks Newton (Thomson Reuters)</li>
+		<li>James Nurthen (Oracle Corporation)</li>
+		<li>Joshue O Connor (Invited Expert)</li>
+		<li>Sailesh Panchang (Deque Systems, Inc.)</li>
+		<li>Charu Pandhi (IBM Corporation)</li>
+		<li>Kim Patch (Invited Expert)</li>
+		<li>Melanie Philipp (Deque Systems, Inc.)</li>
+		<li>Mike Pluke (Invited Expert)</li>
+		<li>Ian Pouncey (The Paciello Group, LLC)</li>
+		<li>Ruoxi Ran (<abbr title="World Wide Web Consortium">W3C</abbr>)</li>
+		<li>Stephen Repsher (Invited Expert)</li>
+		<li>Jan Richards (Invited Expert)</li>
+		<li>John Rochford (Invited Expert)</li>
+		<li>Marla Runyan (Invited Expert)</li>
+		<li>Stefan Schnabel (SAP SE)</li>
+		<li>Ayelet Seeman (Invited Expert)</li>
+		<li>Lisa Seeman-Kestenbaum (Invited Expert)</li>
+		<li>Glenda Sims (Deque Systems, Inc.)</li>
+		<li>Avneesh Singh (DAISY Consortium)</li>
+		<li>David Sloan (The Paciello Group, LLC)</li>
+		<li>Alan Smith (Invited Expert)</li>
+		<li>Jim Smith (Unify Software and Solutions)</li>
+		<li>Andrew Somers (Invited Expert)</li>
+		<li>Adam Solomon (Invited Expert)</li>
+		<li>Jaeil Song (National Information Society Agency (NIA))</li>
+		<li>Jeanne Spellman (The Paciello Group, LLC)</li>
+		<li>Makoto Ueki (Invited Expert)</li>
+		<li>Jatin Vaishnav (Deque Systems, Inc.)</li>
+		<li>Gregg Vanderheiden (Raising the Floor)</li>
+		<li>Evangelos Vlachogiannis (Fraunhofer Gesellschaft)</li>
+		<li>Kathleen Wahlbin (Invited Expert)</li>
+		<li>Can Wang (Zhejiang University)</li>
+		<li>Léonie Watson (The Paciello Group, LLC)</li>
+		<li>Jason White (Educational Testing Service)</li>
+		<li>Mark Wilcock (Unify Software and Solutions)</li>
+	</ul>
 </section>
-
+         		<section id="ack_participants-previous"><div class="header-wrapper"><h3 id="b-2-other-previously-active-wcag-wg-participants-and-other-contributors-to-wcag-2-0-wcag-2-1-or-supporting-resources"><bdi class="secno">B.2 </bdi>以前に活動していた他の WCAG WG 参加者及び WCAG 2.0、WCAG 2.1、又は関連文書への他の貢献者</h3><a class="self-link" href="#ack_participants-previous" aria-label="Permalink for Appendix B.2"></a></div>
+	
+	<p>Paul Adam, Jenae Andershonis, Wilhelm Joys Andersen, Andrew Arch, Avi Arditti, Aries Arditi, Mark Barratt, Mike Barta, Sandy Bartell, Kynn Bartlett, Chris Beer, Charles Belov, Marco Bertoni, Harvey Bingham, Chris Blouch, Paul Bohman, Frederick Boland, Denis Boudreau, Patrice Bourlon, Andy Brown, Dick Brown, Doyle Burnett, Raven Calais, Ben Caldwell, Tomas Caspers, Roberto Castaldo, Sofia Celic-Li, Sambhavi Chandrashekar, Mike Cherim, Jonathan Chetwynd, Wendy Chisholm, Alan Chuter, David M Clark, Joe Clark, Darcy Clarke, James Coltham, Earl Cousins, James Craig, Tom Croucher, Pierce Crowell, Nir Dagan, Daniel Dardailler, Geoff Deering, Sébastien Delorme, Pete DeVasto, Iyad Abu Doush, Sylvie Duchateau, Cherie Eckholm, Roberto Ellero, Don Evans, Gavin Evans, Neal Ewers, Steve Faulkner, Bengt Farre, Lainey Feingold, Wilco Fiers, Michel Fitos, Alan J. Flavell, Nikolaos Floratos, Kentarou Fukuda, Miguel Garcia, P.J. Gardner, Alistair Garrison, Greg Gay, Becky Gibson, Al Gilman, Kerstin Goldsmith, Michael Grade, Karl Groves, Loretta Guarino Reid, Jon Gunderson, Emmanuelle Gutiérrez y Restrepo, Brian Hardy, Eric Hansen, Benjamin Hawkes-Lewis, Sean Hayes, Shawn Henry, Hans Hillen, Donovan Hipke, Bjoern Hoehrmann, Allen Hoffman, Chris Hofstader, Yvette Hoitink, Martijn Houtepen, Carlos Iglesias, Richard Ishida, Jonas Jacek, Ian Jacobs, Phill Jenkins, Barry Johnson, Duff Johnson, Jyotsna Kaki, Shilpi Kapoor, Leonard R. Kasday, Kazuhito Kidachi, Ken Kipness, Johannes Koch, Marja-Riitta Koivunen, Preety Kumar, Kristjan Kure, Andrew LaHart, Gez Lemon, Chuck Letourneau, Aurélien Levy, Harry Loots, Scott Luebking, Tim Lacy, Jim Ley, Alex Li, William Loughborough, N Maffeo, Mark Magennis, Kapsi Maria, Luca Mascaro, Matt May, Sheena McCullagh, Liam McGee, Jens Oliver Meiert, Niqui Merret, Jonathan Metz, Alessandro Miele, Steven Miller, Mathew J Mirabella, Matt May, Marti McCuller, Sorcha Moore, Charles F. Munat, Robert Neff, Charles Nevile, Liddy Nevile, Dylan Nicholson, Bruno von Niman, Tim Noonan, Sebastiano Nutarelli, Graham Oliver, Sean B. Palmer, Devarshi Pant, Nigel Peck, Anne Pemberton, David Poehlman, Ian Pouncey, Charles Pritchard, Kerstin Probiesch, W Reagan, Adam Victor Reed, Chris Reeve, Chris Ridpath, Lee Roberts, Mark Rogers, Raph de Rooij, Gregory J. Rosmaita, Matthew Ross, Sharron Rush, Joel Sanda, Janina Sajka, Roberto Scano, Gordon Schantz, Tim van Schie, Wolf Schmidt, Stefan Schnabel, Cynthia Shelly, Glenda Sims, John Slatin, Becky Smith, Jared Smith, Andi Snow-Weaver, Neil Soiffer, Mike Squillace, Michael Stenitzer, Diane Stottlemyer, Christophe Strobbe, Sarah J Swierenga, Jim Thatcher, Terry Thompson, Justin Thorp, David Todd, Mary Utt, Jean Vanderdonckt, Carlos A Velasco, Eric Velleman, Gijs Veyfeyken, Dena Wainwright, Paul Walsch, Daman Wandke, Richard Warren, Elle Waters, Takayuki Watanabe, Gian Wild, David Wooley, Wu Wei, Kenny Zhang, Leona Zumbo.</p>
+</section>
+         		<section id="enabling-funders"><div class="header-wrapper"><h3 id="b-3-enabling-funders"><bdi class="secno">B.3 </bdi>有効な資金提供者</h3><a class="self-link" href="#enabling-funders" aria-label="Permalink for Appendix B.3"></a></div>
+	
+	<p> この出版物は、当初は契約番号 ED-OSE-10-C-0067 のもとで、現在は契約番号 HHSP23301500054C のもとで米国保健福祉省・障害者自立生活リハビリテーション研究所 (NIDILRR) の政府資金によって一部賄われている。この出版物の内容は、必ずしも米国保健福祉省又は米国教育省の見解や政策を反映するものではなく、また商品名、商用製品、組織の言及は米国政府による支持を意味するものではない。</p>
+</section>
+         	
+      </section>
+      
+   
+   
+<section id="references" class="appendix"><div class="header-wrapper"><h2 id="c-references"><bdi class="secno">C. </bdi>参考文献</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix C."></a></div><section id="informative-references"><div class="header-wrapper"><h3 id="c-1-informative-references"><bdi class="secno">C.1 </bdi>参考文書</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix C.1"></a></div>
     
+    <dl class="bibliography"><dt id="bib-css3-values">[css3-values]</dt><dd><a href="https://www.w3.org/TR/css-values-3/"><cite>CSS Values and Units Module Level 3</cite></a>. Tab Atkins Jr.; Elika Etemad. W3C. 1 December 2022. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a></dd><dt id="bib-html">[HTML]</dt><dd><a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters. WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a></dd><dt id="bib-iso_9241-391">[ISO_9241-391]</dt><dd><a href="https://www.iso.org/standard/56350.html"><cite>Ergonomics of human-system interaction—Part 391: Requirements, analysis and compliance test methods for the reduction of photosensitive seizures</cite></a>. International Standards Organization. URL: <a href="https://www.iso.org/standard/56350.html">https://www.iso.org/standard/56350.html</a></dd><dt id="bib-pointerevents">[pointerevents]</dt><dd><a href="https://www.w3.org/TR/pointerevents/"><cite>Pointer Events</cite></a>. Jacob Rossi; Matt Brubeck. W3C. 4 April 2019. W3C Recommendation. URL: <a href="https://www.w3.org/TR/pointerevents/">https://www.w3.org/TR/pointerevents/</a></dd><dt id="bib-rfc2119">[RFC2119]</dt><dd><a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner. IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a></dd><dt id="bib-srgb">[SRGB]</dt><dd><a href="https://webstore.iec.ch/publication/6169"><cite>Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB</cite></a>. IEC. URL: <a href="https://webstore.iec.ch/publication/6169">https://webstore.iec.ch/publication/6169</a></dd><dt id="bib-uaag10">[UAAG10]</dt><dd><a href="https://www.w3.org/TR/UAAG10/"><cite>User Agent Accessibility Guidelines 1.0</cite></a>. Ian Jacobs; Jon Gunderson; Eric Hansen. W3C. 17 December 2002. W3C Recommendation. URL: <a href="https://www.w3.org/TR/UAAG10/">https://www.w3.org/TR/UAAG10/</a></dd><dt id="bib-unesco">[UNESCO]</dt><dd><a href="http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm"><cite>International Standard Classification of Education</cite></a>. 1997. URL: <a href="http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm">http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm</a></dd><dt id="bib-wai-webcontent">[WAI-WEBCONTENT]</dt><dd><a href="https://www.w3.org/TR/WAI-WEBCONTENT/"><cite>Web Content Accessibility Guidelines 1.0</cite></a>. Wendy Chisholm; Gregg Vanderheiden; Ian Jacobs. W3C. 5 May 1999. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WAI-WEBCONTENT/">https://www.w3.org/TR/WAI-WEBCONTENT/</a></dd><dt id="bib-wcag20">[WCAG20]</dt><dd><a href="https://www.w3.org/TR/WCAG20/"><cite>Web Content Accessibility Guidelines (WCAG) 2.0</cite></a>. Ben Caldwell; Michael Cooper; Loretta Guarino Reid; Gregg Vanderheiden et al. W3C. 11 December 2008. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WCAG20/">https://www.w3.org/TR/WCAG20/</a></dd></dl>
+  </section></section><p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-abbreviations" aria-label="Links in this document to definition: abbreviation"><span class="caret"></span><div><a class="self-link" href="#dfn-abbreviations" aria-label="Permalink for definition: abbreviation. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-abbreviations-1" title="§ 3.1.4 Abbreviations">§ 3.1.4 Abbreviations</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-accessibility-supported" aria-label="Links in this document to definition: accessibility supported"><span class="caret"></span><div><a class="self-link" href="#dfn-accessibility-supported" aria-label="Permalink for definition: accessibility supported. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-accessibility-supported-1" title="§ 2.5.4 Motion Actuation">§ 2.5.4 Motion Actuation</a></li><li><a href="#ref-for-dfn-accessibility-supported-2" title="§ 5. Conformance">§ 5. Conformance</a></li><li><a href="#ref-for-dfn-accessibility-supported-3" title="§ 5.2.4 Only Accessibility-Supported Ways of Using Technologies">§ 5.2.4 Only Accessibility-Supported Ways of Using Technologies</a></li><li><a href="#ref-for-dfn-accessibility-supported-4" title="§ 5.2.5 Non-Interference">§ 5.2.5 Non-Interference</a></li><li><a href="#ref-for-dfn-accessibility-supported-5" title="§ 5.5 Statement of Partial Conformance - Language">§ 5.5 Statement of Partial Conformance - Language</a></li><li><a href="#ref-for-dfn-accessibility-supported-6" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-alternative-for-time-based-media" aria-label="Links in this document to definition: alternative for time-based media"><span class="caret"></span><div><a class="self-link" href="#dfn-alternative-for-time-based-media" aria-label="Permalink for definition: alternative for time-based media. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-alternative-for-time-based-media-1" title="§ 1.2.1 Audio-only and Video-only (Prerecorded)">§ 1.2.1 Audio-only and Video-only (Prerecorded)</a></li><li><a href="#ref-for-dfn-alternative-for-time-based-media-2" title="§ 1.2.3 Audio Description or Media Alternative (Prerecorded)">§ 1.2.3 Audio Description or Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-alternative-for-time-based-media-3" title="§ 1.2.8 Media Alternative (Prerecorded)">§ 1.2.8 Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-alternative-for-time-based-media-4" title="§ 1.2.9 Audio-only (Live)">§ 1.2.9 Audio-only (Live)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-ambiguous-to-users-in-general" aria-label="Links in this document to definition: ambiguous to users in general"><span class="caret"></span><div><a class="self-link" href="#dfn-ambiguous-to-users-in-general" aria-label="Permalink for definition: ambiguous to users in general. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-ambiguous-to-users-in-general-1" title="§ 2.4.4 Link Purpose (In Context)">§ 2.4.4 Link Purpose (In Context)</a></li><li><a href="#ref-for-dfn-ambiguous-to-users-in-general-2" title="§ 2.4.9 Link Purpose (Link Only)">§ 2.4.9 Link Purpose (Link Only)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-ascii-art" aria-label="Links in this document to definition: ASCII art"><span class="caret"></span><div><a class="self-link" href="#dfn-ascii-art" aria-label="Permalink for definition: ASCII art. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-ascii-art-1" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-assistive-technologies" aria-label="Links in this document to definition: assistive technology"><span class="caret"></span><div><a class="self-link" href="#dfn-assistive-technologies" aria-label="Permalink for definition: assistive technology. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-assistive-technologies-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li><li><a href="#ref-for-dfn-assistive-technologies-2" title="§ 1.4.4 Resize Text">§ 1.4.4 Resize Text</a></li><li><a href="#ref-for-dfn-assistive-technologies-3" title="§ 4.1.2 Name, Role, Value">§ 4.1.2 Name, Role, Value</a></li><li><a href="#ref-for-dfn-assistive-technologies-4" title="§ 4.1.3 Status Messages">§ 4.1.3 Status Messages</a></li><li><a href="#ref-for-dfn-assistive-technologies-5" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-assistive-technologies-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-assistive-technologies-7" title="Reference 3">(3)</a> <a href="#ref-for-dfn-assistive-technologies-8" title="Reference 4">(4)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-audio" aria-label="Links in this document to definition: audio"><span class="caret"></span><div><a class="self-link" href="#dfn-audio" aria-label="Permalink for definition: audio. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-audio-1" title="§ 1.2.2 Captions (Prerecorded)">§ 1.2.2 Captions (Prerecorded)</a></li><li><a href="#ref-for-dfn-audio-2" title="§ 1.2.4 Captions (Live)">§ 1.2.4 Captions (Live)</a></li><li><a href="#ref-for-dfn-audio-3" title="§ 1.2.6 Sign Language (Prerecorded)">§ 1.2.6 Sign Language (Prerecorded)</a></li><li><a href="#ref-for-dfn-audio-4" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-audio-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-audio-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-audio-7" title="Reference 4">(4)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-audio-descriptions" aria-label="Links in this document to definition: audio description"><span class="caret"></span><div><a class="self-link" href="#dfn-audio-descriptions" aria-label="Permalink for definition: audio description. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-audio-descriptions-1" title="§ 1.2.3 Audio Description or Media Alternative (Prerecorded)">§ 1.2.3 Audio Description or Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-audio-descriptions-2" title="§ 1.2.5 Audio Description (Prerecorded)">§ 1.2.5 Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-audio-descriptions-3" title="§ 1.2.7 Extended Audio Description (Prerecorded)">§ 1.2.7 Extended Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-audio-descriptions-4" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-audio-descriptions-5" title="Reference 2">(2)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-audio-only" aria-label="Links in this document to definition: audio-only"><span class="caret"></span><div><a class="self-link" href="#dfn-audio-only" aria-label="Permalink for definition: audio-only. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-audio-only-1" title="§ 1.2.1 Audio-only and Video-only (Prerecorded)">§ 1.2.1 Audio-only and Video-only (Prerecorded)</a></li><li><a href="#ref-for-dfn-audio-only-2" title="§ 1.2.9 Audio-only (Live)">§ 1.2.9 Audio-only (Live)</a></li><li><a href="#ref-for-dfn-audio-only-3" title="§ 1.4.7 Low or No Background Audio">§ 1.4.7 Low or No Background Audio</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-blinking" aria-label="Links in this document to definition: blinking"><span class="caret"></span><div><a class="self-link" href="#dfn-blinking" aria-label="Permalink for definition: blinking. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-blinking-1" title="§ 2.2.2 Pause, Stop, Hide">§ 2.2.2 Pause, Stop, Hide</a></li><li><a href="#ref-for-dfn-blinking-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-blocks-of-text" aria-label="Links in this document to definition: blocks of text"><span class="caret"></span><div><a class="self-link" href="#dfn-blocks-of-text" aria-label="Permalink for definition: blocks of text. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-blocks-of-text-1" title="§ 1.4.8 Visual Presentation">§ 1.4.8 Visual Presentation</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-captcha" aria-label="Links in this document to definition: CAPTCHA"><span class="caret"></span><div><a class="self-link" href="#dfn-captcha" aria-label="Permalink for definition: CAPTCHA. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-captcha-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li><li><a href="#ref-for-dfn-captcha-2" title="§ 1.4.7 Low or No Background Audio">§ 1.4.7 Low or No Background Audio</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-captions" aria-label="Links in this document to definition: captions"><span class="caret"></span><div><a class="self-link" href="#dfn-captions" aria-label="Permalink for definition: captions. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-captions-1" title="§ 1.2.2 Captions (Prerecorded)">§ 1.2.2 Captions (Prerecorded)</a></li><li><a href="#ref-for-dfn-captions-2" title="§ 1.2.4 Captions (Live)">§ 1.2.4 Captions (Live)</a></li><li><a href="#ref-for-dfn-captions-3" title="§ 1.4.4 Resize Text">§ 1.4.4 Resize Text</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-change-of-context" aria-label="Links in this document to definition: changes of context"><span class="caret"></span><div><a class="self-link" href="#dfn-change-of-context" aria-label="Permalink for definition: changes of context. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-change-of-context-1" title="§ 3.2.1 On Focus">§ 3.2.1 On Focus</a></li><li><a href="#ref-for-dfn-change-of-context-2" title="§ 3.2.2 On Input">§ 3.2.2 On Input</a></li><li><a href="#ref-for-dfn-change-of-context-3" title="§ 3.2.5 Change on Request">§ 3.2.5 Change on Request</a></li><li><a href="#ref-for-dfn-change-of-context-4" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conform" aria-label="Links in this document to definition: conformance"><span class="caret"></span><div><a class="self-link" href="#dfn-conform" aria-label="Permalink for definition: conformance. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-conform-1" title="§ 5. Conformance">§ 5. Conformance</a></li><li><a href="#ref-for-dfn-conform-2" title="§ 5.2.2 Full pages">§ 5.2.2 Full pages</a></li><li><a href="#ref-for-dfn-conform-3" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-conform-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-conform-5" title="Reference 3">(3)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-alternate-versions" aria-label="Links in this document to definition: conforming alternate version"><span class="caret"></span><div><a class="self-link" href="#dfn-conforming-alternate-versions" aria-label="Permalink for definition: conforming alternate version. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-conforming-alternate-versions-1" title="§ 5.2.1 Conformance Level">§ 5.2.1 Conformance Level</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-content" aria-label="Links in this document to definition: content"><span class="caret"></span><div><a class="self-link" href="#dfn-content" aria-label="Permalink for definition: content. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-content-1" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-content-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-content-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-content-4" title="Reference 4">(4)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-context-sensitive-help" aria-label="Links in this document to definition: context-sensitive help"><span class="caret"></span><div><a class="self-link" href="#dfn-context-sensitive-help" aria-label="Permalink for definition: context-sensitive help. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-context-sensitive-help-1" title="§ 3.3.5 Help">§ 3.3.5 Help</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-contrast-ratio" aria-label="Links in this document to definition: contrast ratio"><span class="caret"></span><div><a class="self-link" href="#dfn-contrast-ratio" aria-label="Permalink for definition: contrast ratio. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-contrast-ratio-1" title="§ 1.4.3 Contrast (Minimum)">§ 1.4.3 Contrast (Minimum)</a></li><li><a href="#ref-for-dfn-contrast-ratio-2" title="§ 1.4.6 Contrast (Enhanced)">§ 1.4.6 Contrast (Enhanced)</a></li><li><a href="#ref-for-dfn-contrast-ratio-3" title="§ 1.4.11 Non-text Contrast">§ 1.4.11 Non-text Contrast</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-correct-reading-sequence" aria-label="Links in this document to definition: correct reading sequence"><span class="caret"></span><div><a class="self-link" href="#dfn-correct-reading-sequence" aria-label="Permalink for definition: correct reading sequence. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-correct-reading-sequence-1" title="§ 1.3.2 Meaningful Sequence">§ 1.3.2 Meaningful Sequence</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-css-pixels" aria-label="Links in this document to definition: CSS pixel"><span class="caret"></span><div><a class="self-link" href="#dfn-css-pixels" aria-label="Permalink for definition: CSS pixel. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-css-pixels-1" title="§ 1.4.10 Reflow">§ 1.4.10 Reflow</a> <a href="#ref-for-dfn-css-pixels-2" title="Reference 2">(2)</a></li><li><a href="#ref-for-dfn-css-pixels-3" title="§ 2.5.5 Target Size">§ 2.5.5 Target Size</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-down-event" aria-label="Links in this document to definition: down-event"><span class="caret"></span><div><a class="self-link" href="#dfn-down-event" aria-label="Permalink for definition: down-event. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-down-event-1" title="§ 2.5.2 Pointer Cancellation">§ 2.5.2 Pointer Cancellation</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-emergency" aria-label="Links in this document to definition: emergency"><span class="caret"></span><div><a class="self-link" href="#dfn-emergency" aria-label="Permalink for definition: emergency. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-emergency-1" title="§ 2.2.4 Interruptions">§ 2.2.4 Interruptions</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-essential" aria-label="Links in this document to definition: essential"><span class="caret"></span><div><a class="self-link" href="#dfn-essential" aria-label="Permalink for definition: essential. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-essential-1" title="§ 1.3.4 Orientation">§ 1.3.4 Orientation</a></li><li><a href="#ref-for-dfn-essential-2" title="§ 1.4.5 Images of Text">§ 1.4.5 Images of Text</a></li><li><a href="#ref-for-dfn-essential-3" title="§ 1.4.9 Images of Text (No Exception)">§ 1.4.9 Images of Text (No Exception)</a></li><li><a href="#ref-for-dfn-essential-4" title="§ 1.4.11 Non-text Contrast">§ 1.4.11 Non-text Contrast</a></li><li><a href="#ref-for-dfn-essential-5" title="§ 2.2.1 Timing Adjustable">§ 2.2.1 Timing Adjustable</a></li><li><a href="#ref-for-dfn-essential-6" title="§ 2.2.2 Pause, Stop, Hide">§ 2.2.2 Pause, Stop, Hide</a></li><li><a href="#ref-for-dfn-essential-7" title="§ 2.2.3 No Timing">§ 2.2.3 No Timing</a></li><li><a href="#ref-for-dfn-essential-8" title="§ 2.3.3 Animation from Interactions">§ 2.3.3 Animation from Interactions</a></li><li><a href="#ref-for-dfn-essential-9" title="§ 2.5.1 Pointer Gestures">§ 2.5.1 Pointer Gestures</a></li><li><a href="#ref-for-dfn-essential-10" title="§ 2.5.2 Pointer Cancellation">§ 2.5.2 Pointer Cancellation</a></li><li><a href="#ref-for-dfn-essential-11" title="§ 2.5.4 Motion Actuation">§ 2.5.4 Motion Actuation</a></li><li><a href="#ref-for-dfn-essential-12" title="§ 2.5.5 Target Size">§ 2.5.5 Target Size</a></li><li><a href="#ref-for-dfn-essential-13" title="§ 2.5.6 Concurrent Input Mechanisms">§ 2.5.6 Concurrent Input Mechanisms</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-extended-audio-description" aria-label="Links in this document to definition: extended audio description"><span class="caret"></span><div><a class="self-link" href="#dfn-extended-audio-description" aria-label="Permalink for definition: extended audio description. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-extended-audio-description-1" title="§ 1.2.7 Extended Audio Description (Prerecorded)">§ 1.2.7 Extended Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-extended-audio-description-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-flashes" aria-label="Links in this document to definition: flash"><span class="caret"></span><div><a class="self-link" href="#dfn-flashes" aria-label="Permalink for definition: flash. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-flashes-1" title="§ 2.3.1 Three Flashes or Below Threshold">§ 2.3.1 Three Flashes or Below Threshold</a></li><li><a href="#ref-for-dfn-flashes-2" title="§ 2.3.2 Three Flashes">§ 2.3.2 Three Flashes</a></li><li><a href="#ref-for-dfn-flashes-3" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-flashes-4" title="Reference 2">(2)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-functionality" aria-label="Links in this document to definition: functionality"><span class="caret"></span><div><a class="self-link" href="#dfn-functionality" aria-label="Permalink for definition: functionality. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-functionality-1" title="§ 2.1.1 Keyboard">§ 2.1.1 Keyboard</a></li><li><a href="#ref-for-dfn-functionality-2" title="§ 2.1.3 Keyboard (No Exception)">§ 2.1.3 Keyboard (No Exception)</a></li><li><a href="#ref-for-dfn-functionality-3" title="§ 2.5.1 Pointer Gestures">§ 2.5.1 Pointer Gestures</a></li><li><a href="#ref-for-dfn-functionality-4" title="§ 2.5.2 Pointer Cancellation">§ 2.5.2 Pointer Cancellation</a></li><li><a href="#ref-for-dfn-functionality-5" title="§ 2.5.4 Motion Actuation">§ 2.5.4 Motion Actuation</a></li><li><a href="#ref-for-dfn-functionality-6" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-general-flash-and-red-flash-thresholds" aria-label="Links in this document to definition: general flash and red flash thresholds"><span class="caret"></span><div><a class="self-link" href="#dfn-general-flash-and-red-flash-thresholds" aria-label="Permalink for definition: general flash and red flash thresholds. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-general-flash-and-red-flash-thresholds-1" title="§ 2.3.1 Three Flashes or Below Threshold">§ 2.3.1 Three Flashes or Below Threshold</a></li><li><a href="#ref-for-dfn-general-flash-and-red-flash-thresholds-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-human-language-s" aria-label="Links in this document to definition: human language"><span class="caret"></span><div><a class="self-link" href="#dfn-human-language-s" aria-label="Permalink for definition: human language. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-human-language-s-1" title="§ 3.1.1 Language of Page">§ 3.1.1 Language of Page</a></li><li><a href="#ref-for-dfn-human-language-s-2" title="§ 3.1.2 Language of Parts">§ 3.1.2 Language of Parts</a></li><li><a href="#ref-for-dfn-human-language-s-3" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-human-language-s-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-human-language-s-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-human-language-s-6" title="Reference 4">(4)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-idioms" aria-label="Links in this document to definition: idiom"><span class="caret"></span><div><a class="self-link" href="#dfn-idioms" aria-label="Permalink for definition: idiom. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-idioms-1" title="§ 3.1.3 Unusual Words">§ 3.1.3 Unusual Words</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-images-of-text" aria-label="Links in this document to definition: image of text"><span class="caret"></span><div><a class="self-link" href="#dfn-images-of-text" aria-label="Permalink for definition: image of text. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-images-of-text-1" title="§ 1.4.3 Contrast (Minimum)">§ 1.4.3 Contrast (Minimum)</a></li><li><a href="#ref-for-dfn-images-of-text-2" title="§ 1.4.4 Resize Text">§ 1.4.4 Resize Text</a></li><li><a href="#ref-for-dfn-images-of-text-3" title="§ 1.4.5 Images of Text">§ 1.4.5 Images of Text</a></li><li><a href="#ref-for-dfn-images-of-text-4" title="§ 1.4.6 Contrast (Enhanced)">§ 1.4.6 Contrast (Enhanced)</a></li><li><a href="#ref-for-dfn-images-of-text-5" title="§ 1.4.9 Images of Text (No Exception)">§ 1.4.9 Images of Text (No Exception)</a></li><li><a href="#ref-for-dfn-images-of-text-6" title="§ 2.5.3 Label in Name">§ 2.5.3 Label in Name</a></li><li><a href="#ref-for-dfn-images-of-text-7" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-informative" aria-label="Links in this document to definition: informative"><span class="caret"></span><div><a class="self-link" href="#dfn-informative" aria-label="Permalink for definition: informative. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-informative-1" title="§ 5.1 Interpreting Normative Requirements">§ 5.1 Interpreting Normative Requirements</a></li><li><a href="#ref-for-dfn-informative-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-input-error" aria-label="Links in this document to definition: input error"><span class="caret"></span><div><a class="self-link" href="#dfn-input-error" aria-label="Permalink for definition: input error. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-input-error-1" title="§ 1.4.13 Content on Hover or Focus">§ 1.4.13 Content on Hover or Focus</a></li><li><a href="#ref-for-dfn-input-error-2" title="§ 3.3.1 Error Identification">§ 3.3.1 Error Identification</a></li><li><a href="#ref-for-dfn-input-error-3" title="§ 3.3.3 Error Suggestion">§ 3.3.3 Error Suggestion</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-jargon" aria-label="Links in this document to definition: jargon"><span class="caret"></span><div><a class="self-link" href="#dfn-jargon" aria-label="Permalink for definition: jargon. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-jargon-1" title="§ 3.1.3 Unusual Words">§ 3.1.3 Unusual Words</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-keyboard-interface" aria-label="Links in this document to definition: keyboard interface"><span class="caret"></span><div><a class="self-link" href="#dfn-keyboard-interface" aria-label="Permalink for definition: keyboard interface. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-keyboard-interface-1" title="§ 2.1.1 Keyboard">§ 2.1.1 Keyboard</a></li><li><a href="#ref-for-dfn-keyboard-interface-2" title="§ 2.1.2 No Keyboard Trap">§ 2.1.2 No Keyboard Trap</a></li><li><a href="#ref-for-dfn-keyboard-interface-3" title="§ 2.1.3 Keyboard (No Exception)">§ 2.1.3 Keyboard (No Exception)</a></li><li><a href="#ref-for-dfn-keyboard-interface-4" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-keyboard-shortcuts" aria-label="Links in this document to definition: keyboard shortcut"><span class="caret"></span><div><a class="self-link" href="#dfn-keyboard-shortcuts" aria-label="Permalink for definition: keyboard shortcut. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-keyboard-shortcuts-1" title="§ 2.1.4 Character Key Shortcuts">§ 2.1.4 Character Key Shortcuts</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-labels" aria-label="Links in this document to definition: label"><span class="caret"></span><div><a class="self-link" href="#dfn-labels" aria-label="Permalink for definition: label. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-labels-1" title="§ 2.4.6 Headings and Labels">§ 2.4.6 Headings and Labels</a></li><li><a href="#ref-for-dfn-labels-2" title="§ 2.5.3 Label in Name">§ 2.5.3 Label in Name</a></li><li><a href="#ref-for-dfn-labels-3" title="§ 3.3.2 Labels or Instructions">§ 3.3.2 Labels or Instructions</a></li><li><a href="#ref-for-dfn-labels-4" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-large-scale" aria-label="Links in this document to definition: large scale"><span class="caret"></span><div><a class="self-link" href="#dfn-large-scale" aria-label="Permalink for definition: large scale. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-large-scale-1" title="§ 1.4.3 Contrast (Minimum)">§ 1.4.3 Contrast (Minimum)</a></li><li><a href="#ref-for-dfn-large-scale-2" title="§ 1.4.6 Contrast (Enhanced)">§ 1.4.6 Contrast (Enhanced)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-legal-commitments" aria-label="Links in this document to definition: legal commitments"><span class="caret"></span><div><a class="self-link" href="#dfn-legal-commitments" aria-label="Permalink for definition: legal commitments. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-legal-commitments-1" title="§ 3.3.4 Error Prevention (Legal, Financial, Data)">§ 3.3.4 Error Prevention (Legal, Financial, Data)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-purpose-of-each-link" aria-label="Links in this document to definition: link purpose"><span class="caret"></span><div><a class="self-link" href="#dfn-purpose-of-each-link" aria-label="Permalink for definition: link purpose. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-purpose-of-each-link-1" title="§ 2.4.4 Link Purpose (In Context)">§ 2.4.4 Link Purpose (In Context)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-live" aria-label="Links in this document to definition: live"><span class="caret"></span><div><a class="self-link" href="#dfn-live" aria-label="Permalink for definition: live. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-live-1" title="§ 1.2.4 Captions (Live)">§ 1.2.4 Captions (Live)</a></li><li><a href="#ref-for-dfn-live-2" title="§ 1.2.9 Audio-only (Live)">§ 1.2.9 Audio-only (Live)</a></li><li><a href="#ref-for-dfn-live-3" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-lower-secondary-education-level" aria-label="Links in this document to definition: lower secondary education level"><span class="caret"></span><div><a class="self-link" href="#dfn-lower-secondary-education-level" aria-label="Permalink for definition: lower secondary education level. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-lower-secondary-education-level-1" title="§ 3.1.5 Reading Level">§ 3.1.5 Reading Level</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-mechanism" aria-label="Links in this document to definition: mechanism"><span class="caret"></span><div><a class="self-link" href="#dfn-mechanism" aria-label="Permalink for definition: mechanism. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-mechanism-1" title="§ 1.4.2 Audio Control">§ 1.4.2 Audio Control</a></li><li><a href="#ref-for-dfn-mechanism-2" title="§ 1.4.8 Visual Presentation">§ 1.4.8 Visual Presentation</a></li><li><a href="#ref-for-dfn-mechanism-3" title="§ 1.4.13 Content on Hover or Focus">§ 1.4.13 Content on Hover or Focus</a></li><li><a href="#ref-for-dfn-mechanism-4" title="§ 2.1.4 Character Key Shortcuts">§ 2.1.4 Character Key Shortcuts</a></li><li><a href="#ref-for-dfn-mechanism-5" title="§ 2.4.1 Bypass Blocks">§ 2.4.1 Bypass Blocks</a></li><li><a href="#ref-for-dfn-mechanism-6" title="§ 2.4.9 Link Purpose (Link Only)">§ 2.4.9 Link Purpose (Link Only)</a></li><li><a href="#ref-for-dfn-mechanism-7" title="§ 2.5.2 Pointer Cancellation">§ 2.5.2 Pointer Cancellation</a></li><li><a href="#ref-for-dfn-mechanism-8" title="§ 3.1.3 Unusual Words">§ 3.1.3 Unusual Words</a></li><li><a href="#ref-for-dfn-mechanism-9" title="§ 3.1.4 Abbreviations">§ 3.1.4 Abbreviations</a></li><li><a href="#ref-for-dfn-mechanism-10" title="§ 3.1.6 Pronunciation">§ 3.1.6 Pronunciation</a></li><li><a href="#ref-for-dfn-mechanism-11" title="§ 3.2.5 Change on Request">§ 3.2.5 Change on Request</a></li><li><a href="#ref-for-dfn-mechanism-12" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-mechanism-13" title="Reference 2">(2)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-media-alternative-for-text" aria-label="Links in this document to definition: media alternative for text"><span class="caret"></span><div><a class="self-link" href="#dfn-media-alternative-for-text" aria-label="Permalink for definition: media alternative for text. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-media-alternative-for-text-1" title="§ 1.2.1 Audio-only and Video-only (Prerecorded)">§ 1.2.1 Audio-only and Video-only (Prerecorded)</a></li><li><a href="#ref-for-dfn-media-alternative-for-text-2" title="§ 1.2.2 Captions (Prerecorded)">§ 1.2.2 Captions (Prerecorded)</a></li><li><a href="#ref-for-dfn-media-alternative-for-text-3" title="§ 1.2.3 Audio Description or Media Alternative (Prerecorded)">§ 1.2.3 Audio Description or Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-media-alternative-for-text-4" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-motion-animation" aria-label="Links in this document to definition: motion animation"><span class="caret"></span><div><a class="self-link" href="#dfn-motion-animation" aria-label="Permalink for definition: motion animation. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-motion-animation-1" title="§ 2.3.3 Animation from Interactions">§ 2.3.3 Animation from Interactions</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-name" aria-label="Links in this document to definition: name"><span class="caret"></span><div><a class="self-link" href="#dfn-name" aria-label="Permalink for definition: name. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-name-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li><li><a href="#ref-for-dfn-name-2" title="§ 2.5.3 Label in Name">§ 2.5.3 Label in Name</a></li><li><a href="#ref-for-dfn-name-3" title="§ 4.1.2 Name, Role, Value">§ 4.1.2 Name, Role, Value</a></li><li><a href="#ref-for-dfn-name-4" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-navigated-sequentially" aria-label="Links in this document to definition: navigated sequentially"><span class="caret"></span><div><a class="self-link" href="#dfn-navigated-sequentially" aria-label="Permalink for definition: navigated sequentially. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-navigated-sequentially-1" title="§ 2.4.3 Focus Order">§ 2.4.3 Focus Order</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-non-text-content" aria-label="Links in this document to definition: non-text content"><span class="caret"></span><div><a class="self-link" href="#dfn-non-text-content" aria-label="Permalink for definition: non-text content. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-non-text-content-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li><li><a href="#ref-for-dfn-non-text-content-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-normative" aria-label="Links in this document to definition: normative"><span class="caret"></span><div><a class="self-link" href="#dfn-normative" aria-label="Permalink for definition: normative. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-normative-1" title="§ 5.1 Interpreting Normative Requirements">§ 5.1 Interpreting Normative Requirements</a></li><li><a href="#ref-for-dfn-normative-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-on-a-full-screen-window" aria-label="Links in this document to definition: on a full-screen window"><span class="caret"></span><div><a class="self-link" href="#dfn-on-a-full-screen-window" aria-label="Permalink for definition: on a full-screen window. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-on-a-full-screen-window-1" title="§ 1.4.8 Visual Presentation">§ 1.4.8 Visual Presentation</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-pause" aria-label="Links in this document to definition: paused"><span class="caret"></span><div><a class="self-link" href="#dfn-pause" aria-label="Permalink for definition: paused. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-pause-1" title="§ 2.2.2 Pause, Stop, Hide">§ 2.2.2 Pause, Stop, Hide</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-pointer-inputs" aria-label="Links in this document to definition: pointer input"><span class="caret"></span><div><a class="self-link" href="#dfn-pointer-inputs" aria-label="Permalink for definition: pointer input. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-pointer-inputs-1" title="§ 2.5.5 Target Size">§ 2.5.5 Target Size</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-prerecorded" aria-label="Links in this document to definition: prerecorded"><span class="caret"></span><div><a class="self-link" href="#dfn-prerecorded" aria-label="Permalink for definition: prerecorded. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-prerecorded-1" title="§ 1.2.1 Audio-only and Video-only (Prerecorded)">§ 1.2.1 Audio-only and Video-only (Prerecorded)</a></li><li><a href="#ref-for-dfn-prerecorded-2" title="§ 1.2.2 Captions (Prerecorded)">§ 1.2.2 Captions (Prerecorded)</a></li><li><a href="#ref-for-dfn-prerecorded-3" title="§ 1.2.3 Audio Description or Media Alternative (Prerecorded)">§ 1.2.3 Audio Description or Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-prerecorded-4" title="§ 1.2.5 Audio Description (Prerecorded)">§ 1.2.5 Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-prerecorded-5" title="§ 1.2.6 Sign Language (Prerecorded)">§ 1.2.6 Sign Language (Prerecorded)</a></li><li><a href="#ref-for-dfn-prerecorded-6" title="§ 1.2.7 Extended Audio Description (Prerecorded)">§ 1.2.7 Extended Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-prerecorded-7" title="§ 1.2.8 Media Alternative (Prerecorded)">§ 1.2.8 Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-prerecorded-8" title="§ 1.4.7 Low or No Background Audio">§ 1.4.7 Low or No Background Audio</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-presentation" aria-label="Links in this document to definition: presentation"><span class="caret"></span><div><a class="self-link" href="#dfn-presentation" aria-label="Permalink for definition: presentation. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-presentation-1" title="§ 1.3.1 Info and Relationships">§ 1.3.1 Info and Relationships</a></li><li><a href="#ref-for-dfn-presentation-2" title="§ 1.4.11 Non-text Contrast">§ 1.4.11 Non-text Contrast</a></li><li><a href="#ref-for-dfn-presentation-3" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-primary-education" aria-label="Links in this document to definition: primary education level"><span class="caret"></span><div><a class="self-link" href="#dfn-primary-education" aria-label="Permalink for definition: primary education level. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-primary-education-1" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-processes" aria-label="Links in this document to definition: process"><span class="caret"></span><div><a class="self-link" href="#dfn-processes" aria-label="Permalink for definition: process. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-processes-1" title="§ 2.4.5 Multiple Ways">§ 2.4.5 Multiple Ways</a></li><li><a href="#ref-for-dfn-processes-2" title="§ 5.2.3 Complete processes">§ 5.2.3 Complete processes</a></li><li><a href="#ref-for-dfn-processes-3" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-processes-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-processes-5" title="Reference 3">(3)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-programmatically-determinable" aria-label="Links in this document to definition: programmatically determined"><span class="caret"></span><div><a class="self-link" href="#dfn-programmatically-determinable" aria-label="Permalink for definition: programmatically determined. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-programmatically-determinable-1" title="§ 1.3.1 Info and Relationships">§ 1.3.1 Info and Relationships</a></li><li><a href="#ref-for-dfn-programmatically-determinable-2" title="§ 1.3.2 Meaningful Sequence">§ 1.3.2 Meaningful Sequence</a></li><li><a href="#ref-for-dfn-programmatically-determinable-3" title="§ 1.3.5 Identify Input Purpose">§ 1.3.5 Identify Input Purpose</a></li><li><a href="#ref-for-dfn-programmatically-determinable-4" title="§ 1.3.6 Identify Purpose">§ 1.3.6 Identify Purpose</a></li><li><a href="#ref-for-dfn-programmatically-determinable-5" title="§ 3.1.1 Language of Page">§ 3.1.1 Language of Page</a></li><li><a href="#ref-for-dfn-programmatically-determinable-6" title="§ 3.1.2 Language of Parts">§ 3.1.2 Language of Parts</a></li><li><a href="#ref-for-dfn-programmatically-determinable-7" title="§ 4.1.2 Name, Role, Value">§ 4.1.2 Name, Role, Value</a></li><li><a href="#ref-for-dfn-programmatically-determinable-8" title="§ 4.1.3 Status Messages">§ 4.1.3 Status Messages</a></li><li><a href="#ref-for-dfn-programmatically-determinable-9" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-programmatically-determinable-10" title="Reference 2">(2)</a> <a href="#ref-for-dfn-programmatically-determinable-11" title="Reference 3">(3)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-programmatically-determined-link-context" aria-label="Links in this document to definition: programmatically determined link context"><span class="caret"></span><div><a class="self-link" href="#dfn-programmatically-determined-link-context" aria-label="Permalink for definition: programmatically determined link context. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-programmatically-determined-link-context-1" title="§ 2.4.4 Link Purpose (In Context)">§ 2.4.4 Link Purpose (In Context)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-programmatically-set" aria-label="Links in this document to definition: programmatically set"><span class="caret"></span><div><a class="self-link" href="#dfn-programmatically-set" aria-label="Permalink for definition: programmatically set. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-programmatically-set-1" title="§ 4.1.2 Name, Role, Value">§ 4.1.2 Name, Role, Value</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-pure-decoration" aria-label="Links in this document to definition: pure decoration"><span class="caret"></span><div><a class="self-link" href="#dfn-pure-decoration" aria-label="Permalink for definition: pure decoration. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-pure-decoration-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li><li><a href="#ref-for-dfn-pure-decoration-2" title="§ 1.4.3 Contrast (Minimum)">§ 1.4.3 Contrast (Minimum)</a></li><li><a href="#ref-for-dfn-pure-decoration-3" title="§ 1.4.6 Contrast (Enhanced)">§ 1.4.6 Contrast (Enhanced)</a></li><li><a href="#ref-for-dfn-pure-decoration-4" title="§ 1.4.9 Images of Text (No Exception)">§ 1.4.9 Images of Text (No Exception)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-real-time-events" aria-label="Links in this document to definition: real-time event"><span class="caret"></span><div><a class="self-link" href="#dfn-real-time-events" aria-label="Permalink for definition: real-time event. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-real-time-events-1" title="§ 2.2.3 No Timing">§ 2.2.3 No Timing</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-regions" aria-label="Links in this document to definition: region"><span class="caret"></span><div><a class="self-link" href="#dfn-regions" aria-label="Permalink for definition: region. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-regions-1" title="§ 1.3.6 Identify Purpose">§ 1.3.6 Identify Purpose</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-relationships" aria-label="Links in this document to definition: relationships"><span class="caret"></span><div><a class="self-link" href="#dfn-relationships" aria-label="Permalink for definition: relationships. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-relationships-1" title="§ 1.3.1 Info and Relationships">§ 1.3.1 Info and Relationships</a></li><li><a href="#ref-for-dfn-relationships-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-relative-luminance" aria-label="Links in this document to definition: relative luminance"><span class="caret"></span><div><a class="self-link" href="#dfn-relative-luminance" aria-label="Permalink for definition: relative luminance. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-relative-luminance-1" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-relative-luminance-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-relative-luminance-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-relative-luminance-4" title="Reference 4">(4)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-relied-upon" aria-label="Links in this document to definition: relied upon"><span class="caret"></span><div><a class="self-link" href="#dfn-relied-upon" aria-label="Permalink for definition: relied upon. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-relied-upon-1" title="§ 5. Conformance">§ 5. Conformance</a></li><li><a href="#ref-for-dfn-relied-upon-2" title="§ 5.2.4 Only Accessibility-Supported Ways of Using Technologies">§ 5.2.4 Only Accessibility-Supported Ways of Using Technologies</a></li><li><a href="#ref-for-dfn-relied-upon-3" title="§ 5.2.5 Non-Interference">§ 5.2.5 Non-Interference</a></li><li><a href="#ref-for-dfn-relied-upon-4" title="§ 5.3.1 Required Components of a Conformance Claim">§ 5.3.1 Required Components of a Conformance Claim</a></li><li><a href="#ref-for-dfn-relied-upon-5" title="§ 5.3.2 Optional Components of a Conformance Claim">§ 5.3.2 Optional Components of a Conformance Claim</a> <a href="#ref-for-dfn-relied-upon-6" title="Reference 2">(2)</a></li><li><a href="#ref-for-dfn-relied-upon-7" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-relied-upon-8" title="Reference 2">(2)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-role" aria-label="Links in this document to definition: role"><span class="caret"></span><div><a class="self-link" href="#dfn-role" aria-label="Permalink for definition: role. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-role-1" title="§ 4.1.2 Name, Role, Value">§ 4.1.2 Name, Role, Value</a></li><li><a href="#ref-for-dfn-role-2" title="§ 4.1.3 Status Messages">§ 4.1.3 Status Messages</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-same-functionality" aria-label="Links in this document to definition: same functionality"><span class="caret"></span><div><a class="self-link" href="#dfn-same-functionality" aria-label="Permalink for definition: same functionality. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-same-functionality-1" title="§ 3.2.4 Consistent Identification">§ 3.2.4 Consistent Identification</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-same-relative-order" aria-label="Links in this document to definition: same relative order"><span class="caret"></span><div><a class="self-link" href="#dfn-same-relative-order" aria-label="Permalink for definition: same relative order. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-same-relative-order-1" title="§ 3.2.3 Consistent Navigation">§ 3.2.3 Consistent Navigation</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-satisfies" aria-label="Links in this document to definition: satisfies a success criterion"><span class="caret"></span><div><a class="self-link" href="#dfn-satisfies" aria-label="Permalink for definition: satisfies a success criterion. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-satisfies-1" title="§ 5.2.1 Conformance Level">§ 5.2.1 Conformance Level</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-section" aria-label="Links in this document to definition: section"><span class="caret"></span><div><a class="self-link" href="#dfn-section" aria-label="Permalink for definition: section. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-section-1" title="§ 2.4.10 Section Headings">§ 2.4.10 Section Headings</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-set-of-web-pages" aria-label="Links in this document to definition: set of web pages"><span class="caret"></span><div><a class="self-link" href="#dfn-set-of-web-pages" aria-label="Permalink for definition: set of web pages. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-set-of-web-pages-1" title="§ 2.4.5 Multiple Ways">§ 2.4.5 Multiple Ways</a></li><li><a href="#ref-for-dfn-set-of-web-pages-2" title="§ 2.4.8 Location">§ 2.4.8 Location</a></li><li><a href="#ref-for-dfn-set-of-web-pages-3" title="§ 3.2.3 Consistent Navigation">§ 3.2.3 Consistent Navigation</a></li><li><a href="#ref-for-dfn-set-of-web-pages-4" title="§ 3.2.4 Consistent Identification">§ 3.2.4 Consistent Identification</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-sign-language" aria-label="Links in this document to definition: sign language"><span class="caret"></span><div><a class="self-link" href="#dfn-sign-language" aria-label="Permalink for definition: sign language. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-sign-language-1" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-sign-language-2" title="Reference 2">(2)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-sign-language-interpretation" aria-label="Links in this document to definition: sign language interpretation"><span class="caret"></span><div><a class="self-link" href="#dfn-sign-language-interpretation" aria-label="Permalink for definition: sign language interpretation. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-sign-language-interpretation-1" title="§ 1.2.6 Sign Language (Prerecorded)">§ 1.2.6 Sign Language (Prerecorded)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-single-pointer" aria-label="Links in this document to definition: single pointer"><span class="caret"></span><div><a class="self-link" href="#dfn-single-pointer" aria-label="Permalink for definition: single pointer. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-single-pointer-1" title="§ 2.5.1 Pointer Gestures">§ 2.5.1 Pointer Gestures</a></li><li><a href="#ref-for-dfn-single-pointer-2" title="§ 2.5.2 Pointer Cancellation">§ 2.5.2 Pointer Cancellation</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-specific-sensory-experience" aria-label="Links in this document to definition: specific sensory experience"><span class="caret"></span><div><a class="self-link" href="#dfn-specific-sensory-experience" aria-label="Permalink for definition: specific sensory experience. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-specific-sensory-experience-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-states" aria-label="Links in this document to definition: state"><span class="caret"></span><div><a class="self-link" href="#dfn-states" aria-label="Permalink for definition: state. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-states-1" title="§ 1.4.11 Non-text Contrast">§ 1.4.11 Non-text Contrast</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-status-messages" aria-label="Links in this document to definition: status message"><span class="caret"></span><div><a class="self-link" href="#dfn-status-messages" aria-label="Permalink for definition: status message. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-status-messages-1" title="§ 4.1.3 Status Messages">§ 4.1.3 Status Messages</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-structure" aria-label="Links in this document to definition: structure"><span class="caret"></span><div><a class="self-link" href="#dfn-structure" aria-label="Permalink for definition: structure. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-structure-1" title="§ 1.3.1 Info and Relationships">§ 1.3.1 Info and Relationships</a></li><li><a href="#ref-for-dfn-structure-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-style-properties" aria-label="Links in this document to definition: style property"><span class="caret"></span><div><a class="self-link" href="#dfn-style-properties" aria-label="Permalink for definition: style property. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-style-properties-1" title="§ 1.4.12 Text Spacing">§ 1.4.12 Text Spacing</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-supplementary-content" aria-label="Links in this document to definition: supplemental content"><span class="caret"></span><div><a class="self-link" href="#dfn-supplementary-content" aria-label="Permalink for definition: supplemental content. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-supplementary-content-1" title="§ 3.1.5 Reading Level">§ 3.1.5 Reading Level</a></li><li><a href="#ref-for-dfn-supplementary-content-2" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-synchronized-media" aria-label="Links in this document to definition: synchronized media"><span class="caret"></span><div><a class="self-link" href="#dfn-synchronized-media" aria-label="Permalink for definition: synchronized media. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-synchronized-media-1" title="§ 1.2.2 Captions (Prerecorded)">§ 1.2.2 Captions (Prerecorded)</a></li><li><a href="#ref-for-dfn-synchronized-media-2" title="§ 1.2.3 Audio Description or Media Alternative (Prerecorded)">§ 1.2.3 Audio Description or Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-synchronized-media-3" title="§ 1.2.4 Captions (Live)">§ 1.2.4 Captions (Live)</a></li><li><a href="#ref-for-dfn-synchronized-media-4" title="§ 1.2.5 Audio Description (Prerecorded)">§ 1.2.5 Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-synchronized-media-5" title="§ 1.2.6 Sign Language (Prerecorded)">§ 1.2.6 Sign Language (Prerecorded)</a></li><li><a href="#ref-for-dfn-synchronized-media-6" title="§ 1.2.7 Extended Audio Description (Prerecorded)">§ 1.2.7 Extended Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-synchronized-media-7" title="§ 1.2.8 Media Alternative (Prerecorded)">§ 1.2.8 Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-synchronized-media-8" title="§ 2.2.3 No Timing">§ 2.2.3 No Timing</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-targets" aria-label="Links in this document to definition: target"><span class="caret"></span><div><a class="self-link" href="#dfn-targets" aria-label="Permalink for definition: target. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-targets-1" title="§ 2.5.5 Target Size">§ 2.5.5 Target Size</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-technologies" aria-label="Links in this document to definition: technology"><span class="caret"></span><div><a class="self-link" href="#dfn-technologies" aria-label="Permalink for definition: technology. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-technologies-1" title="§ 5.2.4 Only Accessibility-Supported Ways of Using Technologies">§ 5.2.4 Only Accessibility-Supported Ways of Using Technologies</a></li><li><a href="#ref-for-dfn-technologies-2" title="§ 5.2.5 Non-Interference">§ 5.2.5 Non-Interference</a></li><li><a href="#ref-for-dfn-technologies-3" title="§ 5.3.1 Required Components of a Conformance Claim">§ 5.3.1 Required Components of a Conformance Claim</a></li><li><a href="#ref-for-dfn-technologies-4" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-technologies-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-technologies-6" title="Reference 3">(3)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-text" aria-label="Links in this document to definition: text"><span class="caret"></span><div><a class="self-link" href="#dfn-text" aria-label="Permalink for definition: text. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-text-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li><li><a href="#ref-for-dfn-text-2" title="§ 1.4.3 Contrast (Minimum)">§ 1.4.3 Contrast (Minimum)</a></li><li><a href="#ref-for-dfn-text-3" title="§ 1.4.4 Resize Text">§ 1.4.4 Resize Text</a></li><li><a href="#ref-for-dfn-text-4" title="§ 1.4.5 Images of Text">§ 1.4.5 Images of Text</a></li><li><a href="#ref-for-dfn-text-5" title="§ 1.4.6 Contrast (Enhanced)">§ 1.4.6 Contrast (Enhanced)</a></li><li><a href="#ref-for-dfn-text-6" title="§ 1.4.9 Images of Text (No Exception)">§ 1.4.9 Images of Text (No Exception)</a></li><li><a href="#ref-for-dfn-text-7" title="§ 1.4.12 Text Spacing">§ 1.4.12 Text Spacing</a></li><li><a href="#ref-for-dfn-text-8" title="§ 2.5.3 Label in Name">§ 2.5.3 Label in Name</a></li><li><a href="#ref-for-dfn-text-9" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-text-10" title="Reference 2">(2)</a> <a href="#ref-for-dfn-text-11" title="Reference 3">(3)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-text-alternative" aria-label="Links in this document to definition: text alternative"><span class="caret"></span><div><a class="self-link" href="#dfn-text-alternative" aria-label="Permalink for definition: text alternative. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-text-alternative-1" title="§ 1.1.1 Non-text Content">§ 1.1.1 Non-text Content</a></li><li><a href="#ref-for-dfn-text-alternative-2" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-text-alternative-3" title="Reference 2">(2)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-up-event" aria-label="Links in this document to definition: up-event"><span class="caret"></span><div><a class="self-link" href="#dfn-up-event" aria-label="Permalink for definition: up-event. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-up-event-1" title="§ 2.5.2 Pointer Cancellation">§ 2.5.2 Pointer Cancellation</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-used-in-an-unusual-or-restricted-way" aria-label="Links in this document to definition: used in an unusual or restricted way"><span class="caret"></span><div><a class="self-link" href="#dfn-used-in-an-unusual-or-restricted-way" aria-label="Permalink for definition: used in an unusual or restricted way. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-used-in-an-unusual-or-restricted-way-1" title="§ 3.1.3 Unusual Words">§ 3.1.3 Unusual Words</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-user-agents" aria-label="Links in this document to definition: user agent"><span class="caret"></span><div><a class="self-link" href="#dfn-user-agents" aria-label="Permalink for definition: user agent. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-user-agents-1" title="§ 4.1.2 Name, Role, Value">§ 4.1.2 Name, Role, Value</a></li><li><a href="#ref-for-dfn-user-agents-2" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-user-agents-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-user-agents-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-user-agents-5" title="Reference 4">(4)</a> <a href="#ref-for-dfn-user-agents-6" title="Reference 5">(5)</a> <a href="#ref-for-dfn-user-agents-7" title="Reference 6">(6)</a> <a href="#ref-for-dfn-user-agents-8" title="Reference 7">(7)</a> <a href="#ref-for-dfn-user-agents-9" title="Reference 8">(8)</a> <a href="#ref-for-dfn-user-agents-10" title="Reference 9">(9)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-user-controllable" aria-label="Links in this document to definition: user-controllable"><span class="caret"></span><div><a class="self-link" href="#dfn-user-controllable" aria-label="Permalink for definition: user-controllable. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-user-controllable-1" title="§ 3.3.4 Error Prevention (Legal, Financial, Data)">§ 3.3.4 Error Prevention (Legal, Financial, Data)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-user-interface-components" aria-label="Links in this document to definition: user interface component"><span class="caret"></span><div><a class="self-link" href="#dfn-user-interface-components" aria-label="Permalink for definition: user interface component. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-user-interface-components-1" title="§ 1.3.6 Identify Purpose">§ 1.3.6 Identify Purpose</a></li><li><a href="#ref-for-dfn-user-interface-components-2" title="§ 1.4.3 Contrast (Minimum)">§ 1.4.3 Contrast (Minimum)</a></li><li><a href="#ref-for-dfn-user-interface-components-3" title="§ 1.4.6 Contrast (Enhanced)">§ 1.4.6 Contrast (Enhanced)</a></li><li><a href="#ref-for-dfn-user-interface-components-4" title="§ 1.4.11 Non-text Contrast">§ 1.4.11 Non-text Contrast</a></li><li><a href="#ref-for-dfn-user-interface-components-5" title="§ 2.1.4 Character Key Shortcuts">§ 2.1.4 Character Key Shortcuts</a></li><li><a href="#ref-for-dfn-user-interface-components-6" title="§ 2.4.10 Section Headings">§ 2.4.10 Section Headings</a></li><li><a href="#ref-for-dfn-user-interface-components-7" title="§ 2.5.3 Label in Name">§ 2.5.3 Label in Name</a></li><li><a href="#ref-for-dfn-user-interface-components-8" title="§ 2.5.4 Motion Actuation">§ 2.5.4 Motion Actuation</a></li><li><a href="#ref-for-dfn-user-interface-components-9" title="§ 3.2.1 On Focus">§ 3.2.1 On Focus</a></li><li><a href="#ref-for-dfn-user-interface-components-10" title="§ 3.2.2 On Input">§ 3.2.2 On Input</a></li><li><a href="#ref-for-dfn-user-interface-components-11" title="§ 4.1.2 Name, Role, Value">§ 4.1.2 Name, Role, Value</a></li><li><a href="#ref-for-dfn-user-interface-components-12" title="§ 7. Input Purposes for User Interface Components">§ 7. Input Purposes for User Interface Components</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-user-inactivity" aria-label="Links in this document to definition: user inactivity"><span class="caret"></span><div><a class="self-link" href="#dfn-user-inactivity" aria-label="Permalink for definition: user inactivity. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-user-inactivity-1" title="§ 2.2.6 Timeouts">§ 2.2.6 Timeouts</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-video" aria-label="Links in this document to definition: video"><span class="caret"></span><div><a class="self-link" href="#dfn-video" aria-label="Permalink for definition: video. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-video-1" title="§ 1.2.3 Audio Description or Media Alternative (Prerecorded)">§ 1.2.3 Audio Description or Media Alternative (Prerecorded)</a></li><li><a href="#ref-for-dfn-video-2" title="§ 1.2.5 Audio Description (Prerecorded)">§ 1.2.5 Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-video-3" title="§ 1.2.7 Extended Audio Description (Prerecorded)">§ 1.2.7 Extended Audio Description (Prerecorded)</a></li><li><a href="#ref-for-dfn-video-4" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-video-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-video-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-video-7" title="Reference 4">(4)</a> <a href="#ref-for-dfn-video-8" title="Reference 5">(5)</a> <a href="#ref-for-dfn-video-9" title="Reference 6">(6)</a> <a href="#ref-for-dfn-video-10" title="Reference 7">(7)</a> <a href="#ref-for-dfn-video-11" title="Reference 8">(8)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-video-only" aria-label="Links in this document to definition: video-only"><span class="caret"></span><div><a class="self-link" href="#dfn-video-only" aria-label="Permalink for definition: video-only. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-video-only-1" title="§ 1.2.1 Audio-only and Video-only (Prerecorded)">§ 1.2.1 Audio-only and Video-only (Prerecorded)</a></li><li><a href="#ref-for-dfn-video-only-2" title="§ 1.2.8 Media Alternative (Prerecorded)">§ 1.2.8 Media Alternative (Prerecorded)</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-viewport" aria-label="Links in this document to definition: viewport"><span class="caret"></span><div><a class="self-link" href="#dfn-viewport" aria-label="Permalink for definition: viewport. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-viewport-1" title="§ 6. Glossary">§ 6. Glossary</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-visually-customized" aria-label="Links in this document to definition: visually customized"><span class="caret"></span><div><a class="self-link" href="#dfn-visually-customized" aria-label="Permalink for definition: visually customized. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-visually-customized-1" title="§ 1.4.5 Images of Text">§ 1.4.5 Images of Text</a></li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-web-page-s" aria-label="Links in this document to definition: Web page"><span class="caret"></span><div><a class="self-link" href="#dfn-web-page-s" aria-label="Permalink for definition: Web page. Activate to close this dialog.">Permalink</a></div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li><a href="#ref-for-dfn-web-page-s-1" title="§ 2.3.1 Three Flashes or Below Threshold">§ 2.3.1 Three Flashes or Below Threshold</a></li><li><a href="#ref-for-dfn-web-page-s-2" title="§ 2.3.2 Three Flashes">§ 2.3.2 Three Flashes</a></li><li><a href="#ref-for-dfn-web-page-s-3" title="§ 2.4.1 Bypass Blocks">§ 2.4.1 Bypass Blocks</a></li><li><a href="#ref-for-dfn-web-page-s-4" title="§ 2.4.2 Page Titled">§ 2.4.2 Page Titled</a></li><li><a href="#ref-for-dfn-web-page-s-5" title="§ 2.4.3 Focus Order">§ 2.4.3 Focus Order</a></li><li><a href="#ref-for-dfn-web-page-s-6" title="§ 2.4.5 Multiple Ways">§ 2.4.5 Multiple Ways</a></li><li><a href="#ref-for-dfn-web-page-s-7" title="§ 3.1.1 Language of Page">§ 3.1.1 Language of Page</a></li><li><a href="#ref-for-dfn-web-page-s-8" title="§ 3.2.3 Consistent Navigation">§ 3.2.3 Consistent Navigation</a></li><li><a href="#ref-for-dfn-web-page-s-9" title="§ 3.3.4 Error Prevention (Legal, Financial, Data)">§ 3.3.4 Error Prevention (Legal, Financial, Data)</a></li><li><a href="#ref-for-dfn-web-page-s-10" title="§ 3.3.6 Error Prevention (All)">§ 3.3.6 Error Prevention (All)</a></li><li><a href="#ref-for-dfn-web-page-s-11" title="§ 5.2.1 Conformance Level">§ 5.2.1 Conformance Level</a></li><li><a href="#ref-for-dfn-web-page-s-12" title="§ 5.2.2 Full pages">§ 5.2.2 Full pages</a></li><li><a href="#ref-for-dfn-web-page-s-13" title="§ 5.2.3 Complete processes">§ 5.2.3 Complete processes</a></li><li><a href="#ref-for-dfn-web-page-s-14" title="§ 5.2.5 Non-Interference">§ 5.2.5 Non-Interference</a></li><li><a href="#ref-for-dfn-web-page-s-15" title="§ 5.3 Conformance Claims (Optional)">§ 5.3 Conformance Claims (Optional)</a></li><li><a href="#ref-for-dfn-web-page-s-16" title="§ 6. Glossary">§ 6. Glossary</a> <a href="#ref-for-dfn-web-page-s-17" title="Reference 2">(2)</a> <a href="#ref-for-dfn-web-page-s-18" title="Reference 3">(3)</a> <a href="#ref-for-dfn-web-page-s-19" title="Reference 4">(4)</a> <a href="#ref-for-dfn-web-page-s-20" title="Reference 5">(5)</a> <a href="#ref-for-dfn-web-page-s-21" title="Reference 6">(6)</a></li>
+  </ul>
+    </div><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
 
-<section id="references" class="appendix"><h2 id="c-references"><span class="secno">C. </span>参考文献<span class="permalink"><a href="#references" aria-label="Permalink for C. References" title="Permalink for C. References"><span>§</span></a></span></h2><section id="informative-references"><h3 id="c-1-informative-references"><span class="secno">C.1 </span>参考文書<span class="permalink"><a href="#informative-references" aria-label="Permalink for C.1 Informative references" title="Permalink for C.1 Informative references"><span>§</span></a></span></h3>
-  
-    <dl class="bibliography"><dt id="bib-css3-values">[css3-values]</dt><dd>
-      <a href="https://www.w3.org/TR/css-values-3/"><cite>CSS Values and Units Module Level 3</cite></a>. Tab Atkins Jr.; Elika Etemad.  W3C. 1 December 2022. W3C Candidate Recommendation. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
-    </dd><dt id="bib-html">[HTML]</dt><dd>
-      <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-    </dd><dt id="bib-iso_9241-391">[ISO_9241-391]</dt><dd>
-      <a href="https://www.iso.org/standard/56350.html"><cite>Ergonomics of human-system interaction—Part 391: Requirements, analysis and compliance test methods for the reduction of photosensitive seizures</cite></a>.  International Standards Organization. URL: <a href="https://www.iso.org/standard/56350.html">https://www.iso.org/standard/56350.html</a>
-    </dd><dt id="bib-pointerevents">[pointerevents]</dt><dd>
-      <a href="https://www.w3.org/TR/pointerevents/"><cite>Pointer Events</cite></a>. Jacob Rossi; Matt Brubeck.  W3C. 4 April 2019. W3C Recommendation. URL: <a href="https://www.w3.org/TR/pointerevents/">https://www.w3.org/TR/pointerevents/</a>
-    </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
-      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
-    </dd><dt id="bib-srgb">[SRGB]</dt><dd>
-      <a href="https://webstore.iec.ch/publication/6169"><cite>Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB</cite></a>.  IEC. URL: <a href="https://webstore.iec.ch/publication/6169">https://webstore.iec.ch/publication/6169</a>
-    </dd><dt id="bib-uaag10">[UAAG10]</dt><dd>
-      <a href="https://www.w3.org/TR/UAAG10/"><cite>User Agent Accessibility Guidelines 1.0</cite></a>. Ian Jacobs; Jon Gunderson; Eric Hansen.  W3C. 17 December 2002. W3C Recommendation. URL: <a href="https://www.w3.org/TR/UAAG10/">https://www.w3.org/TR/UAAG10/</a>
-    </dd><dt id="bib-unesco">[UNESCO]</dt><dd>
-      <a href="http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm"><cite>International Standard Classification of Education</cite></a>. 1997. URL: <a href="http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm">http://www.unesco.org/education/information/nfsunesco/doc/isced_1997.htm</a>
-    </dd><dt id="bib-wai-webcontent">[WAI-WEBCONTENT]</dt><dd>
-      <a href="https://www.w3.org/TR/WAI-WEBCONTENT/"><cite>Web Content Accessibility Guidelines 1.0</cite></a>. Wendy Chisholm; Gregg Vanderheiden; Ian Jacobs.  W3C. 5 May 1999. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WAI-WEBCONTENT/">https://www.w3.org/TR/WAI-WEBCONTENT/</a>
-    </dd><dt id="bib-wcag20">[WCAG20]</dt><dd>
-      <a href="https://www.w3.org/TR/WCAG20/"><cite>Web Content Accessibility Guidelines (WCAG) 2.0</cite></a>. Ben Caldwell; Michael Cooper; Loretta Guarino Reid; Gregg Vanderheiden et al.  W3C. 11 December 2008. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WCAG20/">https://www.w3.org/TR/WCAG20/</a>
-    </dd></dl>
-  </section></section><p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
 
 <script type="text/javascript" src="waic_link.js"></script>
 


### PR DESCRIPTION
Close #1808

OmegaTを利用して、日本語訳を2023年版のW3Cの原文HTMLに流し込んだものです

GitHubの差分は多すぎて役に立たないと思いますので、差分はHTML Diffを参照してください：
[HTML Diffはこちら](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwaic.github.io%2Fwcag21%2Fguidelines%2F&doc2=https%3A%2F%2Frawcdn.githack.com%2Fwaic%2Fwcag21%2Fb68757c6a71e5fdc3a94f686a841dd72433f04ee%2Fguidelines%2Findex.html)

以下について修正しています。

- 達成基準 1.3.4 表示の向きで「表示装置」が残っていたものを「ディスプレイ」に差し替え
- 全角・半角間のスペースの調整
- 明らかな誤字
- 原文の修正に追随できていなかった箇所の更新

@bakera ご確認ください。