### PR TITLE
WCAG 2.1 用語集の修正を解説書に反映 : 相対輝度 (relative luminance)

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -2829,7 +2829,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
    
    <div class="note" role="note" id="issue-container-generatedID-123"><div role="heading" class="note-title marker" id="h-note-123" aria-level="3"><span>注記</span></div><p class="">コントラストと閃光を検証する際に、この計算を自動で行うツールが利用できる。</p></div>
    
-   <div class="note" role="note" id="issue-container-generatedID-124"><div role="heading" class="note-title marker" id="h-note-124" aria-level="3"><span>注記</span></div><p class=""><a href="relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。</p></div>
+   <div class="note" role="note" id="issue-container-generatedID-124"><div role="heading" class="note-title marker" id="h-note-124" aria-level="3"><span>注記</span></div><p class=""><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。</p></div>
    
 </dd>
 

--- a/understanding/contrast-enhanced.html
+++ b/understanding/contrast-enhanced.html
@@ -506,14 +506,14 @@
                            <li>BsRGB = B8bit/255</li>
                            </ul>
 
-                        <p>^ という記号は、指数演算子である(計算式は、[IEC-4WD]を参考にしている)。
+                        <p>^ という記号は、指数演算子である(計算式は、[SRGB] を参考にしている)。
                            </p>
                         </div>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、仕様の古いバージョンから取られたものであり、更新されている。本ガイドラインの文脈における計算には、実用上の影響はない。</p>
+                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、古いバージョンの仕様から取り込んだものであり、現在は更新されている。本ガイドラインの文脈における計算には、実質的な影響はない。</p>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
@@ -536,7 +536,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.xml">MathML version of the relative luminance definition</a> も参照できる。
+                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/contrast-minimum.html
+++ b/understanding/contrast-minimum.html
@@ -539,14 +539,14 @@
                            <li>BsRGB = B8bit/255</li>
                            </ul>
 
-                        <p>^ という記号は、指数演算子である(計算式は、[IEC-4WD]を参考にしている)。
+                        <p>^ という記号は、指数演算子である(計算式は、[SRGB] を参考にしている)。
                            </p>
                         </div>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、仕様の古いバージョンから取られたものであり、更新されている。本ガイドラインの文脈における計算には、実用上の影響はない。</p>
+                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、古いバージョンの仕様から取り込んだものであり、現在は更新されている。本ガイドラインの文脈における計算には、実質的な影響はない。</p>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
@@ -569,7 +569,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.xml">MathML version of the relative luminance definition</a> も参照できる。
+                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/non-text-contrast.html
+++ b/understanding/non-text-contrast.html
@@ -988,14 +988,14 @@
                            <li>BsRGB = B8bit/255</li>
                            </ul>
 
-                        <p>^ という記号は、指数演算子である(計算式は、[IEC-4WD]を参考にしている)。
+                        <p>^ という記号は、指数演算子である(計算式は、[SRGB] を参考にしている)。
                            </p>
                         </div>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、仕様の古いバージョンから取られたものであり、更新されている。本ガイドラインの文脈における計算には、実用上の影響はない。</p>
+                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、古いバージョンの仕様から取り込んだものであり、現在は更新されている。本ガイドラインの文脈における計算には、実質的な影響はない。</p>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
@@ -1018,7 +1018,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.xml">MathML version of the relative luminance definition</a> も参照できる。
+                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/pause-stop-hide.html
+++ b/understanding/pause-stop-hide.html
@@ -431,14 +431,14 @@
                            <li>BsRGB = B8bit/255</li>
                            </ul>
 
-                        <p>^ という記号は、指数演算子である(計算式は、[IEC-4WD]を参考にしている)。
+                        <p>^ という記号は、指数演算子である(計算式は、[SRGB] を参考にしている)。
                            </p>
                         </div>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、仕様の古いバージョンから取られたものであり、更新されている。本ガイドラインの文脈における計算には、実用上の影響はない。</p>
+                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、古いバージョンの仕様から取り込んだものであり、現在は更新されている。本ガイドラインの文脈における計算には、実質的な影響はない。</p>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
@@ -461,7 +461,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.xml">MathML version of the relative luminance definition</a> も参照できる。
+                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/three-flashes-or-below-threshold.html
+++ b/understanding/three-flashes-or-below-threshold.html
@@ -323,14 +323,14 @@
                            <li>BsRGB = B8bit/255</li>
                            </ul>
 
-                        <p>^ という記号は、指数演算子である(計算式は、[IEC-4WD]を参考にしている)。
+                        <p>^ という記号は、指数演算子である(計算式は、[SRGB] を参考にしている)。
                            </p>
                         </div>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、仕様の古いバージョンから取られたものであり、更新されている。本ガイドラインの文脈における計算には、実用上の影響はない。</p>
+                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、古いバージョンの仕様から取り込んだものであり、現在は更新されている。本ガイドラインの文脈における計算には、実質的な影響はない。</p>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
@@ -353,7 +353,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.xml">MathML version of the relative luminance definition</a> も参照できる。
+                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。
                         </p>
                   </div>
                   </definition>

--- a/understanding/three-flashes.html
+++ b/understanding/three-flashes.html
@@ -283,14 +283,14 @@
                            <li>BsRGB = B8bit/255</li>
                            </ul>
 
-                        <p>^ という記号は、指数演算子である(計算式は、[IEC-4WD]を参考にしている)。
+                        <p>^ という記号は、指数演算子である(計算式は、[SRGB] を参考にしている)。
                            </p>
                         </div>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、仕様の古いバージョンから取られたものであり、更新されている。本ガイドラインの文脈における計算には、実用上の影響はない。</p>
+                     <p>2021 年 5 月以前は、定義にある 0.04045 の値が異なっていた (0.03928)。これは、古いバージョンの仕様から取り込んだものであり、現在は更新されている。本ガイドラインの文脈における計算には、実質的な影響はない。</p>
                   </div>
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
@@ -313,7 +313,7 @@
 
                   <div xmlns="http://www.w3.org/1999/xhtml" class="note">
                      <div role="heading" class="note-title marker" aria-level="2">注記</div>
-                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.xml">MathML version of the relative luminance definition</a> も参照できる。
+                     <p><a href="https://www.w3.org/TR/WCAG21/relative-luminance.html">MathML を用いて相対輝度の定義を与える別のページ</a>でもこの計算式を表示できる。
                         </p>
                   </div>
                   </definition>


### PR DESCRIPTION
# プルリクエスト作成時の確認事項

- [ ] [翻訳ガイドライン](https://github.com/waic/translation_guidelines/blob/master/WAIC-wcag20-trans-guide.md)を確認し、ガイドラインに沿っているかチェックした
- [ ] [WCAGの用語集](https://waic.jp/docs/WCAG20/Overview.html#glossary)を確認し、用語が揃っているかチェックした
- [ ] [WG4の用語集](https://docs.google.com/spreadsheets/d/1V8wX-pxAO-zuYwTSvTSuZ_FtnV47su6Tyy2vM5GEOLw/edit#gid=0)を確認し、用語が揃っているかチェックした

# コメント

